### PR TITLE
Fix float/long truncation when a binary operator's RHS is parenthesized

### DIFF
--- a/baseline_test_dcc.txt
+++ b/baseline_test_dcc.txt
@@ -3638,6 +3638,8 @@ test tlongreg
 tlongreg: all tests passed with great success
 test tlongopt
 tlongopt passed with great success
+test tctxops
+tctxops passed with great success
 test tppreg
 tppreg: all tests passed
 test tinitreg

--- a/runall.bat
+++ b/runall.bat
@@ -15,7 +15,7 @@ set _applist=sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong ^
              tc89fcnv tc89fadd tc89fmul tc89fdiv tc89ffio tc89flng tc89fmat ^
              ttrig tlog tphi tap cpmenumd tbits tfo pihex tstrify tlcont primes ^
              tpreproc trwold tlimits spsmash tcrcfix trtl2 tsyntax tstr2 tstr3 ^
-             tlongaud tlongreg tlongopt tppreg tinitreg ttypesr ttype2 tdecinit tmalloch ^
+             tlongaud tlongreg tlongopt tctxops tppreg tinitreg ttypesr ttype2 tdecinit tmalloch ^
              tallocx tstdlib tioerr tqsort tbsearch trw2 terrno tpostfld tswitch tppifcom tpostidx ^
              tpostut tbug2 tlongsub treg tret tstructv tstructi tstructp tstri2 ^
              tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom ^

--- a/runall.sh
+++ b/runall.sh
@@ -13,7 +13,7 @@ APPLIST="sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong \
          tc89fcnv tc89fadd tc89fmul tc89fdiv tc89ffio tc89flng tc89fmat \
          ttrig tlog tphi tap cpmenumd tbits tfo pihex tstrify tlcont primes \
          tpreproc trwold tlimits spsmash tcrcfix trtl2 tsyntax tstr2 tstr3 \
-         tlongaud tlongreg tlongopt tppreg tinitreg ttypesr ttype2 tdecinit tmalloch \
+         tlongaud tlongreg tlongopt tctxops tppreg tinitreg ttypesr ttype2 tdecinit tmalloch \
          tallocx tstdlib tioerr tqsort tbsearch trw2 terrno tpostfld tswitch tppifcom tpostidx \
          tpostut tbug2 tlongsub treg tret tstructv tstructi tstructp tstri2 \
          tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom \

--- a/src/dcc/dcc_cmp.c
+++ b/src/dcc/dcc_cmp.c
@@ -678,16 +678,23 @@ int simple_direct_condition_until(int stop_kind)
         if (depth == 0 && tok.kind == stop_kind)
             break;
 
-        if (depth == 0) {
-            if (tok.kind == TOK_FLOATLIT) {
+        /*
+         * A float operand anywhere in the condition -- including inside
+         * parentheses such as  if (x < (fa * fb))  -- means the integer
+         * direct-branch comparison path cannot represent it.  Check at every
+         * depth (not just depth 0) so it falls back to the general expression
+         * path, which converts and compares as float.
+         */
+        if (tok.kind == TOK_FLOATLIT) {
+            bad = 1;
+        } else if (tok.kind == TOK_ID) {
+            struct Sym *fs;
+            fs = find_sym(tok.text);
+            if (fs && type_is_float(fs->type))
                 bad = 1;
-            } else if (tok.kind == TOK_ID) {
-                struct Sym *fs;
-                fs = find_sym(tok.text);
-                if (fs && type_is_float(fs->type))
-                    bad = 1;
-            }
+        }
 
+        if (depth == 0) {
             if (is_relop_token(tok.kind)) {
                 if (found)
                     bad = 1;

--- a/src/dcc/dcc_ops.c
+++ b/src/dcc/dcc_ops.c
@@ -453,6 +453,22 @@ int peek_simple_unary_type(void)
                 g_tok_long_suffix = save_long_suffix; g_tok_unsigned_suffix = save_unsigned_suffix; tok = save_tok;
                 return promote_int_type(t);
             }
+        } else {
+            /*
+             * Parenthesized expression (not a cast): peek the type of its
+             * first operand so a compound RHS such as (fa * fb) or (la + lb)
+             * is predicted as float / long instead of defaulting to int.
+             * Without this, gen_add/gen_mul/gen_rel/gen_eq pick the 16-bit
+             * branch for  x + (fa * fb)  and truncate the float (or long)
+             * result.  The recursion is bounded by paren nesting and only
+             * refines the lookahead; it returns the inner operand's promoted
+             * type.
+             */
+            int inner = peek_simple_unary_type();
+            posi = save_pos; tok_start_pos = save_tok_start;
+            line_no = save_line; tok_line = save_tok_line;
+            g_tok_long_suffix = save_long_suffix; g_tok_unsigned_suffix = save_unsigned_suffix; tok = save_tok;
+            return inner;
         }
     } else if (tok.kind == TOK_FLOATLIT) {
         t = TYPE_FLOAT;

--- a/tctxops.c
+++ b/tctxops.c
@@ -1,0 +1,118 @@
+/*
+ * tctxops.c - regression for binary-operator type prediction across contexts.
+ *
+ * peek_simple_unary_type() only inspects the first operand token of the RHS,
+ * so a *parenthesized* or otherwise compound RHS such as (fa * fb) or (la + lb)
+ * used to be mis-predicted as 16-bit int.  That truncated long results (high
+ * word dropped) and corrupted float results in arithmetic, comparison, and the
+ * direct if/while branch paths.  These tests pin the fixed behaviour:
+ *   - peek recurses into a non-cast parenthesized expression, and
+ *   - the direct-branch condition scanner treats a float operand at ANY paren
+ *     depth as needing the general (float) comparison path.
+ */
+#include <stdio.h>
+#include <stdint.h>
+
+static int fails;
+static void chk(long got, long want, char *name)
+{
+    if (got != want) { printf("FAIL %s got=%ld want=%ld\n", name, got, want); fails++; }
+}
+static void chku(unsigned long got, unsigned long want, char *name)
+{
+    if (got != want) { printf("FAIL %s got=%lu want=%lu\n", name, got, want); fails++; }
+}
+static void chkf(float got, float want, char *name)
+{
+    float d = got - want;
+    if (d < 0) d = -d;
+    if (d > 0.001) { printf("FAIL %s got=%f want=%f\n", name, got, want); fails++; }
+}
+
+/* ---- compound long RHS (first token 16-bit) across contexts ------------- */
+static long ca_pluseq(long s, int y, long la) { s += (y + la); return s; }
+static long ca_muleq(long s, int y, long la)  { s *= (y + la); return s; }
+static long ca_diveq(long s, int y, long la)  { s /= (y + la); return s; }
+static long ca_modeq(long s, int y, long la)  { s %= (y + la); return s; }
+static long ca_andeq(long s, int y, long la)  { s &= (y + la); return s; }
+static long ca_tern(int c, int y, long la, long lb) { return c ? (y + la) : (y + lb); }
+static long ca_sink(long v) { return v + 1L; }
+static long ca_callarg(int y, long la) { return ca_sink(y + la); }
+static long ca_ret(int y, long la) { return y + la; }
+static long ca_arr[8];
+static long ca_index(int y, long lb) { return ca_arr[(int)(y + lb)]; }
+static long ca_switch(int y, long la)
+{
+    switch (y + la) { case 100000L: return 1; case 100001L: return 2; default: return 9; }
+}
+static long ca_init(int y, long la) { long x = y + la; return x; }
+static unsigned long ca_upluseq(unsigned long s, unsigned int y, unsigned long la)
+{ s += (y + la); return s; }
+
+/* ---- compound float RHS (peek predicted 16-bit) ------------------------- */
+static float fa, fb;
+static float cf_add(int x)  { return x + (fa * fb); }
+static float cf_sub(int x)  { return x - (fa * fb); }
+static float cf_mul(int x)  { return x * (fa + fb); }
+static float cf_addp1(int x){ return x + (fa); }
+static float cf_addl(long lx) { return lx + (fa * fb); }
+/* float compare inside an if-condition (direct-branch path) */
+static int cf_lt(int x) { if (x < (fa * fb)) return 1; return 0; }
+static int cf_gt(int x) { if (x > (fa * fb)) return 1; return 0; }
+static int cf_eq(int x) { if (x == (fa + fb)) return 1; return 0; }
+static int cf_le(int x) { if (x <= (fa * fb)) return 1; return 0; }
+
+/* ---- shift / unsigned div with compound long ---------------------------- */
+static long sh_shl(int y, long la)  { return (y + la) << 2; }
+static long sh_shr(int y, long la)  { return (y + la) >> 2; }
+static unsigned long sh_ushr(unsigned int y, unsigned long la) { return (y + la) >> 2; }
+static int sh_cmp(int y, long la) { if (((y + la) >> 1) > 50000L) return 1; return 0; }
+static unsigned long sh_udiv(unsigned int y, unsigned long la) { return (y + la) / 7UL; }
+static unsigned long sh_umod(unsigned int y, unsigned long la) { return (y + la) % 7UL; }
+
+int main(void)
+{
+    int i;
+    for (i = 0; i < 8; i++) ca_arr[i] = (long)i * 100000L;
+
+    chk(ca_pluseq(1000000L, 5, 100000L), 1100005L, "pluseq");
+    chk(ca_muleq(3L, 5, 100000L), 300015L, "muleq");
+    chk(ca_diveq(1000000L, 0, 1000L), 1000L, "diveq");
+    chk(ca_modeq(1000003L, 0, 1000L), 3L, "modeq");
+    chk(ca_andeq(0x1FFFFL, 0, 0x10001L), 0x10001L, "andeq");
+    chk(ca_tern(1, 5, 100000L, 200000L), 100005L, "tern true");
+    chk(ca_tern(0, 5, 100000L, 200000L), 200005L, "tern false");
+    chk(ca_callarg(5, 100000L), 100006L, "callarg");
+    chk(ca_ret(5, 100000L), 100005L, "ret");
+    chk(ca_index(1, 2L), 300000L, "index");
+    chk(ca_switch(0, 100000L), 1, "switch0");
+    chk(ca_switch(1, 100000L), 2, "switch1");
+    chk(ca_switch(5, 100000L), 9, "switch default");
+    chk(ca_init(5, 100000L), 100005L, "init");
+    chku(ca_upluseq(1000000UL, 5U, 100000UL), 1100005UL, "upluseq");
+
+    fa = 3.0f; fb = 4.0f;   /* fa*fb=12, fa+fb=7 */
+    chkf(cf_add(5), 17.0f, "f add");
+    chkf(cf_sub(5), -7.0f, "f sub");
+    chkf(cf_mul(5), 35.0f, "f mul");
+    chkf(cf_addp1(5), 8.0f, "f add paren1");
+    chkf(cf_addl(100000L), 100012.0f, "f add long");
+    chk(cf_lt(5), 1, "f lt");
+    chk(cf_lt(20), 0, "f lt no");
+    chk(cf_gt(20), 1, "f gt");
+    chk(cf_eq(7), 1, "f eq");
+    chk(cf_eq(8), 0, "f eq no");
+    chk(cf_le(12), 1, "f le");
+
+    chk(sh_shl(0, 100000L), 400000L, "shl");
+    chk(sh_shr(0, 100000L), 25000L, "shr");
+    chku(sh_ushr(0U, 4000000000UL), 1000000000UL, "ushr");
+    chk(sh_cmp(0, 200000L), 1, "shcmp");
+    chk(sh_cmp(0, 80000L), 0, "shcmp no");
+    chku(sh_udiv(1U, 99UL), 14UL, "udiv");
+    chku(sh_umod(1U, 99UL), 2UL, "umod");
+
+    if (fails == 0) printf("tctxops passed with great success\n");
+    else printf("tctxops FAILED: %d\n", fails);
+    return fails != 0;
+}


### PR DESCRIPTION
The expression-type lookahead, peek_simple_unary_type(), only inspects the
first operand token of an operator's right-hand side. A parenthesized or
otherwise compound RHS such as  x + (fa * fb)  or  x < (la + lb)  was
therefore predicted as 16-bit int: it saw the leading '(' and fell through
to the int default. gen_add/gen_mul/gen_rel/gen_eq then took the 16-bit
fast path and either dropped a long's high word or reinterpreted a float
result as a 16-bit integer (e.g. 5 + (3.0f * 4.0f) yielded 5.0, not 17.0).

Root-cause fixes (rather than per-operator band-aids):

* peek_simple_unary_type (src/dcc/dcc_ops.c): when the leading '(' does not
  begin a cast, recurse to classify the parenthesized expression's first
  operand and return that promoted type instead of defaulting to int. This
  lets the existing float and long branches in the operator generators fire
  correctly for parenthesized RHS operands. Parser state is saved/restored,
  so the lookahead remains side-effect free.

* simple_direct_condition_until (src/dcc/dcc_cmp.c): detect a float operand
  at any parenthesis depth, not just depth 0, so a condition like
  if (x < (fa * fb)) falls back from the integer direct-branch comparison
  to the general float comparison path.

Testing:

* New tctxops.c (wired into runall.sh, runall.bat, and baseline_test_dcc.txt)
  covers a compound long RHS across compound assignment, ternary, call
  argument, return, array index, switch, initializer, shift, and unsigned
  div/mod, plus a compound float RHS in arithmetic and in if-condition
  comparisons.
* Verified that compound-long contexts other than the two fixed float cases
  were already correct.

Full runall regression green (peep + nopeep); no other test output changed.

