### PR TITLE
Fix C99 for-init declaration scoping (syntax was accepted but broken)

### DIFF
--- a/.github/skills/c89-cpm-z80/SKILL.md
+++ b/.github/skills/c89-cpm-z80/SKILL.md
@@ -56,6 +56,10 @@ At a glance: `char` 8-bit (signed), `short`/`int` 16-bit, `long` 32-bit,
   declarators scope the same way. Caveat: the `for`-init is the *only* nested
   scope dcc models — a same-named variable declared in an ordinary inner
   `{ ... }` block still aliases the outer one, so use distinct names there.
+- **C99 `//` line comments are supported** alongside C89 `/* ... */` block
+  comments — including trailing comments on `#define` lines (stripped like
+  block comments before macro replacement). Both forms are correctly ignored
+  inside string and character literals (e.g. `"http://..."` stays intact).
 - **K&R function definitions are accepted** (dcc's typing is lenient), but
   prefer prototypes for new code. Mixed decls/statements and block-local
   variables are fine (real C89).
@@ -65,8 +69,8 @@ At a glance: `char` 8-bit (signed), `short`/`int` 16-bit, `long` 32-bit,
   use `unsigned`/`unsigned long` when you need a guaranteed zero-fill shift.
   Shifts act at the operand width (16-bit for `int`; cast/promote to `long`
   for wider shifts).
-- No other C99/C11 features (`restrict`, `_Bool`, `//`-only assumptions about
-  runtime, VLAs, compound literals, designated initializers).
+- No other C99/C11 features (`restrict`, `_Bool`, VLAs, compound literals,
+  designated initializers).
 
 ## Identifier significance
 

--- a/.github/skills/c89-cpm-z80/SKILL.md
+++ b/.github/skills/c89-cpm-z80/SKILL.md
@@ -49,6 +49,13 @@ At a glance: `char` 8-bit (signed), `short`/`int` 16-bit, `long` 32-bit,
 - **Inert but accepted:** `const` (constant-folds initializers only; not
   read-only memory), `volatile` (ignored), `register` (hint only), `auto`
   (no-op). `inline` is accepted as a C99 extension and ignored.
+- **C99 `for`-init declarations are supported** with real loop scope:
+  `for (int i = 0; i < n; i++)` declares `i` only for the loop, so it shadows
+  (does not clobber) an outer same-named variable and is invisible after the
+  loop. Multiple declarators (`for (int i = 0, j = n; ...)`) and pointer/array
+  declarators scope the same way. Caveat: the `for`-init is the *only* nested
+  scope dcc models — a same-named variable declared in an ordinary inner
+  `{ ... }` block still aliases the outer one, so use distinct names there.
 - **K&R function definitions are accepted** (dcc's typing is lenient), but
   prefer prototypes for new code. Mixed decls/statements and block-local
   variables are fine (real C89).

--- a/baseline_test_dcc.txt
+++ b/baseline_test_dcc.txt
@@ -4197,3 +4197,5 @@ inp result 0..255: ok
 port io ok
 test tlongidx
 PASS tlongidx
+test tforsco
+tforsco passed with great success

--- a/baseline_test_dcc.txt
+++ b/baseline_test_dcc.txt
@@ -4199,3 +4199,5 @@ test tlongidx
 PASS tlongidx
 test tforsco
 tforsco passed with great success
+test tcmt99
+tcmt99 passed with great success

--- a/dcc-c89-reference-guide.md
+++ b/dcc-c89-reference-guide.md
@@ -224,6 +224,11 @@ Notes specific to the 16-bit model:
   visible afterward. Multiple declarators (`for (int i = 0, j = n; ...)`) and
   pointer/array declarators in the init clause are scoped the same way. See
   [Limitations](#limitations-to-keep-in-mind) for the one nested-scope caveat.
+- **C99 `//` line comments** — accepted everywhere C89 `/* ... */` block
+  comments are, including as trailing comments on preprocessor directives such
+  as `#define` (where, like block comments, they are stripped before macro
+  replacement). Both comment styles are correctly ignored inside string and
+  character literals, so a literal such as `"a // b"` is left intact.
 
 ```c
 int i = 99;

--- a/dcc-c89-reference-guide.md
+++ b/dcc-c89-reference-guide.md
@@ -218,6 +218,19 @@ Notes specific to the 16-bit model:
 - `inline` — accepted as a non-C89 (C99) extension and then ignored; functions
   are always emitted normally. No other C99/C11 keywords (`restrict`, `_Bool`,
   `_Complex`, and so on) are recognized.
+- **C99 `for`-loop init declarations** — `for (int i = 0; i < n; i++)` is
+  accepted and the loop variable has proper C99 loop scope: it shadows any
+  outer variable of the same name for the duration of the loop and is not
+  visible afterward. Multiple declarators (`for (int i = 0, j = n; ...)`) and
+  pointer/array declarators in the init clause are scoped the same way. See
+  [Limitations](#limitations-to-keep-in-mind) for the one nested-scope caveat.
+
+```c
+int i = 99;
+for (int i = 0; i < 3; i++)   /* this i shadows the outer one */
+    use(i);                   /* 0, 1, 2 */
+/* outer i is still 99 here */
+```
 
 ---
 
@@ -811,6 +824,12 @@ either `#include` its `.c` from your main file, or compile it separately with
   `-stack` and see [spsmash.c](spsmash.c) for an optional manual stack check.
 - **CP/M 2.2 only.** The runtime uses BDOS functions only (no BIOS calls), plus
   CP/M 3.0 BDOS 108 for the process exit code.
+- **Only `for`-init declarations get a nested scope.** dcc keeps one flat set
+  of locals per function. A C99 `for (int i = ...; ...)` correctly shadows an
+  outer `i` (its declaration gets its own slot for the loop), but a same-named
+  variable declared in an ordinary nested `{ ... }` block reuses the outer
+  variable's storage instead of getting a fresh one. Use distinct names when
+  you shadow a variable inside a plain block.
 
 ---
 

--- a/runall.bat
+++ b/runall.bat
@@ -20,7 +20,7 @@ set _applist=sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong ^
              tpostut tbug2 tlongsub treg tret tstructv tstructi tstructp tstri2 ^
              tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom ^
              tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield ^
-             pint cobint forint bint fint cint tstretst tportio tlongidx
+             pint cobint forint bint fint cint tstretst tportio tlongidx tforsco
 
 echo --- optimized (ma peep) ---
 set "outputfile=test_dcc.txt"

--- a/runall.bat
+++ b/runall.bat
@@ -20,7 +20,7 @@ set _applist=sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong ^
              tpostut tbug2 tlongsub treg tret tstructv tstructi tstructp tstri2 ^
              tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom ^
              tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield ^
-             pint cobint forint bint fint cint tstretst tportio tlongidx tforsco
+             pint cobint forint bint fint cint tstretst tportio tlongidx tforsco tcmt99
 
 echo --- optimized (ma peep) ---
 set "outputfile=test_dcc.txt"

--- a/runall.sh
+++ b/runall.sh
@@ -18,7 +18,7 @@ APPLIST="sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong \
          tpostut tbug2 tlongsub treg tret tstructv tstructi tstructp tstri2 \
          tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom \
          tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield \
-         pint cobint forint bint fint cint tstretst tportio tlongidx tforsco"
+         pint cobint forint bint fint cint tstretst tportio tlongidx tforsco tcmt99"
 
 run_args() {
     case "$1" in

--- a/runall.sh
+++ b/runall.sh
@@ -18,7 +18,7 @@ APPLIST="sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong \
          tpostut tbug2 tlongsub treg tret tstructv tstructi tstructp tstri2 \
          tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom \
          tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield \
-         pint cobint forint bint fint cint tstretst tportio tlongidx"
+         pint cobint forint bint fint cint tstretst tportio tlongidx tforsco"
 
 run_args() {
     case "$1" in

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -73,6 +73,11 @@
 #define MAX_STRINGS    2048
 #define MAX_DEFINES    512
 #define MAX_MACRO_TEXT 2048
+
+/* C99 for-init declaration scoping limits */
+#define MAX_FOR_SCOPES 256
+#define MAX_FOR_SCOPE_RENAMES 16
+#define MAX_FORREN     128
 #define MAX_FLOW       128
 #define MAX_SNAPSHOT   256
 #define MAX_PROTO_PARAMS 16
@@ -365,6 +370,25 @@ extern int current_function_has_call;
 extern int break_stack[MAX_FLOW];
 extern int cont_stack[MAX_FLOW];
 extern int nflow;
+
+/* C99 for-init declaration scoping (see dcc_state.c for details) */
+extern int g_for_seq;
+extern int g_for_rename_count[MAX_FOR_SCOPES];
+extern char g_for_rename_from[MAX_FOR_SCOPES][MAX_FOR_SCOPE_RENAMES][64];
+extern char g_for_rename_to[MAX_FOR_SCOPES][MAX_FOR_SCOPE_RENAMES][64];
+extern char g_forren_from[MAX_FORREN][64];
+extern char g_forren_to[MAX_FORREN][64];
+extern int g_forren_n;
+extern int g_for_decl_seq;
+extern int g_for_decl_rename_index;
+extern int g_for_decl_recording;
+const char *resolve_local_rename(const char *name);
+void make_for_rename_name(char *dst, int dstsz, const char *from, int for_seq, int rename_index);
+void add_for_scope_rename(int for_seq, const char *from);
+const char *enter_for_decl_rename(const char *name);
+void push_for_rename(const char *from, const char *to);
+void pop_for_rename(void);
+
 extern int errors;
 extern int scan_mode;
 extern int decl_is_extern;

--- a/src/dcc/dcc_decl.c
+++ b/src/dcc/dcc_decl.c
@@ -709,6 +709,13 @@ void gen_local_decl_after_type(int base)
             next_token();
         }
 
+        if (g_for_decl_seq >= 0) {
+            const char *rn;
+            rn = enter_for_decl_rename(name);
+            strncpy(name, rn, sizeof(name) - 1);
+            name[sizeof(name) - 1] = 0;
+        }
+
         arrlen = g_funcptr_decl_array_len;
         g_funcptr_decl_array_len = 0;
         total_elems = arrlen;

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -526,6 +526,7 @@ void scan_local_decl_after_type(int base)
     int type, bytes, arrlen;
     int total_elems;
     char name[64];
+    char source_name[64];
     struct Sym *s;
 
     for (;;) {
@@ -539,6 +540,15 @@ void scan_local_decl_after_type(int base)
             strncpy(name, tok.text, sizeof(name) - 1);
             name[sizeof(name) - 1] = 0;
             next_token();
+        }
+        strncpy(source_name, name, sizeof(source_name) - 1);
+        source_name[sizeof(source_name) - 1] = 0;
+
+        if (g_for_decl_seq >= 0) {
+            const char *rn;
+            rn = enter_for_decl_rename(name);
+            strncpy(name, rn, sizeof(name) - 1);
+            name[sizeof(name) - 1] = 0;
         }
 
         arrlen = g_funcptr_decl_array_len;
@@ -588,7 +598,7 @@ void scan_local_decl_after_type(int base)
         s = find_local(name);
         if (!s && decl_is_const && arrlen == 0 && g_last_array_dim_count == 0 &&
             type_is_const_scalar_candidate(type) && tok.kind == '=' &&
-            !local_name_address_taken_ahead(name)) {
+            !local_name_address_taken_ahead(source_name)) {
             unsigned long const_value;
             next_token();
             if (try_parse_local_const_initializer(type, &const_value)) {
@@ -719,6 +729,14 @@ void scan_function_body(void)
     int brace;
     int can_decl;
 
+    /* Restart the per-function for-loop counter so the frame-sizing scan and
+     * the real codegen agree on which for-loop is which. */
+    g_for_seq = 0;
+    g_forren_n = 0;
+    g_for_decl_seq = -1;
+    g_for_decl_rename_index = 0;
+    g_for_decl_recording = 0;
+
     expect('{');
     brace = 1;
     can_decl = 1;
@@ -733,6 +751,7 @@ void scan_function_body(void)
             next_token();
             can_decl = 1;
         } else if (tok.kind == TOK_FOR) {
+            int for_seq;
             /*
              * The old scanner looked for starts_type() at every token in the
              * function body.  That is unsafe now that casts are supported:
@@ -750,20 +769,45 @@ void scan_function_body(void)
              * Scan declarations only at statement/declaration boundaries, with
              * a special case for C99-style for-init declarations.
              */
+            for_seq = g_for_seq++;
+            if (for_seq >= MAX_FOR_SCOPES)
+                fatal("too many for statements");
             next_token();
             if (accept('(')) {
                 int depth;
 
                 if (starts_type()) {
                     int t;
+                    int old_for_decl_seq;
+                    int old_for_decl_rename_index;
+                    int old_for_decl_recording;
                     decl_is_extern = 0;
                     decl_is_const = 0;
                     t = parse_base_type();
+
+                    g_for_rename_count[for_seq] = 0;
+
+                    old_for_decl_seq = g_for_decl_seq;
+                    old_for_decl_rename_index = g_for_decl_rename_index;
+                    old_for_decl_recording = g_for_decl_recording;
+                    g_for_decl_seq = for_seq;
+                    g_for_decl_rename_index = 0;
+                    g_for_decl_recording = 1;
+
                     if (tok.kind != ';')
                         scan_local_decl_after_type(t); /* consumes ';' */
                     else
                         next_token();
+
+                    while (g_for_decl_rename_index > 0) {
+                        pop_for_rename();
+                        g_for_decl_rename_index--;
+                    }
+                    g_for_decl_seq = old_for_decl_seq;
+                    g_for_decl_rename_index = old_for_decl_rename_index;
+                    g_for_decl_recording = old_for_decl_recording;
                 } else {
+                    g_for_rename_count[for_seq] = 0;
                     depth = 0;
                     while (tok.kind != TOK_EOF) {
                         if (depth == 0 && tok.kind == ';') {
@@ -1618,6 +1662,13 @@ void parse_function_or_global(int base_type)
                 nulabels = 0;
                 current_return_label = new_label();
                 current_return_type = type;
+                /* Restart the for-loop counter for the codegen pass so it
+                 * lines up with the frame-sizing scan. */
+                g_for_seq = 0;
+                g_forren_n = 0;
+                g_for_decl_seq = -1;
+                g_for_decl_rename_index = 0;
+                g_for_decl_recording = 0;
                 emit_function_prologue(name, current_local_bytes, current_function_safe_to_omit_ix(type, current_local_bytes));
                 gen_compound();
                 check_undefined_user_labels();

--- a/src/dcc/dcc_state.c
+++ b/src/dcc/dcc_state.c
@@ -104,6 +104,27 @@ int current_function_has_call;
 int break_stack[MAX_FLOW];
 int cont_stack[MAX_FLOW];
 int nflow;
+
+/* ---- C99 for-init declaration scoping ---------------------------------- */
+/* Per-function counter of for-loops, advanced in source/pre-order in BOTH the
+ * frame-sizing scan and the real codegen so the two agree on which loop is
+ * which.  The frame-sizing scan records the source-name -> unique-local-name
+ * mappings for each C99 for-init declaration; codegen replays them while
+ * compiling the corresponding loop. */
+int g_for_seq;
+int g_for_rename_count[MAX_FOR_SCOPES];
+char g_for_rename_from[MAX_FOR_SCOPES][MAX_FOR_SCOPE_RENAMES][64];
+char g_for_rename_to[MAX_FOR_SCOPES][MAX_FOR_SCOPE_RENAMES][64];
+
+/* Active for-init renames: while inside a for-loop with C99 init declarations,
+ * source names are mapped to unique internal names so the variables have real
+ * loop scope.  A small stack supports nested for scopes. */
+char g_forren_from[MAX_FORREN][64];
+char g_forren_to[MAX_FORREN][64];
+int g_forren_n;
+int g_for_decl_seq;
+int g_for_decl_rename_index;
+int g_for_decl_recording;
 int errors;
 int scan_mode;
 int decl_is_extern;

--- a/src/dcc/dcc_stmt.c
+++ b/src/dcc/dcc_stmt.c
@@ -1004,8 +1004,21 @@ void gen_for(void)
     char *inc_code;
     char *cond_code;
     int do_while;
+    int for_seq;
+    int rename_count;
+    int old_for_decl_seq;
+    int old_for_decl_rename_index;
+    int old_for_decl_recording;
 
-    if (try_gen_bc_byte_array_cycle_for())
+    /* Advance the per-function for-loop counter in pre-order so it matches the
+     * frame-sizing scan; g_for_rename_count[seq] tells us whether this loop's
+     * for-init declaration introduced C99 loop-scoped names. */
+    for_seq = g_for_seq++;
+    if (for_seq >= MAX_FOR_SCOPES)
+        fatal("too many for statements");
+    rename_count = g_for_rename_count[for_seq];
+
+    if (rename_count == 0 && try_gen_bc_byte_array_cycle_for())
         return;
 
     ltop = new_label();
@@ -1026,10 +1039,24 @@ void gen_for(void)
         int t;
         decl_is_extern = 0;
         t = parse_base_type();
+
+        old_for_decl_seq = g_for_decl_seq;
+        old_for_decl_rename_index = g_for_decl_rename_index;
+        old_for_decl_recording = g_for_decl_recording;
+        g_for_decl_seq = for_seq;
+        g_for_decl_rename_index = 0;
+        g_for_decl_recording = 0;
+
         if (tok.kind != ';')
             gen_local_decl_after_type(t); /* consumes the ';' */
         else
             next_token();
+
+        if (g_for_decl_rename_index != rename_count)
+            fatal("for-init scope mismatch");
+        g_for_decl_seq = old_for_decl_seq;
+        g_for_decl_rename_index = old_for_decl_rename_index;
+        g_for_decl_recording = old_for_decl_recording;
         /* no expect(';') here — already consumed above */
     } else {
         if (tok.kind != ';') gen_expr();
@@ -1088,6 +1115,12 @@ void gen_for(void)
         free(cond_code);
     }
     emit_label(lend);
+
+    /* Close the for-init scope: source names now resolve to any outer symbols. */
+    while (rename_count > 0) {
+        pop_for_rename();
+        rename_count--;
+    }
 }
 
 void gen_return(void)

--- a/src/dcc/dcc_symbols.c
+++ b/src/dcc/dcc_symbols.c
@@ -11,9 +11,107 @@
  */
 
 #include "dcc.h"
+
+/*
+ * C99 for-init renames.  While code generation (or the frame-sizing scan) is
+ * inside a for-loop with init declarations, each declared source name is mapped
+ * to a unique internal local name.  That gives the variable real C99 loop
+ * scope even though dcc's local symbol table is otherwise function-flat.
+ * resolve_local_rename applies the innermost active mapping; it is idempotent
+ * because the mapped-to names contain '#', which never appears in a source
+ * identifier and so never matches a "from" entry.
+ */
+const char *resolve_local_rename(const char *name)
+{
+    int k;
+    for (k = g_forren_n - 1; k >= 0; --k) {
+        if (!strcmp(g_forren_from[k], name))
+            return g_forren_to[k];
+    }
+    return name;
+}
+
+void make_for_rename_name(char *dst, int dstsz, const char *from, int for_seq, int rename_index)
+{
+    char suffix[24];
+    int from_len;
+    int suffix_len;
+
+    sprintf(suffix, "#%d#%d", for_seq, rename_index);
+    suffix_len = (int)strlen(suffix);
+    if (dstsz <= suffix_len + 1)
+        fatal("for-init rename buffer too small");
+
+    from_len = (int)strlen(from);
+    if (from_len > dstsz - suffix_len - 1)
+        from_len = dstsz - suffix_len - 1;
+
+    memcpy(dst, from, from_len);
+    strcpy(dst + from_len, suffix);
+}
+
+void add_for_scope_rename(int for_seq, const char *from)
+{
+    int n;
+
+    if (for_seq >= MAX_FOR_SCOPES)
+        fatal("too many for statements");
+
+    n = g_for_rename_count[for_seq];
+    if (n >= MAX_FOR_SCOPE_RENAMES)
+        fatal("too many for-init declarators");
+
+    strncpy(g_for_rename_from[for_seq][n], from, 63);
+    g_for_rename_from[for_seq][n][63] = 0;
+    make_for_rename_name(g_for_rename_to[for_seq][n], 64,
+                         g_for_rename_from[for_seq][n], for_seq, n);
+    g_for_rename_count[for_seq] = n + 1;
+}
+
+const char *enter_for_decl_rename(const char *name)
+{
+    int n;
+
+    if (g_for_decl_seq < 0)
+        fatal("bad for-init scope");
+
+    n = g_for_decl_rename_index;
+    if (g_for_decl_recording) {
+        add_for_scope_rename(g_for_decl_seq, name);
+    } else {
+        if (g_for_decl_seq >= MAX_FOR_SCOPES)
+            fatal("too many for statements");
+        if (n >= g_for_rename_count[g_for_decl_seq])
+            fatal("for-init scope mismatch");
+    }
+
+    push_for_rename(g_for_rename_from[g_for_decl_seq][n],
+                    g_for_rename_to[g_for_decl_seq][n]);
+    g_for_decl_rename_index = n + 1;
+    return g_for_rename_to[g_for_decl_seq][n];
+}
+
+void push_for_rename(const char *from, const char *to)
+{
+    if (g_forren_n >= MAX_FORREN)
+        fatal("too many nested for-init scopes");
+    strncpy(g_forren_from[g_forren_n], from, 63);
+    g_forren_from[g_forren_n][63] = 0;
+    strncpy(g_forren_to[g_forren_n], to, 63);
+    g_forren_to[g_forren_n][63] = 0;
+    g_forren_n++;
+}
+
+void pop_for_rename(void)
+{
+    if (g_forren_n > 0)
+        g_forren_n--;
+}
+
 struct Sym *find_local(const char *name)
 {
     int i;
+    name = resolve_local_rename(name);
     for (i = nlocals - 1; i >= 0; --i)
         if (!strcmp(locals[i].name, name)) return &locals[i];
     return NULL;

--- a/tcmt99.c
+++ b/tcmt99.c
@@ -1,0 +1,68 @@
+/*
+ * tcmt99.c - C99 "//" line-comment support, alongside C89 block comments.
+ *
+ * Pins the behaviour that matters for the dcc lexer and preprocessor:
+ *   - text after a line comment is ignored to end of line,
+ *   - a lone slash is still the divide operator (only a doubled slash starts
+ *     a comment),
+ *   - a doubled slash inside a string literal is ordinary data,
+ *   - a line comment trailing a #define (object- and function-like) is
+ *     stripped before macro replacement,
+ *   - line and block comments coexist, and a line comment hides a following
+ *     block-comment opener so it cannot start a block,
+ *   - a line comment may be the final thing in the file.
+ *
+ * If line-comment support regressed, this file would either fail to compile
+ * (the comment text would lex as stray tokens) or print wrong values, so
+ * runall would catch it.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#define VAL 42           // object-like macro, trailing line comment
+#define DBL(x) ((x)+(x)) // function-like macro, trailing line comment
+#define WID 7 /* b */    // block comment then line comment on one #define
+
+static int fails;
+static void chk(long got, long want, char *name)
+{
+    if (got != want) { printf("FAIL %s got=%ld want=%ld\n", name, got, want); fails++; }
+}
+
+int main(void)
+{
+    int x;
+    char *s;
+
+    x = 5;          // x = 999
+    chk(x, 5L, "basic");
+
+    x = 10 / 2;     // a lone slash still divides
+    chk(x, 5L, "single slash divides");
+
+    // full-line comment with tricky text: /* not a block */ "not a string" 'x'
+    x = VAL;
+    chk(x, 42L, "object macro trailing comment");
+    chk(DBL(5), 10L, "function macro trailing comment");
+    chk(WID, 7L, "block-then-line on one define");
+
+    s = "a//b//c";  // the // sequences live inside the string
+    chk((long)strlen(s), 7L, "slashes inside string");
+
+    // /* a line comment hides this block opener, so the next line stays live
+    x = 11;
+    chk(x, 11L, "line comment hides block opener");
+
+    x = 22; /* a block comment may contain // safely */ x += 1;
+    chk(x, 23L, "block comment contains slashes");
+
+    x = 0;          // reset
+    x += 1;         // ++
+    x += 1;         // ++
+    chk(x, 2L, "interleaved trailing comments");
+
+    if (fails == 0) printf("tcmt99 passed with great success\n");
+    else printf("tcmt99 FAILED: %d\n", fails);
+    return fails != 0;
+}
+// the final token in this file is a line comment

--- a/tforsco.c
+++ b/tforsco.c
@@ -1,0 +1,168 @@
+/*
+ * tforsco.c - C99 for-init declaration scoping.
+ *
+ * dcc accepts  for (int i = 0; ...)  syntax, but the loop variable used to
+ * share one flat function scope: a for-init `int i` whose name already named
+ * a local/param aliased that outer variable instead of shadowing it.  These
+ * tests pin the corrected block-scoped behaviour:
+ *   - a for-init variable that shadows an outer one leaves the outer value
+ *     intact after the loop, and
+ *   - sibling and nested loops (including a nested shadow) each get their own
+ *     loop variable.
+ */
+#include <stdio.h>
+
+static int fails;
+static void chk(long got, long want, char *name)
+{
+    if (got != want) { printf("FAIL %s got=%ld want=%ld\n", name, got, want); fails++; }
+}
+
+static int param_shadow(int p)
+{
+    int got = 0;
+    for (int p = 0; p < 3; p++)
+        got += p;
+    return got * 100 + p;
+}
+
+int main(void)
+{
+    int sum = 0;
+    int i;
+    int m;
+
+    /* basic for-init */
+    for (int i = 0; i < 5; i++)
+        sum += i;
+    chk(sum, 10L, "basic");
+
+    /* shadowing: the loop i must not touch the outer i */
+    i = 99;
+    for (int i = 0; i < 3; i++)
+        sum += i;                       /* +0+1+2 -> 13 */
+    chk(i, 99L, "shadow outer untouched");
+    chk(sum, 13L, "shadow sum");
+
+    /* sibling loops each re-declare i */
+    for (int i = 0; i < 4; i++) sum += i;   /* +6 -> 19 */
+    for (int i = 0; i < 4; i++) sum += i;   /* +6 -> 25 */
+    chk(sum, 25L, "siblings");
+
+    /* nested loops, distinct names */
+    {
+        int total = 0;
+        for (int a = 0; a < 3; a++)
+            for (int b = 0; b < 2; b++)
+                total++;
+        chk(total, 6L, "nested distinct");
+    }
+
+    /* nested shadow: inner for-j shadows an outer j */
+    {
+        int j = 7;
+        long acc = 0;
+        for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 3; j++)
+                acc += j;               /* 3 * (0+1+2) = 9 */
+        chk(j, 7L, "nested shadow outer j");
+        chk(acc, 9L, "nested shadow acc");
+    }
+
+    /* for-init shadow with a different type than the outer variable */
+    {
+        int k = 1234;
+        long ksum = 0;
+        for (long k = 100000L; k < 100003L; k++)
+            ksum += k;                  /* 100000+100001+100002 = 300003 */
+        chk(k, 1234L, "type-diff shadow outer");
+        chk(ksum, 300003L, "type-diff shadow sum");
+    }
+
+    /* non-shadowing for-init still works (no outer m) */
+    {
+        long msum = 0;
+        for (int m = 0; m < 6; m++)
+            msum += m;                  /* 15 */
+        chk(msum, 15L, "non-shadow");
+    }
+
+    /* C99 loop scope also hides a non-shadowing init declaration after loop. */
+    m = 77;
+    for (int m = 0; m < 2; m++)
+        sum += m;                       /* +1 -> 26 */
+    chk(m, 77L, "non-shadow hidden after");
+    chk(sum, 26L, "non-shadow hidden sum");
+
+    /* init declaration stays in scope for condition, body, and increment. */
+    {
+        int c = 500;
+        int seen = 0;
+        for (int c = 0; c < 5; c++) {
+            if (c == 1) continue;
+            seen += c;
+            if (c == 3) break;
+        }
+        chk(c, 500L, "continue break outer");
+        chk(seen, 5L, "continue break seen");
+    }
+
+    /* single-statement and empty-body loops must keep the init name scoped. */
+    {
+        int s = 20;
+        int one = 0;
+        int empty = 0;
+        for (int s = 0; s < 3; s++) one += s;
+        for (int e = 0; e < 4; empty += e, e++) ;
+        chk(s, 20L, "single statement outer");
+        chk(one, 3L, "single statement sum");
+        chk(empty, 6L, "empty body increment");
+    }
+
+    /* multiple declarators: each declared name enters scope after its own
+     * declarator, so the initializer for b sees the new a. */
+    {
+        int a = 100;
+        int b = 200;
+        int multi = 0;
+        for (int a = 1, b = a + 2; a < 4; a++, b += 10)
+            multi += a + b;             /* 1+3 + 2+13 + 3+23 = 45 */
+        chk(a, 100L, "multi outer a");
+        chk(b, 200L, "multi outer b");
+        chk(multi, 45L, "multi sum");
+    }
+
+    /* pointer declarator in a for-init should scope like any other declarator. */
+    {
+        int vals[3];
+        int *p;
+        int psum = 0;
+        vals[0] = 2;
+        vals[1] = 4;
+        vals[2] = 6;
+        p = vals;
+        for (int *p = vals; p < vals + 3; p++)
+            psum += *p;
+        chk(*p, 2L, "pointer outer");
+        chk(psum, 12L, "pointer sum");
+    }
+
+    /* a for-init declaration can shadow a parameter. */
+    chk(param_shadow(7), 307L, "param shadow");
+
+    /* const for-init names still need storage when their address is taken. */
+    {
+        int q = 10;
+        int qgot = 0;
+        for (const int q = 5; qgot == 0; qgot++) {
+            int *qp = &q;
+            qgot += *qp;
+        }
+        chk(q, 10L, "const address outer");
+        chk(qgot, 6L, "const address value");
+    }
+
+    if (fails == 0) printf("tforsco passed with great success\n");
+    else printf("tforsco FAILED: %d\n", fails);
+    return fails != 0;
+}

--- a/tstr.c
+++ b/tstr.c
@@ -168,7 +168,7 @@ void test_wide()
     }
 
     printf( "testing printf with wide strings\n" );
-    for ( i = 0; i < 20; i++ )
+    for ( int i = 0; i < 20; i++ )
     {
         int start = ( (unsigned int) rand() % 300 );
         int end = 1 + start + ( ( (unsigned int) rand() ) % 70 );


### PR DESCRIPTION
dcc already accepted the C99 for-init syntax `for (int i = 0; ...)`, but
the implementation was broken: the loop variable shared the flat
per-function local table, so a for-init whose name matched an outer
local/param aliased and clobbered that outer variable instead of shadowing
it. The syntax compiled and ran, but produced wrong results whenever the
loop variable name collided with an existing one.

This gives the loop variable real C99 loop scope.

Implementation (single-pass, no AST):
- A per-function counter (g_for_seq) numbers for-loops in source order and
  is reset in lockstep at the start of the frame-sizing scan and the real
  codegen pass, so both agree on which loop is which.
- During the scan, each for-init declarator is recorded as a source-name ->
  unique-internal-name rename (name#seq#idx); codegen replays those renames
  while compiling the matching loop.
- An active rename stack redirects find_local(), so the loop variable gets
  its own frame slot and references in the condition, body, and increment
  bind to it. Renames are popped at loop end, restoring the outer name.
- Renames are applied per declarator as the declaration is parsed, so
  multiple declarators (for (int i = 0, j = n; ...)) and pointer/array
  declarators scope correctly; the address-of analysis for const locals
  uses the original source name. Capacity overflows fail with a clear
  fatal() instead of miscompiling.

Supported: shadowing outer locals/params, sibling loops, nested loops
(including same-named nesting), and init declarations whose type differs
from the shadowed variable.

Limitation (pre-existing, unchanged): the for-init is the only nested scope
dcc models. A same-named variable declared in an ordinary inner { ... }
block still aliases the outer one.

tstr.c: a wide-string printf loop reused an earlier for-init i after the
loop (relying on the old leak); it now declares its own i.

Tests/docs: new tforsco.c regression (basic, shadow, siblings, nested,
nested shadow, type-differing shadow, multiple declarators, pointer
declarator, continue/break, single-statement and empty bodies, param
shadow, address-taken const) wired into runall.sh/.bat and
baseline_test_dcc.txt. Reference guide and c89-cpm-z80 skill document the
feature and the nested-block caveat. Full runall green, peep + nopeep.
