### PR TITLE
Block scope stack

### DIFF
--- a/.github/skills/c89-cpm-z80/SKILL.md
+++ b/.github/skills/c89-cpm-z80/SKILL.md
@@ -53,9 +53,12 @@ At a glance: `char` 8-bit (signed), `short`/`int` 16-bit, `long` 32-bit,
   `for (int i = 0; i < n; i++)` declares `i` only for the loop, so it shadows
   (does not clobber) an outer same-named variable and is invisible after the
   loop. Multiple declarators (`for (int i = 0, j = n; ...)`) and pointer/array
-  declarators scope the same way. Caveat: the `for`-init is the *only* nested
-  scope dcc models — a same-named variable declared in an ordinary inner
-  `{ ... }` block still aliases the outer one, so use distinct names there.
+  declarators scope the same way.
+- **Block scope is fully modeled.** A variable declared in an inner `{ ... }`
+  block (including `if`/`while`/`for`/`switch` bodies) shadows an outer
+  same-named local or parameter for that block only and is invisible once the
+  block ends — sibling blocks may safely reuse a name, and an inner block may
+  shadow a `for`-init loop variable.
 - **C99 `//` line comments are supported** alongside C89 `/* ... */` block
   comments — including trailing comments on `#define` lines (stripped like
   block comments before macro replacement). Both forms are correctly ignored

--- a/.github/skills/c89-cpm-z80/SKILL.md
+++ b/.github/skills/c89-cpm-z80/SKILL.md
@@ -56,6 +56,10 @@ At a glance: `char` 8-bit (signed), `short`/`int` 16-bit, `long` 32-bit,
   declarators scope the same way. Caveat: the `for`-init is the *only* nested
   scope dcc models — a same-named variable declared in an ordinary inner
   `{ ... }` block still aliases the outer one, so use distinct names there.
+- **C99 `//` line comments are supported** alongside C89 `/* ... */` block
+  comments — including trailing comments on `#define` lines (stripped like
+  block comments before macro replacement). Both forms are correctly ignored
+  inside string and character literals (e.g. `"http://..."` stays intact).
 - **K&R function definitions are accepted** (dcc's typing is lenient), but
   prefer prototypes for new code. Mixed decls/statements and block-local
   variables are fine (real C89).
@@ -65,8 +69,8 @@ At a glance: `char` 8-bit (signed), `short`/`int` 16-bit, `long` 32-bit,
   use `unsigned`/`unsigned long` when you need a guaranteed zero-fill shift.
   Shifts act at the operand width (16-bit for `int`; cast/promote to `long`
   for wider shifts).
-- No other C99/C11 features (`restrict`, `_Bool`, `//`-only assumptions about
-  runtime, VLAs, compound literals, designated initializers).
+- No other C99/C11 features (`restrict`, `_Bool`, VLAs, compound literals,
+  designated initializers).
 
 ## Identifier significance
 

--- a/.github/skills/c89-cpm-z80/SKILL.md
+++ b/.github/skills/c89-cpm-z80/SKILL.md
@@ -49,6 +49,13 @@ At a glance: `char` 8-bit (signed), `short`/`int` 16-bit, `long` 32-bit,
 - **Inert but accepted:** `const` (constant-folds initializers only; not
   read-only memory), `volatile` (ignored), `register` (hint only), `auto`
   (no-op). `inline` is accepted as a C99 extension and ignored.
+- **C99 `for`-init declarations are supported** with real loop scope:
+  `for (int i = 0; i < n; i++)` declares `i` only for the loop, so it shadows
+  (does not clobber) an outer same-named variable and is invisible after the
+  loop. Multiple declarators (`for (int i = 0, j = n; ...)`) and pointer/array
+  declarators scope the same way. Caveat: the `for`-init is the *only* nested
+  scope dcc models — a same-named variable declared in an ordinary inner
+  `{ ... }` block still aliases the outer one, so use distinct names there.
 - **K&R function definitions are accepted** (dcc's typing is lenient), but
   prefer prototypes for new code. Mixed decls/statements and block-local
   variables are fine (real C89).

--- a/baseline_test_dcc.txt
+++ b/baseline_test_dcc.txt
@@ -4197,3 +4197,5 @@ inp result 0..255: ok
 port io ok
 test tlongidx
 PASS tlongidx
+test tforsco
+tforsco passed with great success

--- a/baseline_test_dcc.txt
+++ b/baseline_test_dcc.txt
@@ -4199,3 +4199,5 @@ test tlongidx
 PASS tlongidx
 test tforsco
 tforsco passed with great success
+test tcmt99
+tcmt99 passed with great success

--- a/baseline_test_dcc.txt
+++ b/baseline_test_dcc.txt
@@ -4199,5 +4199,7 @@ test tlongidx
 PASS tlongidx
 test tforsco
 tforsco passed with great success
+test tforblk
+tforblk passed with great success
 test tcmt99
 tcmt99 passed with great success

--- a/dcc-c89-reference-guide.md
+++ b/dcc-c89-reference-guide.md
@@ -222,8 +222,7 @@ Notes specific to the 16-bit model:
   accepted and the loop variable has proper C99 loop scope: it shadows any
   outer variable of the same name for the duration of the loop and is not
   visible afterward. Multiple declarators (`for (int i = 0, j = n; ...)`) and
-  pointer/array declarators in the init clause are scoped the same way. See
-  [Limitations](#limitations-to-keep-in-mind) for the one nested-scope caveat.
+  pointer/array declarators in the init clause are scoped the same way.
 - **C99 `//` line comments** — accepted everywhere C89 `/* ... */` block
   comments are, including as trailing comments on preprocessor directives such
   as `#define` (where, like block comments, they are stripped before macro
@@ -235,6 +234,19 @@ int i = 99;
 for (int i = 0; i < 3; i++)   /* this i shadows the outer one */
     use(i);                   /* 0, 1, 2 */
 /* outer i is still 99 here */
+```
+
+Block-local declarations nest the same way: a variable declared inside any
+`{ ... }` block (including `if`/`while`/`for`/`switch` bodies) shadows an outer
+same-named local or parameter only for that block and is invisible afterward.
+
+```c
+int x = 10;
+{
+    int x = 20;               /* shadows the outer x */
+    use(x);                   /* 20 */
+}
+/* outer x is still 10 here */
 ```
 
 ---
@@ -829,12 +841,6 @@ either `#include` its `.c` from your main file, or compile it separately with
   `-stack` and see [spsmash.c](spsmash.c) for an optional manual stack check.
 - **CP/M 2.2 only.** The runtime uses BDOS functions only (no BIOS calls), plus
   CP/M 3.0 BDOS 108 for the process exit code.
-- **Only `for`-init declarations get a nested scope.** dcc keeps one flat set
-  of locals per function. A C99 `for (int i = ...; ...)` correctly shadows an
-  outer `i` (its declaration gets its own slot for the loop), but a same-named
-  variable declared in an ordinary nested `{ ... }` block reuses the outer
-  variable's storage instead of getting a fresh one. Use distinct names when
-  you shadow a variable inside a plain block.
 
 ---
 

--- a/dcc-c89-reference-guide.md
+++ b/dcc-c89-reference-guide.md
@@ -224,6 +224,11 @@ Notes specific to the 16-bit model:
   visible afterward. Multiple declarators (`for (int i = 0, j = n; ...)`) and
   pointer/array declarators in the init clause are scoped the same way. See
   [Limitations](#limitations-to-keep-in-mind) for the one nested-scope caveat.
+- **C99 `//` line comments** — accepted everywhere C89 `/* ... */` block
+  comments are, including as trailing comments on preprocessor directives such
+  as `#define` (where, like block comments, they are stripped before macro
+  replacement). Both comment styles are correctly ignored inside string and
+  character literals, so a literal such as `"a // b"` is left intact.
 
 ```c
 int i = 99;

--- a/dcc-c89-reference-guide.md
+++ b/dcc-c89-reference-guide.md
@@ -218,6 +218,19 @@ Notes specific to the 16-bit model:
 - `inline` — accepted as a non-C89 (C99) extension and then ignored; functions
   are always emitted normally. No other C99/C11 keywords (`restrict`, `_Bool`,
   `_Complex`, and so on) are recognized.
+- **C99 `for`-loop init declarations** — `for (int i = 0; i < n; i++)` is
+  accepted and the loop variable has proper C99 loop scope: it shadows any
+  outer variable of the same name for the duration of the loop and is not
+  visible afterward. Multiple declarators (`for (int i = 0, j = n; ...)`) and
+  pointer/array declarators in the init clause are scoped the same way. See
+  [Limitations](#limitations-to-keep-in-mind) for the one nested-scope caveat.
+
+```c
+int i = 99;
+for (int i = 0; i < 3; i++)   /* this i shadows the outer one */
+    use(i);                   /* 0, 1, 2 */
+/* outer i is still 99 here */
+```
 
 ---
 
@@ -811,6 +824,12 @@ either `#include` its `.c` from your main file, or compile it separately with
   `-stack` and see [spsmash.c](spsmash.c) for an optional manual stack check.
 - **CP/M 2.2 only.** The runtime uses BDOS functions only (no BIOS calls), plus
   CP/M 3.0 BDOS 108 for the process exit code.
+- **Only `for`-init declarations get a nested scope.** dcc keeps one flat set
+  of locals per function. A C99 `for (int i = ...; ...)` correctly shadows an
+  outer `i` (its declaration gets its own slot for the loop), but a same-named
+  variable declared in an ordinary nested `{ ... }` block reuses the outer
+  variable's storage instead of getting a fresh one. Use distinct names when
+  you shadow a variable inside a plain block.
 
 ---
 

--- a/runall.bat
+++ b/runall.bat
@@ -20,7 +20,7 @@ set _applist=sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong ^
              tpostut tbug2 tlongsub treg tret tstructv tstructi tstructp tstri2 ^
              tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom ^
              tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield ^
-             pint cobint forint bint fint cint tstretst tportio tlongidx
+             pint cobint forint bint fint cint tstretst tportio tlongidx tforsco
 
 echo --- optimized (ma peep) ---
 set "outputfile=test_dcc.txt"

--- a/runall.bat
+++ b/runall.bat
@@ -20,7 +20,7 @@ set _applist=sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong ^
              tpostut tbug2 tlongsub treg tret tstructv tstructi tstructp tstri2 ^
              tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom ^
              tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield ^
-             pint cobint forint bint fint cint tstretst tportio tlongidx tforsco
+             pint cobint forint bint fint cint tstretst tportio tlongidx tforsco tcmt99
 
 echo --- optimized (ma peep) ---
 set "outputfile=test_dcc.txt"

--- a/runall.bat
+++ b/runall.bat
@@ -20,7 +20,7 @@ set _applist=sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong ^
              tpostut tbug2 tlongsub treg tret tstructv tstructi tstructp tstri2 ^
              tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom ^
              tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield ^
-             pint cobint forint bint fint cint tstretst tportio tlongidx tforsco tcmt99
+             pint cobint forint bint fint cint tstretst tportio tlongidx tforsco tforblk tcmt99
 
 echo --- optimized (ma peep) ---
 set "outputfile=test_dcc.txt"

--- a/runall.sh
+++ b/runall.sh
@@ -18,7 +18,7 @@ APPLIST="sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong \
          tpostut tbug2 tlongsub treg tret tstructv tstructi tstructp tstri2 \
          tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom \
          tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield \
-         pint cobint forint bint fint cint tstretst tportio tlongidx tforsco"
+         pint cobint forint bint fint cint tstretst tportio tlongidx tforsco tcmt99"
 
 run_args() {
     case "$1" in

--- a/runall.sh
+++ b/runall.sh
@@ -18,7 +18,7 @@ APPLIST="sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong \
          tpostut tbug2 tlongsub treg tret tstructv tstructi tstructp tstri2 \
          tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom \
          tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield \
-         pint cobint forint bint fint cint tstretst tportio tlongidx tforsco tcmt99"
+         pint cobint forint bint fint cint tstretst tportio tlongidx tforsco tforblk tcmt99"
 
 run_args() {
     case "$1" in

--- a/runall.sh
+++ b/runall.sh
@@ -18,7 +18,7 @@ APPLIST="sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong \
          tpostut tbug2 tlongsub treg tret tstructv tstructi tstructp tstri2 \
          tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom \
          tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield \
-         pint cobint forint bint fint cint tstretst tportio tlongidx"
+         pint cobint forint bint fint cint tstretst tportio tlongidx tforsco"
 
 run_args() {
     case "$1" in

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -78,6 +78,8 @@
 #define MAX_FOR_SCOPES 256
 #define MAX_FOR_SCOPE_RENAMES 16
 #define MAX_FORREN     128
+/* General lexical block-scope nesting depth (C block scope, beyond for-init) */
+#define MAX_SCOPE_DEPTH 64
 #define MAX_FLOW       128
 #define MAX_SNAPSHOT   256
 #define MAX_PROTO_PARAMS 16
@@ -197,6 +199,7 @@ struct Token {
 
 struct Sym {
     char name[64];
+    char link_name[64];
     int type;
     int storage;
     int offset;
@@ -389,6 +392,19 @@ const char *enter_for_decl_rename(const char *name);
 void push_for_rename(const char *from, const char *to);
 void pop_for_rename(void);
 
+/* General lexical block scope stack (see dcc_state.c).  enter_scope/leave_scope
+ * bracket every { } block in both the frame-sizing scan and codegen.  Codegen
+ * rebuilds the locals table exactly as the scan did, so both passes truncate
+ * nlocals on block exit and a local declared in an inner block stops resolving
+ * once the block ends. */
+extern int g_scope_watermark[MAX_SCOPE_DEPTH];
+extern int g_scope_depth;
+extern int g_static_local_func_index;
+extern int g_static_local_seq;
+void enter_scope(void);
+void leave_scope(void);
+struct Sym *find_local_decl(const char *name);
+
 extern int errors;
 extern int scan_mode;
 extern int decl_is_extern;
@@ -442,6 +458,7 @@ int asm_name_must_mangle(const char *cname);
 int asm_name_is_internal_public(const char *cname);
 const char *asm_name_for_runtime(const char *cname);
 const char *asm_name_for(const char *cname);
+const char *sym_asm_name(struct Sym *s);
 
 /* ---- diag_emit ---- */
 void fatal(const char *msg);
@@ -796,6 +813,8 @@ void gen_expr_statement(void);
 int parse_float_init_literal(unsigned long *bits);
 int type_is_const_scalar_candidate(int type);
 int try_parse_local_const_initializer(int type, unsigned long *valuep);
+struct Sym *try_const_fold_local(const char *store_name, const char *src_name,
+                                 int type, int has_array);
 void emit_load_const_sym_value(struct Sym *s);
 int try_parse_auto_const_init_value(int type, long *valuep);
 void emit_store_const_to_local_array_elem(struct Sym *s, int elem_type, int index, long v);

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -73,6 +73,11 @@
 #define MAX_STRINGS    2048
 #define MAX_DEFINES    512
 #define MAX_MACRO_TEXT 2048
+
+/* C99 for-init declaration scoping limits */
+#define MAX_FOR_SCOPES 256
+#define MAX_FOR_SCOPE_RENAMES 16
+#define MAX_FORREN     128
 #define MAX_FLOW       128
 #define MAX_SNAPSHOT   256
 #define MAX_PROTO_PARAMS 16
@@ -365,6 +370,25 @@ extern int current_function_has_call;
 extern int break_stack[MAX_FLOW];
 extern int cont_stack[MAX_FLOW];
 extern int nflow;
+
+/* C99 for-init declaration scoping (see dcc_state.c for details) */
+extern int g_for_seq;
+extern int g_for_rename_count[MAX_FOR_SCOPES];
+extern char g_for_rename_from[MAX_FOR_SCOPES][MAX_FOR_SCOPE_RENAMES][64];
+extern char g_for_rename_to[MAX_FOR_SCOPES][MAX_FOR_SCOPE_RENAMES][64];
+extern char g_forren_from[MAX_FORREN][64];
+extern char g_forren_to[MAX_FORREN][64];
+extern int g_forren_n;
+extern int g_for_decl_seq;
+extern int g_for_decl_rename_index;
+extern int g_for_decl_recording;
+const char *resolve_local_rename(const char *name);
+void make_for_rename_name(char *dst, int dstsz, const char *from, int for_seq, int rename_index);
+void add_for_scope_rename(int for_seq, const char *from);
+const char *enter_for_decl_rename(const char *name);
+void push_for_rename(const char *from, const char *to);
+void pop_for_rename(void);
+
 extern int errors;
 extern int scan_mode;
 extern int decl_is_extern;

--- a/src/dcc/dcc_assign.c
+++ b/src/dcc/dcc_assign.c
@@ -191,11 +191,11 @@ void emit_global_byte_array_index_addr(struct Sym *arr, struct Sym *idx_sym, lon
     emit_extrn_if_needed(arr);
     if (has_const) {
         if (idx_const == 0)
-            fprintf(outf, "\tld hl,%s\n", asm_name_for(arr->name));
+            fprintf(outf, "\tld hl,%s\n", asm_name_for(sym_asm_name(arr)));
         else
-            fprintf(outf, "\tld hl,%s+%ld\n", asm_name_for(arr->name), idx_const & 0xffffL);
+            fprintf(outf, "\tld hl,%s+%ld\n", asm_name_for(sym_asm_name(arr)), idx_const & 0xffffL);
     } else {
-        fprintf(outf, "\tld hl,%s\n", asm_name_for(arr->name));
+        fprintf(outf, "\tld hl,%s\n", asm_name_for(sym_asm_name(arr)));
         fprintf(outf, "\tld e,(ix%+d)\n", idx_sym->offset);
         emit("\tld d,0\n");
         emit("\tadd hl,de\n");

--- a/src/dcc/dcc_cmp.c
+++ b/src/dcc/dcc_cmp.c
@@ -509,13 +509,13 @@ void emit_byte_operand_to_a(struct ByteOperand *op)
     } else if (op->kind == 3) {
         emit_extrn_if_needed(op->sym);
         if (op->idx_sym) {
-            fprintf(outf, "\tld hl,%s\n", asm_name_for(op->sym->name));
+            fprintf(outf, "\tld hl,%s\n", asm_name_for(sym_asm_name(op->sym)));
             fprintf(outf, "\tld e,(ix%+d)\n", op->idx_sym->offset);
             emit("\tld d,0\n");
             emit("\tadd hl,de\n");
             emit("\tld a,(hl)\n");
         } else {
-            fprintf(outf, "\tld a,(%s+%ld)\n", asm_name_for(op->sym->name), op->val & 0xffffL);
+            fprintf(outf, "\tld a,(%s+%ld)\n", asm_name_for(sym_asm_name(op->sym)), op->val & 0xffffL);
         }
     }
 }
@@ -530,14 +530,14 @@ void emit_cp_byte_operand(struct ByteOperand *op)
         emit_extrn_if_needed(op->sym);
         if (op->idx_sym) {
             emit("\tld b,a\n");
-            fprintf(outf, "\tld hl,%s\n", asm_name_for(op->sym->name));
+            fprintf(outf, "\tld hl,%s\n", asm_name_for(sym_asm_name(op->sym)));
             fprintf(outf, "\tld e,(ix%+d)\n", op->idx_sym->offset);
             emit("\tld d,0\n");
             emit("\tadd hl,de\n");
             emit("\tld a,b\n");
             emit("\tcp (hl)\n");
         } else {
-            fprintf(outf, "\tcp (%s+%ld)\n", asm_name_for(op->sym->name), op->val & 0xffffL);
+            fprintf(outf, "\tcp (%s+%ld)\n", asm_name_for(sym_asm_name(op->sym)), op->val & 0xffffL);
         }
     }
 }

--- a/src/dcc/dcc_data.c
+++ b/src/dcc/dcc_data.c
@@ -171,8 +171,8 @@ void emit_data(void)
         if (!(s->has_init && s->init_count > 0) && !(s->has_init && !s->is_array)) continue;
 
         if (!s->is_static)
-            fprintf(outf, "\tpublic %s\n", asm_name_for(s->name));
-        fprintf(outf, "%s:\n", asm_name_for(s->name));
+            fprintf(outf, "\tpublic %s\n", asm_name_for(sym_asm_name(s)));
+        fprintf(outf, "%s:\n", asm_name_for(sym_asm_name(s)));
         if (s->has_init && s->init_count > 0) {
             int j;
             int elem_bytes;
@@ -232,8 +232,8 @@ void emit_data(void)
 
                 bss_size = s->size > 0 ? s->size : 2;
                 if (!s->is_static)
-                    fprintf(outf, "\tpublic %s\n", asm_name_for(s->name));
-                fprintf(outf, "%s:\n", asm_name_for(s->name));
+                    fprintf(outf, "\tpublic %s\n", asm_name_for(sym_asm_name(s)));
+                fprintf(outf, "%s:\n", asm_name_for(sym_asm_name(s)));
                 fprintf(outf, "\tds %d\n", bss_size);
             }
             return;
@@ -268,7 +268,7 @@ void emit_data(void)
             if ((s->has_init && s->init_count > 0) || (s->has_init && !s->is_array)) continue;
 
             bss_size = s->size > 0 ? s->size : 2;
-            fprintf(outf, "%s\tequ\t__bssb+%d\n", asm_name_for(s->name), bss_off);
+            fprintf(outf, "%s\tequ\t__bssb+%d\n", asm_name_for(sym_asm_name(s)), bss_off);
             bss_off += bss_size;
         }
 

--- a/src/dcc/dcc_decl.c
+++ b/src/dcc/dcc_decl.c
@@ -153,6 +153,65 @@ int try_parse_local_const_initializer(int type, unsigned long *valuep)
     return 0;
 }
 
+/*
+ * Shared const-scalar folding decision for a local declaration, used by BOTH
+ * the frame-sizing scan and codegen so they allocate identically.  A
+ * `const`-qualified scalar with a compile-time-constant initializer whose
+ * address is never taken needs no stack storage: it folds to its value.  On
+ * success the symbol is created with zero storage (is_const_value set) and the
+ * initializer tokens are consumed.  On any miss the lexer is left exactly at
+ * the '=' so the caller can allocate real storage and emit/skip the
+ * initializer normally.  store_name is the (possibly for-init-renamed) table
+ * name; src_name is the original spelling used for the address-taken probe.
+ */
+struct Sym *try_const_fold_local(const char *store_name, const char *src_name,
+                                 int type, int has_array)
+{
+    long save_pos;
+    long save_tok_start;
+    int save_line;
+    int save_tok_line;
+    int save_errors;
+    int save_long_suffix;
+    int save_unsigned_suffix;
+    struct Token save_tok;
+    unsigned long const_value;
+    struct Sym *s;
+
+    if (!decl_is_const || has_array ||
+        !type_is_const_scalar_candidate(type) || tok.kind != '=' ||
+        local_name_address_taken_ahead(src_name))
+        return NULL;
+
+    save_pos = posi;
+    save_tok_start = tok_start_pos;
+    save_line = line_no;
+    save_tok_line = tok_line;
+    save_errors = errors;
+    save_long_suffix = g_tok_long_suffix;
+    save_unsigned_suffix = g_tok_unsigned_suffix;
+    save_tok = tok;
+
+    next_token();   /* consume '=' */
+    if (try_parse_local_const_initializer(type, &const_value)) {
+        s = add_local_known(store_name, type, SC_LOCAL, 0, 0);
+        s->is_const_value = 1;
+        s->const_value = const_value;
+        return s;
+    }
+
+    /* Not a compile-time constant: rewind to the '=' for the caller. */
+    posi = save_pos;
+    tok_start_pos = save_tok_start;
+    line_no = save_line;
+    tok_line = save_tok_line;
+    errors = save_errors;
+    g_tok_long_suffix = save_long_suffix;
+    g_tok_unsigned_suffix = save_unsigned_suffix;
+    tok = save_tok;
+    return NULL;
+}
+
 void emit_load_const_sym_value(struct Sym *s)
 {
     struct ConstVal cv;
@@ -691,6 +750,7 @@ void gen_local_decl_after_type(int base)
     int type, bytes, arrlen;
     int total_elems;
     char name[64];
+    char source_name[64];
     struct Sym *s;
 
     for (;;) {
@@ -708,6 +768,9 @@ void gen_local_decl_after_type(int base)
             name[sizeof(name) - 1] = 0;
             next_token();
         }
+
+        strncpy(source_name, name, sizeof(source_name) - 1);
+        source_name[sizeof(source_name) - 1] = 0;
 
         if (g_for_decl_seq >= 0) {
             const char *rn;
@@ -767,7 +830,10 @@ void gen_local_decl_after_type(int base)
             total_elems = g_typedef_array_len;
         }
 
-        s = find_local(name);
+        s = find_local_decl(name);
+        if (!s)
+            s = try_const_fold_local(name, source_name, type,
+                                     total_elems > 0 || g_last_array_dim_count > 0);
         if (!s) {
             bytes = type_size(type);
             if (total_elems > 0)

--- a/src/dcc/dcc_decl.c
+++ b/src/dcc/dcc_decl.c
@@ -709,6 +709,13 @@ void gen_local_decl_after_type(int base)
             next_token();
         }
 
+        if (g_for_decl_seq >= 0) {
+            const char *rn;
+            rn = enter_for_decl_rename(name);
+            strncpy(name, rn, sizeof(name) - 1);
+            name[sizeof(name) - 1] = 0;
+        }
+
         arrlen = g_funcptr_decl_array_len;
         g_funcptr_decl_array_len = 0;
         total_elems = arrlen;

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -526,6 +526,7 @@ void scan_local_decl_after_type(int base)
     int type, bytes, arrlen;
     int total_elems;
     char name[64];
+    char source_name[64];
     struct Sym *s;
 
     for (;;) {
@@ -539,6 +540,15 @@ void scan_local_decl_after_type(int base)
             strncpy(name, tok.text, sizeof(name) - 1);
             name[sizeof(name) - 1] = 0;
             next_token();
+        }
+        strncpy(source_name, name, sizeof(source_name) - 1);
+        source_name[sizeof(source_name) - 1] = 0;
+
+        if (g_for_decl_seq >= 0) {
+            const char *rn;
+            rn = enter_for_decl_rename(name);
+            strncpy(name, rn, sizeof(name) - 1);
+            name[sizeof(name) - 1] = 0;
         }
 
         arrlen = g_funcptr_decl_array_len;
@@ -588,7 +598,7 @@ void scan_local_decl_after_type(int base)
         s = find_local(name);
         if (!s && decl_is_const && arrlen == 0 && g_last_array_dim_count == 0 &&
             type_is_const_scalar_candidate(type) && tok.kind == '=' &&
-            !local_name_address_taken_ahead(name)) {
+            !local_name_address_taken_ahead(source_name)) {
             unsigned long const_value;
             next_token();
             if (try_parse_local_const_initializer(type, &const_value)) {
@@ -719,6 +729,14 @@ void scan_function_body(void)
     int brace;
     int can_decl;
 
+    /* Restart the per-function for-loop counter so the frame-sizing scan and
+     * the real codegen agree on which for-loop is which. */
+    g_for_seq = 0;
+    g_forren_n = 0;
+    g_for_decl_seq = -1;
+    g_for_decl_rename_index = 0;
+    g_for_decl_recording = 0;
+
     expect('{');
     brace = 1;
     can_decl = 1;
@@ -733,6 +751,7 @@ void scan_function_body(void)
             next_token();
             can_decl = 1;
         } else if (tok.kind == TOK_FOR) {
+            int for_seq;
             /*
              * The old scanner looked for starts_type() at every token in the
              * function body.  That is unsafe now that casts are supported:
@@ -750,20 +769,45 @@ void scan_function_body(void)
              * Scan declarations only at statement/declaration boundaries, with
              * a special case for C99-style for-init declarations.
              */
+            for_seq = g_for_seq++;
+            if (for_seq >= MAX_FOR_SCOPES)
+                fatal("too many for statements");
             next_token();
             if (accept('(')) {
                 int depth;
 
                 if (starts_type()) {
                     int t;
+                    int old_for_decl_seq;
+                    int old_for_decl_rename_index;
+                    int old_for_decl_recording;
                     decl_is_extern = 0;
                     decl_is_const = 0;
                     t = parse_base_type();
+
+                    g_for_rename_count[for_seq] = 0;
+
+                    old_for_decl_seq = g_for_decl_seq;
+                    old_for_decl_rename_index = g_for_decl_rename_index;
+                    old_for_decl_recording = g_for_decl_recording;
+                    g_for_decl_seq = for_seq;
+                    g_for_decl_rename_index = 0;
+                    g_for_decl_recording = 1;
+
                     if (tok.kind != ';')
                         scan_local_decl_after_type(t); /* consumes ';' */
                     else
                         next_token();
+
+                    while (g_for_decl_rename_index > 0) {
+                        pop_for_rename();
+                        g_for_decl_rename_index--;
+                    }
+                    g_for_decl_seq = old_for_decl_seq;
+                    g_for_decl_rename_index = old_for_decl_rename_index;
+                    g_for_decl_recording = old_for_decl_recording;
                 } else {
+                    g_for_rename_count[for_seq] = 0;
                     depth = 0;
                     while (tok.kind != TOK_EOF) {
                         if (depth == 0 && tok.kind == ';') {
@@ -1618,6 +1662,13 @@ void parse_function_or_global(int base_type)
                 nulabels = 0;
                 current_return_label = new_label();
                 current_return_type = type;
+                /* Restart the for-loop counter for the codegen pass so it
+                 * lines up with the frame-sizing scan. */
+                g_for_seq = 0;
+                g_forren_n = 0;
+                g_for_decl_seq = -1;
+                g_for_decl_rename_index = 0;
+                g_for_decl_recording = 0;
                 emit_function_prologue(name, current_local_bytes, current_function_safe_to_omit_ix(type, current_local_bytes));
                 gen_compound();
                 check_undefined_user_labels();

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -595,21 +595,10 @@ void scan_local_decl_after_type(int base)
         bytes = type_size(type);
         if (total_elems > 0) bytes *= total_elems;
 
-        s = find_local(name);
-        if (!s && decl_is_const && arrlen == 0 && g_last_array_dim_count == 0 &&
-            type_is_const_scalar_candidate(type) && tok.kind == '=' &&
-            !local_name_address_taken_ahead(source_name)) {
-            unsigned long const_value;
-            next_token();
-            if (try_parse_local_const_initializer(type, &const_value)) {
-                s = add_local_known(name, type, SC_LOCAL, 0, 0);
-                s->is_const_value = 1;
-                s->const_value = const_value;
-            } else {
-                s = add_local_alloc(name, type, bytes);
-                skip_initializer_or_decl_tail();
-            }
-        }
+        s = find_local_decl(name);
+        if (!s)
+            s = try_const_fold_local(name, source_name, type,
+                                     arrlen != 0 || g_last_array_dim_count != 0);
 
         if (!s) {
             s = add_local_alloc(name, type, bytes);
@@ -650,6 +639,7 @@ void scan_static_local_decl_after_type(int base)
 {
     int type, bytes, arrlen;
     char name[64];
+    char backing_name[64];
     struct Sym *g;
     struct Sym *l;
 
@@ -682,7 +672,19 @@ void scan_static_local_decl_after_type(int base)
         else if (arrlen < 0)
             bytes = 0;
 
-        g = add_global(name, type, SC_GLOBAL);
+        l = find_local_decl(name);
+        if (l && l->link_name[0]) {
+            strncpy(backing_name, l->link_name, sizeof(backing_name) - 1);
+            backing_name[sizeof(backing_name) - 1] = 0;
+        } else {
+            sprintf(backing_name, "__sl%d_%d", g_static_local_func_index,
+                    g_static_local_seq++);
+        }
+
+        g = add_global(backing_name, type, SC_GLOBAL);
+        g->is_defined = 1;
+        g->needs_extrn = 0;
+        g->is_static = 1;
         g->size = bytes;
         if (arrlen != 0) {
             g->is_array = 1;
@@ -692,8 +694,10 @@ void scan_static_local_decl_after_type(int base)
             copy_last_array_dims_to_sym(g);
         }
 
-        if (!find_local(name)) {
+        if (!l) {
             l = add_local_known(name, type, SC_GLOBAL, 0, bytes);
+            strncpy(l->link_name, backing_name, sizeof(l->link_name) - 1);
+            l->link_name[sizeof(l->link_name) - 1] = 0;
             if (arrlen != 0) {
                 l->is_array = 1;
                 l->array_len = arrlen > 0 ? arrlen : 0;
@@ -709,7 +713,7 @@ void scan_static_local_decl_after_type(int base)
          * inferred the real storage size.  Mirror that back into the local
          * alias used for references inside the function.
          */
-        l = find_local(name);
+        l = find_local_decl(name);
         if (l && g->is_array && l->is_array) {
             l->size = g->size;
             l->array_len = g->array_len;
@@ -736,19 +740,23 @@ void scan_function_body(void)
     g_for_decl_seq = -1;
     g_for_decl_rename_index = 0;
     g_for_decl_recording = 0;
+    g_scope_depth = 0;
 
     expect('{');
+    enter_scope();              /* function body block */
     brace = 1;
     can_decl = 1;
 
     while (tok.kind != TOK_EOF && brace > 0) {
         if (tok.kind == '{') {
+            enter_scope();
             brace++;
             next_token();
             can_decl = 1;
         } else if (tok.kind == '}') {
             brace--;
             next_token();
+            leave_scope();
             can_decl = 1;
         } else if (tok.kind == TOK_FOR) {
             int for_seq;
@@ -1006,7 +1014,11 @@ int parse_global_init_atom(long *val, char *label, int labelsz)
         }
 
         if (label && labelsz > 0) {
-            strncpy(label, tok.text, labelsz - 1);
+            struct Sym *ls;
+            const char *lname;
+            ls = find_sym(tok.text);
+            lname = ls ? sym_asm_name(ls) : tok.text;
+            strncpy(label, lname, labelsz - 1);
             label[labelsz - 1] = 0;
         }
         next_token();
@@ -1017,7 +1029,11 @@ int parse_global_init_atom(long *val, char *label, int labelsz)
         next_token();
         if (tok.kind == TOK_ID) {
             if (label && labelsz > 0) {
-                strncpy(label, tok.text, labelsz - 1);
+                struct Sym *ls;
+                const char *lname;
+                ls = find_sym(tok.text);
+                lname = ls ? sym_asm_name(ls) : tok.text;
+                strncpy(label, lname, labelsz - 1);
                 label[labelsz - 1] = 0;
             }
             next_token();
@@ -1629,6 +1645,8 @@ void parse_function_or_global(int base_type)
                 saved_param_offset = param_offset;
 
                 current_function_has_call = 0;
+                g_static_local_func_index = (int)(s - globals);
+                g_static_local_seq = 0;
                 scan_function_body();
                 body_end_pos = posi;
                 body_end_tok_start = tok_start_pos;
@@ -1648,6 +1666,8 @@ void parse_function_or_global(int base_type)
                 local_size = saved_local_size;
                 param_offset = saved_param_offset;
 
+                g_static_local_func_index = (int)(s - globals);
+                g_static_local_seq = 0;
                 scan_function_body();
 
                 posi = saved_pos;
@@ -1669,6 +1689,15 @@ void parse_function_or_global(int base_type)
                 g_for_decl_seq = -1;
                 g_for_decl_rename_index = 0;
                 g_for_decl_recording = 0;
+                /* Codegen rebuilds the local table exactly as the frame-sizing
+                 * scan did - block scopes truncate nlocals as they close - so
+                 * restart from just the parameters with an empty scope stack.
+                 * Both passes therefore assign identical frame offsets. */
+                nlocals = saved_nlocals;
+                local_size = saved_local_size;
+                g_scope_depth = 0;
+                g_static_local_func_index = (int)(s - globals);
+                g_static_local_seq = 0;
                 emit_function_prologue(name, current_local_bytes, current_function_safe_to_omit_ix(type, current_local_bytes));
                 gen_compound();
                 check_undefined_user_labels();

--- a/src/dcc/dcc_state.c
+++ b/src/dcc/dcc_state.c
@@ -104,6 +104,27 @@ int current_function_has_call;
 int break_stack[MAX_FLOW];
 int cont_stack[MAX_FLOW];
 int nflow;
+
+/* ---- C99 for-init declaration scoping ---------------------------------- */
+/* Per-function counter of for-loops, advanced in source/pre-order in BOTH the
+ * frame-sizing scan and the real codegen so the two agree on which loop is
+ * which.  The frame-sizing scan records the source-name -> unique-local-name
+ * mappings for each C99 for-init declaration; codegen replays them while
+ * compiling the corresponding loop. */
+int g_for_seq;
+int g_for_rename_count[MAX_FOR_SCOPES];
+char g_for_rename_from[MAX_FOR_SCOPES][MAX_FOR_SCOPE_RENAMES][64];
+char g_for_rename_to[MAX_FOR_SCOPES][MAX_FOR_SCOPE_RENAMES][64];
+
+/* Active for-init renames: while inside a for-loop with C99 init declarations,
+ * source names are mapped to unique internal names so the variables have real
+ * loop scope.  A small stack supports nested for scopes. */
+char g_forren_from[MAX_FORREN][64];
+char g_forren_to[MAX_FORREN][64];
+int g_forren_n;
+int g_for_decl_seq;
+int g_for_decl_rename_index;
+int g_for_decl_recording;
 int errors;
 int scan_mode;
 int decl_is_extern;

--- a/src/dcc/dcc_state.c
+++ b/src/dcc/dcc_state.c
@@ -125,6 +125,16 @@ int g_forren_n;
 int g_for_decl_seq;
 int g_for_decl_rename_index;
 int g_for_decl_recording;
+
+/* General lexical block scope stack: the nlocals watermark saved at each open
+ * { } block.  leave_scope truncates nlocals back so block-local names leave
+ * scope.  Codegen rebuilds the table the same way the scan did, so the two
+ * passes assign identical offsets; storage (local_size) is monotonic, so the
+ * frame equals the sum over all scopes. */
+int g_scope_watermark[MAX_SCOPE_DEPTH];
+int g_scope_depth;
+int g_static_local_func_index;
+int g_static_local_seq;
 int errors;
 int scan_mode;
 int decl_is_extern;

--- a/src/dcc/dcc_stmt.c
+++ b/src/dcc/dcc_stmt.c
@@ -13,6 +13,7 @@
 void gen_compound(void)
 {
     expect('{');
+    enter_scope();
 
     while (tok.kind != TOK_EOF && tok.kind != '}') {
         if (tok.kind == TOK_TYPEDEF) {
@@ -35,6 +36,7 @@ void gen_compound(void)
         }
     }
 
+    leave_scope();
     expect('}');
 }
 
@@ -77,7 +79,7 @@ void emit_load_sym_word_to_bc(struct Sym *s)
         }
     } else if (is_global_word_sym(s)) {
         emit_extrn_if_needed(s);
-        fprintf(outf, "\tld bc,(%s)\n", asm_name_for(s->name));
+        fprintf(outf, "\tld bc,(%s)\n", asm_name_for(sym_asm_name(s)));
     }
 }
 
@@ -93,7 +95,7 @@ void emit_store_de_to_sym_word(struct Sym *s)
         }
     } else if (is_global_word_sym(s)) {
         emit_extrn_if_needed(s);
-        fprintf(outf, "\tld (%s),de\n", asm_name_for(s->name));
+        fprintf(outf, "\tld (%s),de\n", asm_name_for(sym_asm_name(s)));
     }
 }
 
@@ -109,7 +111,7 @@ void emit_store_bc_to_sym_word(struct Sym *s)
         }
     } else if (is_global_word_sym(s)) {
         emit_extrn_if_needed(s);
-        fprintf(outf, "\tld (%s),bc\n", asm_name_for(s->name));
+        fprintf(outf, "\tld (%s),bc\n", asm_name_for(sym_asm_name(s)));
     }
 }
 
@@ -257,7 +259,7 @@ int try_gen_bc_pointer_copy_while(void)
         fprintf(outf, "\tld d,(ix%+d)\n", dstsym->offset + 1);
     } else {
         emit_extrn_if_needed(dstsym);
-        fprintf(outf, "\tld de,(%s)\n", asm_name_for(dstsym->name));
+        fprintf(outf, "\tld de,(%s)\n", asm_name_for(sym_asm_name(dstsym)));
     }
     emit_label(ltop);
     if (selem == 1) {
@@ -966,7 +968,7 @@ int try_gen_bc_byte_array_cycle_for(void)
     lnowrap = new_label();
 
     emit("\tld bc,0\n");
-    fprintf(outf, "\tld de,%s\n", asm_name_for(asym->name));
+    fprintf(outf, "\tld de,%s\n", asm_name_for(sym_asm_name(asym)));
     fprintf(outf, "\tld h,%ld\n", base & 255L);
     emit_label(ltop);
     emit("\tld a,h\n");
@@ -1321,6 +1323,7 @@ void gen_switch_chain(void)
     emit_jp_label("jp", default_lab >= 0 ? default_lab : lend);
 
     expect('{');
+    enter_scope();
 
     break_stack[nflow] = lend;
     /* continue inside a switch should target the enclosing loop, not the switch */
@@ -1374,6 +1377,7 @@ void gen_switch_chain(void)
         }
     }
 
+    leave_scope();
     expect('}');
 
     nflow--;
@@ -1689,6 +1693,7 @@ void gen_switch_table(void)
     emit_switch_jump_table(minv, maxv, case_vals, case_labs, ncase, default_lab, lend);
 
     expect('{');
+    enter_scope();
 
     break_stack[nflow] = lend;
     cont_stack[nflow] = (nflow > 0) ? cont_stack[nflow - 1] : lend;
@@ -1730,6 +1735,7 @@ void gen_switch_table(void)
         }
     }
 
+    leave_scope();
     expect('}');
     nflow--;
     emit_label(lend);

--- a/src/dcc/dcc_stmt.c
+++ b/src/dcc/dcc_stmt.c
@@ -1004,8 +1004,21 @@ void gen_for(void)
     char *inc_code;
     char *cond_code;
     int do_while;
+    int for_seq;
+    int rename_count;
+    int old_for_decl_seq;
+    int old_for_decl_rename_index;
+    int old_for_decl_recording;
 
-    if (try_gen_bc_byte_array_cycle_for())
+    /* Advance the per-function for-loop counter in pre-order so it matches the
+     * frame-sizing scan; g_for_rename_count[seq] tells us whether this loop's
+     * for-init declaration introduced C99 loop-scoped names. */
+    for_seq = g_for_seq++;
+    if (for_seq >= MAX_FOR_SCOPES)
+        fatal("too many for statements");
+    rename_count = g_for_rename_count[for_seq];
+
+    if (rename_count == 0 && try_gen_bc_byte_array_cycle_for())
         return;
 
     ltop = new_label();
@@ -1026,10 +1039,24 @@ void gen_for(void)
         int t;
         decl_is_extern = 0;
         t = parse_base_type();
+
+        old_for_decl_seq = g_for_decl_seq;
+        old_for_decl_rename_index = g_for_decl_rename_index;
+        old_for_decl_recording = g_for_decl_recording;
+        g_for_decl_seq = for_seq;
+        g_for_decl_rename_index = 0;
+        g_for_decl_recording = 0;
+
         if (tok.kind != ';')
             gen_local_decl_after_type(t); /* consumes the ';' */
         else
             next_token();
+
+        if (g_for_decl_rename_index != rename_count)
+            fatal("for-init scope mismatch");
+        g_for_decl_seq = old_for_decl_seq;
+        g_for_decl_rename_index = old_for_decl_rename_index;
+        g_for_decl_recording = old_for_decl_recording;
         /* no expect(';') here — already consumed above */
     } else {
         if (tok.kind != ';') gen_expr();
@@ -1088,6 +1115,12 @@ void gen_for(void)
         free(cond_code);
     }
     emit_label(lend);
+
+    /* Close the for-init scope: source names now resolve to any outer symbols. */
+    while (rename_count > 0) {
+        pop_for_rename();
+        rename_count--;
+    }
 }
 
 void gen_return(void)

--- a/src/dcc/dcc_stmt_fast.c
+++ b/src/dcc/dcc_stmt_fast.c
@@ -352,7 +352,7 @@ void emit_store_a_to_sym_byte_preserve_de(struct Sym *s, int byte_off)
 
     /* Conservative fallback for globals: preserve DE while storing A. */
     emit("\tpush de\n");
-    fprintf(outf, "\tld hl,%s\n", asm_name_for(s->name));
+    fprintf(outf, "\tld hl,%s\n", asm_name_for(sym_asm_name(s)));
     if (byte_off)
         fprintf(outf, "\tld de,%d\n\tadd hl,de\n", byte_off);
     emit("\tld (hl),a\n\tpop de\n");

--- a/src/dcc/dcc_symbols.c
+++ b/src/dcc/dcc_symbols.c
@@ -108,12 +108,80 @@ void pop_for_rename(void)
         g_forren_n--;
 }
 
+const char *sym_asm_name(struct Sym *s)
+{
+    if (s && s->link_name[0])
+        return s->link_name;
+    return s ? s->name : "";
+}
+
+/*
+ * General lexical block scope.  The frame-sizing scan and codegen both bracket
+ * every { } block with enter_scope/leave_scope, and both build the locals[]
+ * table the same way: a block's locals are truncated away when it closes.
+ * Storage (local_size) is monotonic, so a block-local still gets a distinct
+ * frame slot and the reserved frame is the sum over all scopes; because codegen
+ * rebuilds the table exactly as the scan did, the two passes assign identical
+ * offsets and resolve names identically.
+ */
+void enter_scope(void)
+{
+    if (g_scope_depth >= MAX_SCOPE_DEPTH)
+        fatal("too many nested block scopes");
+    g_scope_watermark[g_scope_depth++] = nlocals;
+}
+
+void leave_scope(void)
+{
+    if (g_scope_depth <= 0)
+        return;
+    /* Block-local names leave scope.  local_size is intentionally left alone:
+     * storage is monotonic (slots are never reused), so the frame size still
+     * equals the sum over every scope. */
+    nlocals = g_scope_watermark[--g_scope_depth];
+}
+
+/* Lookup used while DECLARING a local: only the innermost open block is
+ * considered, and for-init renames are ignored.  This lets an inner block (or a
+ * for body) declare a name that shadows an outer local, a parameter, or an
+ * active for-init loop variable instead of binding to it. */
+struct Sym *find_local_decl(const char *name)
+{
+    int i, base;
+    base = g_scope_depth > 0 ? g_scope_watermark[g_scope_depth - 1] : 0;
+    for (i = nlocals - 1; i >= base; --i)
+        if (!strcmp(locals[i].name, name)) return &locals[i];
+    return NULL;
+}
+
 struct Sym *find_local(const char *name)
 {
     int i;
-    name = resolve_local_rename(name);
+    const char *rn;
+    int plain_idx;
+    int ren_idx;
+
+    /* Two backward searches over the in-scope locals (nlocals is truncated on
+     * block exit, so out-of-scope names are excluded): one for the original
+     * spelling (block locals and ordinary locals) and one for an active
+     * for-init rename (the loop variable lives under a unique internal name).
+     * The higher index wins because declaration order equals scope depth, so
+     * the innermost binding is selected.  This makes a for-init variable shadow
+     * an outer same-named local, and an inner block redeclaration shadow the
+     * for-init variable, both correctly. */
+    plain_idx = -1;
     for (i = nlocals - 1; i >= 0; --i)
-        if (!strcmp(locals[i].name, name)) return &locals[i];
+        if (!strcmp(locals[i].name, name)) { plain_idx = i; break; }
+
+    ren_idx = -1;
+    rn = resolve_local_rename(name);
+    if (rn != name) {
+        for (i = nlocals - 1; i >= 0; --i)
+            if (!strcmp(locals[i].name, rn)) { ren_idx = i; break; }
+    }
+
+    if (ren_idx > plain_idx) return &locals[ren_idx];
+    if (plain_idx >= 0) return &locals[plain_idx];
     return NULL;
 }
 
@@ -147,7 +215,7 @@ int is_global_char_array_sym(struct Sym *s)
 void emit_global_char_index_addr(struct Sym *s)
 {
     emit_extrn_if_needed(s);
-    fprintf(outf, "\tld de,%s\n", asm_name_for(s->name));
+    fprintf(outf, "\tld de,%s\n", asm_name_for(sym_asm_name(s)));
     emit("\tadd hl,de\n");
 }
 
@@ -342,7 +410,7 @@ void emit_extrn_if_needed(struct Sym *s)
          * real generation pass must still print it before the first reference.
          */
         if (!scan_mode) {
-            fprintf(outf, "\textrn %s\n", asm_name_for(s->name));
+            fprintf(outf, "\textrn %s\n", asm_name_for(sym_asm_name(s)));
             s->needs_extrn = 0;
         }
         return;
@@ -366,7 +434,7 @@ void emit_deferred_extrns(void)
         struct Sym *s;
         s = used_extrns[i];
         if (s && s->needs_extrn && !s->is_defined && !asm_name_is_internal_public(s->name))
-            fprintf(outf, "\textrn %s\n", asm_name_for(s->name));
+            fprintf(outf, "\textrn %s\n", asm_name_for(sym_asm_name(s)));
     }
 }
 
@@ -436,7 +504,7 @@ void emit_load_sym_addr(struct Sym *s)
         emit_load_frame_addr_hl(s);
     } else {
         emit_extrn_if_needed(s);
-        fprintf(outf, "\tld hl,%s\n", asm_name_for(s->name));
+        fprintf(outf, "\tld hl,%s\n", asm_name_for(sym_asm_name(s)));
     }
 }
 
@@ -466,14 +534,14 @@ int is_global_word_sym(struct Sym *s)
 void emit_load_global_word_direct(struct Sym *s)
 {
     emit_extrn_if_needed(s);
-    fprintf(outf, "\tld hl,(%s)\n", asm_name_for(s->name));
+    fprintf(outf, "\tld hl,(%s)\n", asm_name_for(sym_asm_name(s)));
 }
 
 /* Z80: ld (name),hl — store 16-bit HL value to global/extern directly. */
 void emit_store_global_word_direct(struct Sym *s)
 {
     emit_extrn_if_needed(s);
-    fprintf(outf, "\tld (%s),hl\n", asm_name_for(s->name));
+    fprintf(outf, "\tld (%s),hl\n", asm_name_for(sym_asm_name(s)));
 }
 
 void emit_load_sym_value_direct(struct Sym *s)

--- a/src/dcc/dcc_symbols.c
+++ b/src/dcc/dcc_symbols.c
@@ -11,9 +11,107 @@
  */
 
 #include "dcc.h"
+
+/*
+ * C99 for-init renames.  While code generation (or the frame-sizing scan) is
+ * inside a for-loop with init declarations, each declared source name is mapped
+ * to a unique internal local name.  That gives the variable real C99 loop
+ * scope even though dcc's local symbol table is otherwise function-flat.
+ * resolve_local_rename applies the innermost active mapping; it is idempotent
+ * because the mapped-to names contain '#', which never appears in a source
+ * identifier and so never matches a "from" entry.
+ */
+const char *resolve_local_rename(const char *name)
+{
+    int k;
+    for (k = g_forren_n - 1; k >= 0; --k) {
+        if (!strcmp(g_forren_from[k], name))
+            return g_forren_to[k];
+    }
+    return name;
+}
+
+void make_for_rename_name(char *dst, int dstsz, const char *from, int for_seq, int rename_index)
+{
+    char suffix[24];
+    int from_len;
+    int suffix_len;
+
+    sprintf(suffix, "#%d#%d", for_seq, rename_index);
+    suffix_len = (int)strlen(suffix);
+    if (dstsz <= suffix_len + 1)
+        fatal("for-init rename buffer too small");
+
+    from_len = (int)strlen(from);
+    if (from_len > dstsz - suffix_len - 1)
+        from_len = dstsz - suffix_len - 1;
+
+    memcpy(dst, from, from_len);
+    strcpy(dst + from_len, suffix);
+}
+
+void add_for_scope_rename(int for_seq, const char *from)
+{
+    int n;
+
+    if (for_seq >= MAX_FOR_SCOPES)
+        fatal("too many for statements");
+
+    n = g_for_rename_count[for_seq];
+    if (n >= MAX_FOR_SCOPE_RENAMES)
+        fatal("too many for-init declarators");
+
+    strncpy(g_for_rename_from[for_seq][n], from, 63);
+    g_for_rename_from[for_seq][n][63] = 0;
+    make_for_rename_name(g_for_rename_to[for_seq][n], 64,
+                         g_for_rename_from[for_seq][n], for_seq, n);
+    g_for_rename_count[for_seq] = n + 1;
+}
+
+const char *enter_for_decl_rename(const char *name)
+{
+    int n;
+
+    if (g_for_decl_seq < 0)
+        fatal("bad for-init scope");
+
+    n = g_for_decl_rename_index;
+    if (g_for_decl_recording) {
+        add_for_scope_rename(g_for_decl_seq, name);
+    } else {
+        if (g_for_decl_seq >= MAX_FOR_SCOPES)
+            fatal("too many for statements");
+        if (n >= g_for_rename_count[g_for_decl_seq])
+            fatal("for-init scope mismatch");
+    }
+
+    push_for_rename(g_for_rename_from[g_for_decl_seq][n],
+                    g_for_rename_to[g_for_decl_seq][n]);
+    g_for_decl_rename_index = n + 1;
+    return g_for_rename_to[g_for_decl_seq][n];
+}
+
+void push_for_rename(const char *from, const char *to)
+{
+    if (g_forren_n >= MAX_FORREN)
+        fatal("too many nested for-init scopes");
+    strncpy(g_forren_from[g_forren_n], from, 63);
+    g_forren_from[g_forren_n][63] = 0;
+    strncpy(g_forren_to[g_forren_n], to, 63);
+    g_forren_to[g_forren_n][63] = 0;
+    g_forren_n++;
+}
+
+void pop_for_rename(void)
+{
+    if (g_forren_n > 0)
+        g_forren_n--;
+}
+
 struct Sym *find_local(const char *name)
 {
     int i;
+    name = resolve_local_rename(name);
     for (i = nlocals - 1; i >= 0; --i)
         if (!strcmp(locals[i].name, name)) return &locals[i];
     return NULL;

--- a/tcmt99.c
+++ b/tcmt99.c
@@ -1,0 +1,68 @@
+/*
+ * tcmt99.c - C99 "//" line-comment support, alongside C89 block comments.
+ *
+ * Pins the behaviour that matters for the dcc lexer and preprocessor:
+ *   - text after a line comment is ignored to end of line,
+ *   - a lone slash is still the divide operator (only a doubled slash starts
+ *     a comment),
+ *   - a doubled slash inside a string literal is ordinary data,
+ *   - a line comment trailing a #define (object- and function-like) is
+ *     stripped before macro replacement,
+ *   - line and block comments coexist, and a line comment hides a following
+ *     block-comment opener so it cannot start a block,
+ *   - a line comment may be the final thing in the file.
+ *
+ * If line-comment support regressed, this file would either fail to compile
+ * (the comment text would lex as stray tokens) or print wrong values, so
+ * runall would catch it.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#define VAL 42           // object-like macro, trailing line comment
+#define DBL(x) ((x)+(x)) // function-like macro, trailing line comment
+#define WID 7 /* b */    // block comment then line comment on one #define
+
+static int fails;
+static void chk(long got, long want, char *name)
+{
+    if (got != want) { printf("FAIL %s got=%ld want=%ld\n", name, got, want); fails++; }
+}
+
+int main(void)
+{
+    int x;
+    char *s;
+
+    x = 5;          // x = 999
+    chk(x, 5L, "basic");
+
+    x = 10 / 2;     // a lone slash still divides
+    chk(x, 5L, "single slash divides");
+
+    // full-line comment with tricky text: /* not a block */ "not a string" 'x'
+    x = VAL;
+    chk(x, 42L, "object macro trailing comment");
+    chk(DBL(5), 10L, "function macro trailing comment");
+    chk(WID, 7L, "block-then-line on one define");
+
+    s = "a//b//c";  // the // sequences live inside the string
+    chk((long)strlen(s), 7L, "slashes inside string");
+
+    // /* a line comment hides this block opener, so the next line stays live
+    x = 11;
+    chk(x, 11L, "line comment hides block opener");
+
+    x = 22; /* a block comment may contain // safely */ x += 1;
+    chk(x, 23L, "block comment contains slashes");
+
+    x = 0;          // reset
+    x += 1;         // ++
+    x += 1;         // ++
+    chk(x, 2L, "interleaved trailing comments");
+
+    if (fails == 0) printf("tcmt99 passed with great success\n");
+    else printf("tcmt99 FAILED: %d\n", fails);
+    return fails != 0;
+}
+// the final token in this file is a line comment

--- a/tforblk.c
+++ b/tforblk.c
@@ -1,0 +1,228 @@
+/*
+ * tforblk.c - general C block scope (scope-stack).
+ *
+ * dcc historically kept one flat set of locals per function, so a variable
+ * declared in an inner { } block aliased an outer same-named one and leaked
+ * after the block.  With the block scope-stack a name declared in an inner
+ * block shadows (does not clobber) an outer local/parameter/for-init variable
+ * and is invisible once the block ends.  These tests pin that behaviour.
+ */
+#include <stdio.h>
+
+static int fails;
+static void chk(long got, long want, char *name)
+{
+    if (got != want) { printf("FAIL %s got=%ld want=%ld\n", name, got, want); fails++; }
+}
+
+static int param_shadow(int x)
+{
+    int acc = 0;
+    {
+        int x = 5;              /* shadows the parameter */
+        acc += x;               /* 5 */
+    }
+    acc += x;                   /* parameter value restored */
+    return acc;
+}
+
+static int static_sibling_blocks(void)
+{
+    int total = 0;
+
+    {
+        static int x = 10;
+        x++;
+        total += x;
+    }
+
+    {
+        static int x = 100;
+        x++;
+        total += x;
+    }
+
+    return total;
+}
+
+static int static_shadows_auto(void)
+{
+    int x = 7;
+    int inner;
+
+    {
+        static int x = 40;
+        x++;
+        inner = x;
+    }
+
+    return x * 100 + inner;
+}
+
+static int static_pointer_initializer(void)
+{
+    int result = 0;
+
+    {
+        static int x = 5;
+        static int *p = &x;
+        *p = *p + 2;
+        result += x;
+    }
+
+    return result;
+}
+
+int main(void)
+{
+    /* 1. basic inner-block shadow leaves the outer value intact */
+    {
+        int x = 10;
+        {
+            int x = 20;
+            chk(x, 20L, "inner x");
+        }
+        chk(x, 10L, "outer x after block");
+    }
+
+    /* 2. sibling blocks each get their own variable */
+    {
+        long s = 0;
+        { int a = 3; s += a; }
+        { int a = 4; s += a; }
+        chk(s, 7L, "sibling blocks");
+    }
+
+    /* 3. three-deep nested shadow */
+    {
+        int v = 1;
+        {
+            int v = 2;
+            {
+                int v = 3;
+                chk(v, 3L, "deep inner");
+            }
+            chk(v, 2L, "mid after deep");
+        }
+        chk(v, 1L, "outer after nested");
+    }
+
+    /* 4. shadow with a different (wider) type */
+    {
+        int n = 100;
+        {
+            long n = 100000L;
+            chk(n, 100000L, "long shadow");
+        }
+        chk(n, 100L, "int after long shadow");
+    }
+
+    /* 5. an inner block redeclares the for-init loop variable */
+    {
+        long acc = 0;
+        for (int i = 0; i < 3; i++) {
+            int i = 50;                 /* shadows the loop variable */
+            acc += i;                   /* 3 * 50 = 150 */
+        }
+        chk(acc, 150L, "for body shadows loop var");
+    }
+
+    /* 5b. the loop counter is unaffected by the inner shadow */
+    {
+        int count = 0;
+        for (int i = 0; i < 4; i++) {
+            long i = 999L;
+            if (i == 999L) count++;
+        }
+        chk(count, 4L, "loop counter intact despite inner shadow");
+    }
+
+    /* 6. a block variable shadows a parameter */
+    chk(param_shadow(7), 12L, "param shadow");   /* 5 + 7 */
+
+    /* 7. block scope inside an if body */
+    {
+        int y = 1;
+        if (y == 1) {
+            int y = 8;
+            chk(y, 8L, "if-block shadow");
+        }
+        chk(y, 1L, "y after if-block");
+    }
+
+    /* 8. block scope inside a while body */
+    {
+        int w = 0;
+        int outer = 77;
+        long sum = 0;
+        while (w < 2) {
+            int outer = w;              /* shadow; outer loop var untouched */
+            sum += outer;               /* 0 + 1 */
+            w++;
+        }
+        chk(outer, 77L, "while-block outer intact");
+        chk(sum, 1L, "while-block inner used");
+    }
+
+    /* 9. block scope inside a switch case */
+    {
+        int sel = 1;
+        int r = 0;
+        switch (sel) {
+            case 1: {
+                int t = 11;
+                r = t;
+                break;
+            }
+            default:
+                r = -1;
+        }
+        chk(r, 11L, "switch case block");
+    }
+
+    /* 10. a declaration after a sibling block gets a fresh slot (no leak) */
+    {
+        long total = 0;
+        { int z = 5; total += z; }
+        {
+            int z = 9;
+            total += z;
+        }
+        chk(total, 14L, "post-block redeclare");
+    }
+
+    /* 11. nested for-loops reusing the same counter name */
+    {
+        long acc = 0;
+        for (int i = 0; i < 3; i++)
+            for (int i = 0; i < 2; i++)
+                acc += i;               /* 3 * (0+1) = 3 */
+        chk(acc, 3L, "nested same-name for");
+    }
+
+    /* 12. for-init shadows an outer local, restored after the loop */
+    {
+        int i = 42;
+        long acc = 0;
+        for (int i = 0; i < 5; i++)
+            acc += i;                   /* 0+1+2+3+4 = 10 */
+        chk(acc, 10L, "for-init sum");
+        chk(i, 42L, "outer i restored after loop");
+    }
+
+    /* 13. block-scope static locals with the same source name are distinct */
+    chk(static_sibling_blocks(), 112L, "static sibling blocks first call");
+    chk(static_sibling_blocks(), 114L, "static sibling blocks second call");
+
+    /* 14. a block static shadows an automatic local only inside the block */
+    chk(static_shadows_auto(), 741L, "static shadows auto first call");
+    chk(static_shadows_auto(), 742L, "static shadows auto second call");
+
+    /* 15. static initializers use the backing symbol for block statics */
+    chk(static_pointer_initializer(), 7L, "static pointer initializer first call");
+    chk(static_pointer_initializer(), 9L, "static pointer initializer second call");
+
+    if (fails == 0) printf("tforblk passed with great success\n");
+    else printf("tforblk FAILED: %d\n", fails);
+    return fails != 0;
+}

--- a/tforsco.c
+++ b/tforsco.c
@@ -1,0 +1,168 @@
+/*
+ * tforsco.c - C99 for-init declaration scoping.
+ *
+ * dcc accepts  for (int i = 0; ...)  syntax, but the loop variable used to
+ * share one flat function scope: a for-init `int i` whose name already named
+ * a local/param aliased that outer variable instead of shadowing it.  These
+ * tests pin the corrected block-scoped behaviour:
+ *   - a for-init variable that shadows an outer one leaves the outer value
+ *     intact after the loop, and
+ *   - sibling and nested loops (including a nested shadow) each get their own
+ *     loop variable.
+ */
+#include <stdio.h>
+
+static int fails;
+static void chk(long got, long want, char *name)
+{
+    if (got != want) { printf("FAIL %s got=%ld want=%ld\n", name, got, want); fails++; }
+}
+
+static int param_shadow(int p)
+{
+    int got = 0;
+    for (int p = 0; p < 3; p++)
+        got += p;
+    return got * 100 + p;
+}
+
+int main(void)
+{
+    int sum = 0;
+    int i;
+    int m;
+
+    /* basic for-init */
+    for (int i = 0; i < 5; i++)
+        sum += i;
+    chk(sum, 10L, "basic");
+
+    /* shadowing: the loop i must not touch the outer i */
+    i = 99;
+    for (int i = 0; i < 3; i++)
+        sum += i;                       /* +0+1+2 -> 13 */
+    chk(i, 99L, "shadow outer untouched");
+    chk(sum, 13L, "shadow sum");
+
+    /* sibling loops each re-declare i */
+    for (int i = 0; i < 4; i++) sum += i;   /* +6 -> 19 */
+    for (int i = 0; i < 4; i++) sum += i;   /* +6 -> 25 */
+    chk(sum, 25L, "siblings");
+
+    /* nested loops, distinct names */
+    {
+        int total = 0;
+        for (int a = 0; a < 3; a++)
+            for (int b = 0; b < 2; b++)
+                total++;
+        chk(total, 6L, "nested distinct");
+    }
+
+    /* nested shadow: inner for-j shadows an outer j */
+    {
+        int j = 7;
+        long acc = 0;
+        for (int i = 0; i < 3; i++)
+            for (int j = 0; j < 3; j++)
+                acc += j;               /* 3 * (0+1+2) = 9 */
+        chk(j, 7L, "nested shadow outer j");
+        chk(acc, 9L, "nested shadow acc");
+    }
+
+    /* for-init shadow with a different type than the outer variable */
+    {
+        int k = 1234;
+        long ksum = 0;
+        for (long k = 100000L; k < 100003L; k++)
+            ksum += k;                  /* 100000+100001+100002 = 300003 */
+        chk(k, 1234L, "type-diff shadow outer");
+        chk(ksum, 300003L, "type-diff shadow sum");
+    }
+
+    /* non-shadowing for-init still works (no outer m) */
+    {
+        long msum = 0;
+        for (int m = 0; m < 6; m++)
+            msum += m;                  /* 15 */
+        chk(msum, 15L, "non-shadow");
+    }
+
+    /* C99 loop scope also hides a non-shadowing init declaration after loop. */
+    m = 77;
+    for (int m = 0; m < 2; m++)
+        sum += m;                       /* +1 -> 26 */
+    chk(m, 77L, "non-shadow hidden after");
+    chk(sum, 26L, "non-shadow hidden sum");
+
+    /* init declaration stays in scope for condition, body, and increment. */
+    {
+        int c = 500;
+        int seen = 0;
+        for (int c = 0; c < 5; c++) {
+            if (c == 1) continue;
+            seen += c;
+            if (c == 3) break;
+        }
+        chk(c, 500L, "continue break outer");
+        chk(seen, 5L, "continue break seen");
+    }
+
+    /* single-statement and empty-body loops must keep the init name scoped. */
+    {
+        int s = 20;
+        int one = 0;
+        int empty = 0;
+        for (int s = 0; s < 3; s++) one += s;
+        for (int e = 0; e < 4; empty += e, e++) ;
+        chk(s, 20L, "single statement outer");
+        chk(one, 3L, "single statement sum");
+        chk(empty, 6L, "empty body increment");
+    }
+
+    /* multiple declarators: each declared name enters scope after its own
+     * declarator, so the initializer for b sees the new a. */
+    {
+        int a = 100;
+        int b = 200;
+        int multi = 0;
+        for (int a = 1, b = a + 2; a < 4; a++, b += 10)
+            multi += a + b;             /* 1+3 + 2+13 + 3+23 = 45 */
+        chk(a, 100L, "multi outer a");
+        chk(b, 200L, "multi outer b");
+        chk(multi, 45L, "multi sum");
+    }
+
+    /* pointer declarator in a for-init should scope like any other declarator. */
+    {
+        int vals[3];
+        int *p;
+        int psum = 0;
+        vals[0] = 2;
+        vals[1] = 4;
+        vals[2] = 6;
+        p = vals;
+        for (int *p = vals; p < vals + 3; p++)
+            psum += *p;
+        chk(*p, 2L, "pointer outer");
+        chk(psum, 12L, "pointer sum");
+    }
+
+    /* a for-init declaration can shadow a parameter. */
+    chk(param_shadow(7), 307L, "param shadow");
+
+    /* const for-init names still need storage when their address is taken. */
+    {
+        int q = 10;
+        int qgot = 0;
+        for (const int q = 5; qgot == 0; qgot++) {
+            int *qp = &q;
+            qgot += *qp;
+        }
+        chk(q, 10L, "const address outer");
+        chk(qgot, 6L, "const address value");
+    }
+
+    if (fails == 0) printf("tforsco passed with great success\n");
+    else printf("tforsco FAILED: %d\n", fails);
+    return fails != 0;
+}

--- a/tstr.c
+++ b/tstr.c
@@ -168,7 +168,7 @@ void test_wide()
     }
 
     printf( "testing printf with wide strings\n" );
-    for ( i = 0; i < 20; i++ )
+    for ( int i = 0; i < 20; i++ )
     {
         int start = ( (unsigned int) rand() % 300 );
         int end = 1 + start + ( ( (unsigned int) rand() ) % 70 );


### PR DESCRIPTION
dcc: model general C lexical block scope (scope-stack)

**MERGE ORDER: merge AFTER the C99 for-init scope PR (branch
c99-for-init-scope). This branch is built directly on top of it and
extends the same local-symbol machinery; merging it first will not
apply cleanly and would leave block scope half-modeled.**

BEHAVIOUR BEFORE THIS FIX:
  dcc kept one flat set of locals per function. A variable declared in
  an inner { } block aliased an outer same-named variable and leaked
  after the block closed. Only C99 for-init declarations had real scope
  (added by the parent PR); ordinary blocks did not. Block-scoped
  `static` locals that shared a source name (e.g. the same `static int x`
  in two sibling blocks) collided on a single backing global.

BEHAVIOUR NOW:
  Every { } block - including if / while / for / switch bodies - opens a
  real lexical scope. A name declared in an inner block shadows (does not
  clobber) an outer same-named local, parameter, or for-init variable,
  and is invisible once the block ends. Sibling blocks may reuse a name
  independently. Block-scoped `static` locals get their own distinct
  backing storage even when they share a source name, and a static
  initializer that takes the address of such a static (`static int *p =
  &x;`) binds to that static's private backing object.

Implementation:
  - Scope-stack: enter_scope/leave_scope save and restore the nlocals
    watermark at each { }. Storage (local_size) stays monotonic, so the
    frame is the sum over all scopes and offsets never overlap. The
    frame-sizing scan and codegen bracket blocks identically, so both
    passes assign the same IX offsets.
  - find_local_decl() resolves only the current block (redeclaration
    guard); find_local() resolves all visible scopes, innermost-wins.
  - Function-scope `static` locals get a deterministic private backing
    global __sl<func>_<seq>, numbered identically in scan and codegen.
    Sym.link_name carries that backing name; all symbol-based assembly
    emission goes through sym_asm_name() so references hit the backing
    object, not the source spelling.

Tests:
  - New regression tforblk.c: inner-block shadow, sibling blocks, deep
    nesting, wider-type shadow, for-body shadowing the loop var, param
    shadow, if/while/switch-body blocks, post-block redeclare, nested
    same-name for, plus block-scoped static sibling/shadow/pointer-init
    cases. Wired into runall.sh / runall.bat with a baseline block.
  - Docs updated: SKILL.md and dcc-c89-reference-guide.md now state block
    scope is fully modeled.
  - Full runall green (peep + nopeep); filtered diff empty apart from the
    expected __DATE__/__TIME__ lines.