### PR TITLE
Expr type authoritative

### DIFF
--- a/baseline_test_dcc.txt
+++ b/baseline_test_dcc.txt
@@ -4203,3 +4203,5 @@ test tforblk
 tforblk passed with great success
 test tcmt99
 tcmt99 passed with great success
+test tctxflt
+tctxflt passed with great success

--- a/dcc-c89-reference-guide.md
+++ b/dcc-c89-reference-guide.md
@@ -212,6 +212,13 @@ Notes specific to the 16-bit model:
   more than 16 bits (for example `(long)x << 20`).
 - The optimizer rewrites multiply/divide by a power-of-two constant into the
   equivalent shift.
+- `%` requires integer operands. For a floating-point remainder use `fmodf`
+  from [math.h](math.h); `floatx % floaty` is rejected at compile time.
+- Mixed-type expressions follow the usual arithmetic conversions: **`float`
+  outranks `long`, which outranks 16-bit `int`/`short`.** So `longv + 1.0f`,
+  `intv < floatv`, and `cond ? 2 : 3.5f` are all computed in `float`, and the
+  result stays `float` until you cast it back. Mind the single-precision limit
+  noted under [math.h](math.h) whenever a wide `long` meets a `float`.
 
 ### Beyond C89
 
@@ -606,6 +613,25 @@ float r = sqrtf(2.0f);
 printf("%f\n", r);          /* needs -ffloatio */
 ```
 
+### Float precision and mixed-type gotchas
+
+- **`float` carries about 7 decimal digits (a 24-bit significand).** Integers up
+  to 2^24 (16,777,216) are exact; beyond that only some integers are
+  representable, so converting a larger `long` to `float` rounds to the nearest
+  single. `(long)(float)16777217L` is `16777216`, not `16777217`. The same
+  rounding applies in constant expressions, `case` labels, and array bounds.
+- **Comparing a wide integer against a `float` happens in `float`.** The integer
+  side converts to `float` first, losing any value below the 2^24 boundary, so
+  `16777216L < (float)16777217L` is **false** (the cast rounded down to
+  `16777216.0f`). Compare as integers when you need full 32-bit precision.
+- **Any `float` arm makes a `?:` a `float` expression.** `cond ? 2 : 3.5f`
+  yields a `float` (`2.0f` or `3.5f`), not an `int`; cast the result if you need
+  an integer. This holds even when the `float` is hidden behind a cast, a struct
+  member, or a nested `?:` arm.
+- **A `float` is "true" when its magnitude is nonzero.** `if (f)`, `f ? a : b`,
+  `!f`, `f && g`, and `while (f)` test against zero, and both `+0.0f` and
+  `-0.0f` count as false.
+
 ---
 
 ## setjmp.h — non-local jumps
@@ -831,6 +857,12 @@ either `#include` its `.c` from your main file, or compile it separately with
 ## Limitations to keep in mind
 
 - **No `double`.** Only 32-bit `float` exists; all math is single precision.
+- **`float` precision is ~24 bits.** Integers past ±2^24 (16,777,216) are not all
+  representable, so converting a large `long` to `float` — or comparing a `long`
+  against a `float` — rounds to the nearest single. Keep values as integers when
+  you need full 32-bit precision.
+- **`%` is integer-only.** Use `fmodf` for a floating-point remainder;
+  `float % float` is a compile error.
 - **`int` is 16-bit.** Use `long` (and `%ld`) when you need more than ±32767.
 - **`scanf` is integer/string only.** Floating input, scansets, `%n`, and `%p`
   are not implemented.

--- a/runall.bat
+++ b/runall.bat
@@ -20,7 +20,7 @@ set _applist=sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong ^
              tpostut tbug2 tlongsub treg tret tstructv tstructi tstructp tstri2 ^
              tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom ^
              tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield ^
-             pint cobint forint bint fint cint tstretst tportio tlongidx tforsco tforblk tcmt99
+             pint cobint forint bint fint cint tstretst tportio tlongidx tforsco tforblk tcmt99 tctxflt
 
 echo --- optimized (ma peep) ---
 set "outputfile=test_dcc.txt"

--- a/runall.sh
+++ b/runall.sh
@@ -18,7 +18,7 @@ APPLIST="sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong \
          tpostut tbug2 tlongsub treg tret tstructv tstructi tstructp tstri2 \
          tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom \
          tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield \
-         pint cobint forint bint fint cint tstretst tportio tlongidx tforsco tforblk tcmt99"
+         pint cobint forint bint fint cint tstretst tportio tlongidx tforsco tforblk tcmt99 tctxflt"
 
 run_args() {
     case "$1" in

--- a/src/dcc/README.md
+++ b/src/dcc/README.md
@@ -32,9 +32,20 @@ includes**, rather than many small per-module headers.
   module reaches them through the `extern` declarations in [`dcc.h`](dcc.h).
 - [`dcc.c`](dcc.c) is the driver translation unit and contains `main()`.
 
-This is the traditional `.c` / `.h` layout. The split is behaviour-preserving:
-the compiler it produces generates **byte-for-byte identical** assembly to the
-monolith, verified by the project's regression suite (see *Verifying* below).
+This is the traditional `.c` / `.h` layout. The split itself was
+behaviour-preserving: at the time of the split the modular compiler generated
+**byte-for-byte identical** assembly to the monolith, verified by the project's
+regression suite (see *Verifying* below).
+
+> The modular tree has since gained **correctness fixes that the monolith
+> snapshot does not have** (notably the float/`long` type-resolution work and
+> the type oracle described below). Those changes intentionally diverge from
+> [`../ddc.c`](../ddc.c); the regression baseline
+> ([`../../baseline_test_dcc.txt`](../../baseline_test_dcc.txt)) now tracks the
+> modular compiler itself, and the byte-identical guarantee is against that
+> baseline, not against the monolith. The suite still compares program output,
+> so a fix that only makes a previously-miscompiled program correct keeps every
+> other app's output unchanged.
 
 ### Why there is one shared header instead of many
 
@@ -55,6 +66,52 @@ a single module and kept `static` there:
   expression cursor)
 - `include_dirs` / `num_include_dirs` → [`dcc.c`](dcc.c) (the include search
   path)
+
+### Type resolution without an AST: the type oracle
+
+Because codegen is interleaved with parsing, the compiler often has to know an
+operand's C type *before* it generates that operand — when it reaches a binary
+operator, a `?:` arm, or a branch condition it must already have chosen 16-bit
+vs 32-bit vs float code. With no AST there is nothing to consult, so the
+historical approach was a **shallow source-text lookahead**
+(`peek_simple_unary_type`, `snippet_simple_type`) that inspects only the first
+token or two of the upcoming operand.
+
+That shallow peek is the root of a recurring **type blind-spot bug class**: a
+type hidden behind parentheses, a cast, a struct member, an array decay, or a
+nested conditional is mis-predicted, and the wrong-width code is emitted (for
+example a `float` operand dropped to 16 bits, or a `long` high word lost). The
+branches around it then need post-generation fixups that trust the *actual*
+result type (`g_expr_type`) once the operand has finally been emitted.
+
+The **type oracle** in [`dcc_ops.c`](dcc_ops.c) replaces the shallow guess with
+a complete answer. `typeof_conditional_arm()` and its internal `to_*` ladder
+(`to_postfix` → `to_unary` → `to_mul`/`to_add`/`to_shift`/`to_rel`/`to_eq` →
+the bitwise levels → `to_conditional` → `to_assign`/`to_comma`) walk the full
+expression grammar and report the C type the code generator will ultimately
+produce — applying the usual arithmetic conversions (`float` outranks `long`
+outranks unsigned outranks `int`), pointer-arithmetic rules, and
+array-to-pointer decay — but **emit no code**. It is a *type-only* mirror of the
+`gen_*` precedence ladder.
+
+Two properties make this safe and cheap:
+
+- **Bounded blast radius.** The public entry snapshots *all* lexer/token state
+  (`posi`, `tok_start_pos`, `line_no`, `tok_line`, the numeric-suffix flags, and
+  the lookahead `tok`) and restores it before returning. The real codegen
+  re-parses the same tokens afterwards, so a bug in the walker can only produce
+  a **wrong type verdict** — it can never corrupt the token stream or desync the
+  parser.
+- **No second real pass.** This is a "1.5-pass" technique: it buys accurate
+  whole-expression type information without a full AST/IR and without a second
+  code-generating pass, preserving dcc's tiny single-pass character.
+
+The oracle is currently adopted narrowly — `gen_conditional` uses it to decide
+whether a `?:` is a `float` expression (so the already-generated arm can be
+converted before the branches join). Other type-guess sites still use the
+shallow peek plus the `g_expr_type` post-generation fallback; routing more of
+them through the oracle is a deliberate, regression-gated follow-up rather than
+a blanket change.
 
 ---
 
@@ -140,7 +197,7 @@ The arrows above show the dominant direction, not a hard layering restriction.
 | [`dcc_fold.c`](dcc_fold.c) | The `cf_*` constant-folding engine (with C type/promotion rules), `sizeof`/`offsetof` evaluation, and emission of folded constant results. |
 | [`dcc_expr.c`](dcc_expr.c) | Core expression code generation: `gen_primary`/`gen_unary`, casts, dereference/address-of, function-call argument marshalling (scalar/struct/variadic), and a large set of recognised fast-path peepholes. |
 | [`dcc_cmp.c`](dcc_cmp.c) | Relational/equality comparison codegen (signed/unsigned, 16- and 32-bit) and condition-to-branch lowering, including single-`cp` byte-operand comparators. |
-| [`dcc_ops.c`](dcc_ops.c) | Binary-operator/arithmetic codegen: `+ - * / %`, shifts, bitwise ops across 16/32-bit and unsigned variants, integer promotion, pointer element-size scaling, and power-of-two float scaling. |
+| [`dcc_ops.c`](dcc_ops.c) | Binary-operator/arithmetic codegen: `+ - * / %`, shifts, bitwise ops across 16/32-bit and unsigned variants, integer promotion, pointer element-size scaling, and power-of-two float scaling. Also hosts the **type oracle** (`typeof_conditional_arm` + the `to_*` ladder): a side-effect-free, type-only walk of the expression grammar used to resolve an operand's type without emitting code (see *Type resolution without an AST* above). |
 | [`dcc_assign.c`](dcc_assign.c) | Assignment lowering (plain/compound; scalar/struct/bitfield/array element), float literal and r-value materialisation, and the top-level `gen_expr` entry points. |
 | [`dcc_stmt_fast.c`](dcc_stmt_fast.c) | Whole-statement fast-path idioms: in-place `++`/`--`, self-add accumulation, and the CRC-update byte idiom. Each falls back to the generic path when unmatched. |
 | [`dcc_decl.c`](dcc_decl.c) | Local declaration and initializer codegen: scalars, arrays, structs/unions, bitfields, brace initializer lists, and const-scalar folding of local initializers. |
@@ -225,3 +282,12 @@ diff baseline_test_dcc.txt test_dcc.txt \
   module, prefer a `static` at the top of that module instead.
 - **After any change**, rebuild and run the regression suite. For pure
   refactors, the filtered diff must stay empty.
+- **Reaching for an operand's type before it is generated?** Prefer the type
+  oracle (`typeof_conditional_arm` in [`dcc_ops.c`](dcc_ops.c)) over the shallow
+  `peek_simple_unary_type` / `snippet_simple_type` lookahead. The shallow peeks
+  only see the first token or two and are the source of the type blind-spot bug
+  class (a float, `long`, or pointer hidden behind parens, a cast, a struct
+  member, an array decay, or a nested `?:`). If you must use a peek, pair it
+  with a post-generation check of the authoritative `g_expr_type`, and add a
+  regression to [`../../tctxflt.c`](../../tctxflt.c) (the context/type-resolution
+  test) for the shape you fixed.

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -777,6 +777,8 @@ int emit_shift_const_long(int op, int lhs_type, long count);
 void emit_shift_loop(int op, int lhs_type);
 void gen_shift(void);
 void emit_float_compare_call(int op);
+void gen_float_cmp_16lhs(int op, int lhs_type);
+void gen_float_cmp_long_lhs(int op, int lhs_type);
 void gen_rel(void);
 void gen_eq(void);
 void gen_band(void);

--- a/src/dcc/dcc_cmp.c
+++ b/src/dcc/dcc_cmp.c
@@ -678,16 +678,21 @@ int simple_direct_condition_until(int stop_kind)
         if (depth == 0 && tok.kind == stop_kind)
             break;
 
-        if (depth == 0) {
-            if (tok.kind == TOK_FLOATLIT) {
+        /* A float operand anywhere in the condition - including inside
+         * parentheses such as "x < (fa * fb)" - rules out the integer
+         * direct-branch path.  Detect it at ANY depth (not only depth 0) so
+         * the caller falls back to the general, float-aware compare path
+         * (gen_rel/gen_eq) instead of silently emitting an integer compare. */
+        if (tok.kind == TOK_FLOATLIT) {
+            bad = 1;
+        } else if (tok.kind == TOK_ID) {
+            struct Sym *fs;
+            fs = find_sym(tok.text);
+            if (fs && type_is_float(fs->type))
                 bad = 1;
-            } else if (tok.kind == TOK_ID) {
-                struct Sym *fs;
-                fs = find_sym(tok.text);
-                if (fs && type_is_float(fs->type))
-                    bad = 1;
-            }
+        }
 
+        if (depth == 0) {
             if (is_relop_token(tok.kind)) {
                 if (found)
                     bad = 1;
@@ -1058,13 +1063,28 @@ void gen_direct_rel_branch_until(int op, int label, int branch_when_true,
         int ptr_cmp;
         ptr_cmp = snippet_is_single_pointer_id(lhs_code);
         gen_snippet_expr(lhs_code);
-        emit_ld_de_const(rhs_const);
-        if ((g_expr_type & TYPE_UNSIGNED) || ptr_cmp) {
-            if (branch_when_true) emit_cmp_branch_true_unsigned(op, label);
-            else emit_cmp_branch_false_unsigned(op, label);
+        if (type_is_float(g_expr_type)) {
+            /* Hidden float LHS (a cast or a struct/union member the snippet
+             * pre-scan cannot classify) compared with an integer constant.
+             * Compare as float so the constant load does not clobber DE (the
+             * float's high word).  const_positive_snippet_value only yields
+             * 1..32767, so the constant fits HL as a positive int. */
+            emit("\tpush de\n\tpush hl\n");
+            if (!scan_mode)
+                fprintf(outf, "\tld hl,%ld\n", rhs_const & 0xffffL);
+            emit_convert_int_to_float(TYPE_INT);
+            emit("\tpush de\n\tpush hl\n");
+            emit_float_compare_call(op);
+            emit_branch_on_bool_hl(label, branch_when_true);
         } else {
-            if (branch_when_true) emit_cmp_branch_true(op, label);
-            else emit_cmp_branch_false(op, label);
+            emit_ld_de_const(rhs_const);
+            if ((g_expr_type & TYPE_UNSIGNED) || ptr_cmp) {
+                if (branch_when_true) emit_cmp_branch_true_unsigned(op, label);
+                else emit_cmp_branch_false_unsigned(op, label);
+            } else {
+                if (branch_when_true) emit_cmp_branch_true(op, label);
+                else emit_cmp_branch_false(op, label);
+            }
         }
     } else {
         int lhs_type;
@@ -1075,16 +1095,40 @@ void gen_direct_rel_branch_until(int op, int label, int branch_when_true,
         if (snippet_needs_long_compare(lhs_code, rhs_code, &common_type)) {
             gen_snippet_expr(lhs_code);
             lhs_type = g_expr_type;
-            emit_cast_16_to_common(lhs_type, common_type);
-            /* Prefer an inline compare against a constant RHS; the LHS is now
-             * in DE:HL, which both that path and the runtime fallback need. */
-            if (!try_emit_long_cmp_const_branch(op, rhs_code, common_type,
-                                                label, branch_when_true)) {
+            if (type_is_float(lhs_type)) {
+                /* The LHS actually generated a float (e.g. "(float)x" or a
+                 * struct-member float) even though the snippet pre-scan put
+                 * the common type at long because the *other* operand looked
+                 * long.  Float dominates: widen the RHS to float and compare
+                 * as float. */
                 emit("\tpush de\n\tpush hl\n");
                 gen_snippet_expr(rhs_code);
-                emit_cast_16_to_common(g_expr_type, common_type);
-                gen_cmp32(op, common_type);
+                if (!type_is_float(g_expr_type))
+                    emit_convert_int_to_float(g_expr_type);
+                emit("\tpush de\n\tpush hl\n");
+                emit_float_compare_call(op);
                 emit_branch_on_bool_hl(label, branch_when_true);
+            } else {
+                emit_cast_16_to_common(lhs_type, common_type);
+                /* Prefer an inline compare against a constant RHS; the LHS is
+                 * now in DE:HL, which both that path and the runtime fallback
+                 * need. */
+                if (!try_emit_long_cmp_const_branch(op, rhs_code, common_type,
+                                                    label, branch_when_true)) {
+                    emit("\tpush de\n\tpush hl\n");
+                    gen_snippet_expr(rhs_code);
+                    if (type_is_float(g_expr_type)) {
+                        /* The RHS actually generated a float while the LHS is
+                         * a long on the stack.  Float dominates: widen the
+                         * stacked long LHS and compare as float. */
+                        gen_float_cmp_long_lhs(op, common_type);
+                        emit_branch_on_bool_hl(label, branch_when_true);
+                    } else {
+                        emit_cast_16_to_common(g_expr_type, common_type);
+                        gen_cmp32(op, common_type);
+                        emit_branch_on_bool_hl(label, branch_when_true);
+                    }
+                }
             }
         } else {
             ptr_cmp = snippet_is_single_pointer_id(lhs_code) ||
@@ -1092,7 +1136,23 @@ void gen_direct_rel_branch_until(int op, int label, int branch_when_true,
             gen_snippet_expr(lhs_code);
             lhs_type = g_expr_type;
 
-            if (type_is_long(lhs_type)) {
+            if (type_is_float(lhs_type)) {
+                /*
+                 * Hidden float LHS (a cast or struct/union member the snippet
+                 * pre-scan could not classify, e.g. "(float)x" or "s->f").
+                 * The float value is in DE:HL; compare as float.  Lay out
+                 * deep=LHS / top=RHS so emit_float_compare_call computes the
+                 * relation LHS op RHS; the RHS is converted to float if it was
+                 * generated as an integer.
+                 */
+                emit("\tpush de\n\tpush hl\n");
+                gen_snippet_expr(rhs_code);
+                if (!type_is_float(g_expr_type))
+                    emit_convert_int_to_float(g_expr_type);
+                emit("\tpush de\n\tpush hl\n");
+                emit_float_compare_call(op);
+                emit_branch_on_bool_hl(label, branch_when_true);
+            } else if (type_is_long(lhs_type)) {
                 /*
                  * The LHS turned out to be a long expression that the snippet
                  * pre-analysis (snippet_simple_type) could not classify, e.g.
@@ -1102,17 +1162,37 @@ void gen_direct_rel_branch_until(int op, int label, int branch_when_true,
                 emit("\tpush de\n\tpush hl\n");
                 gen_snippet_expr(rhs_code);
                 rhs_type = g_expr_type;
-                common_type = common_arith_type(lhs_type, rhs_type);
-                emit_cast_16_to_common(rhs_type, common_type);
-                gen_cmp32(op, common_type);
-                emit_branch_on_bool_hl(label, branch_when_true);
+                if (type_is_float(rhs_type)) {
+                    /* The RHS actually generated a float while the LHS is a
+                     * long on the stack (e.g. "l < (F)y" with a float
+                     * typedef).  Float dominates: widen the stacked long LHS
+                     * and compare as float. */
+                    gen_float_cmp_long_lhs(op, lhs_type);
+                    emit_branch_on_bool_hl(label, branch_when_true);
+                } else {
+                    common_type = common_arith_type(lhs_type, rhs_type);
+                    emit_cast_16_to_common(rhs_type, common_type);
+                    gen_cmp32(op, common_type);
+                    emit_branch_on_bool_hl(label, branch_when_true);
+                }
             } else {
                 emit("\tpush hl\n");
                 gen_snippet_expr(rhs_code);
                 rhs_type = g_expr_type;
                 common_type = common_arith_type(lhs_type, rhs_type);
 
-                if (type_is_long(rhs_type)) {
+                if (type_is_float(rhs_type)) {
+                    /*
+                     * Hidden float RHS (a cast or struct/union member, e.g.
+                     * "(float)y" or "s->f") that the snippet pre-scan could
+                     * not classify, while the LHS was generated as a 16-bit
+                     * value (only HL was pushed).  Reuse the shared fallback:
+                     * it reloads the LHS, widens it to float, and compares
+                     * LHS op RHS, leaving 0/1 in HL.
+                     */
+                    gen_float_cmp_16lhs(op, lhs_type);
+                    emit_branch_on_bool_hl(label, branch_when_true);
+                } else if (type_is_long(rhs_type)) {
                     /*
                      * The RHS is long but the LHS was generated as a 16-bit
                      * value (only HL was pushed).  Reclaim the 16-bit LHS,

--- a/src/dcc/dcc_constexpr.c
+++ b/src/dcc/dcc_constexpr.c
@@ -67,11 +67,23 @@ long parse_const_long_primary(void)
          */
         if (starts_type()) {
             int t;
-            (void)t;
             t = parse_type();
             while (accept('*')) { skip_type_qualifiers(); t = type_add_ptr(t); }
             expect(')');
             v = parse_const_long_primary();
+            /*
+             * A cast to float rounds through single precision before any
+             * outer integer cast consumes the value: (long)(float)16777217 is
+             * 16777216, because 16777217 is not representable as a 32-bit
+             * float.  This integer-only evaluator otherwise ignores the cast
+             * type, which silently dropped that rounding.  The host build has
+             * real floats, so round the operand the same way the Z80 runtime
+             * would.  Pointer casts (t became a pointer above) are not float. */
+            if (type_is_float(t)) {
+                float ftmp;
+                ftmp = (float)v;
+                v = (long)ftmp;
+            }
             return sign * v;
         }
 

--- a/src/dcc/dcc_expr.c
+++ b/src/dcc/dcc_expr.c
@@ -3576,13 +3576,7 @@ void gen_unary(void)
         lt = new_label();
         le = new_label();
         gen_unary();
-        if (type_is_long(g_expr_type)) {
-            /* logical not of 32-bit: zero iff DE:HL==0 */
-            emit("\tld a,h\n\tor l\n\tor d\n\tor e\n");
-        } else {
-            emit("\tld a,h\n\tor l\n");
-        }
-        emit_jp_label("jp z,", lt);
+        emit_test_expr_nonzero(g_expr_type, lt, 0);
         emit("\tld hl,0\n");
         emit_jp_label("jp", le);
         emit_label(lt);

--- a/src/dcc/dcc_fold.c
+++ b/src/dcc/dcc_fold.c
@@ -221,6 +221,16 @@ int cf_parse_primary(struct ConstVal *out)
             expect(')');
             if (!cf_parse_primary(out))
                 return 0;
+            /*
+             * The cf_* engine is integer-only: it has no IEEE-754 rounding,
+             * so it cannot represent a cast to float faithfully.  Folding
+             * (float)16777217L as the integer 16777217 is wrong, because the
+             * single-precision value rounds to 16777216.0f.  Decline so the
+             * expression falls through to the runtime float code path, which
+             * converts and compares with correct single-precision semantics.
+             */
+            if (type_is_float(t))
+                return 0;
             cf_cast_to_type(out, t);
             return 1;
         }

--- a/src/dcc/dcc_ops.c
+++ b/src/dcc/dcc_ops.c
@@ -725,6 +725,85 @@ static void gen_binop32_promote_16lhs(int op, int lhs_type, int common_type)
     g_long_from16 = 0;
 }
 
+/*
+ * Arithmetic fallback for a float RHS that peek_simple_unary_type mis-predicted
+ * as 16-bit (e.g. a parenthesized "fa * fb" or a float-returning call).  The
+ * predictive peek is only a hint; once the RHS has actually been generated the
+ * authoritative type lives in g_expr_type, and these fallbacks trust it.
+ *
+ * On entry the 16-bit LHS is the top word of the stack (pushed by the caller)
+ * and the float RHS is in DE:HL.  Convert the LHS to float and evaluate in the
+ * canonical deep=LHS / top=RHS stack order the float helpers expect, so the
+ * result is LHS op RHS (correct for the non-commutative '-' and '/').  Result
+ * left in DE:HL; the stack is fully balanced.  op is one of '+','-','*','/'.
+ */
+static void gen_float_binop_16lhs(int op, int lhs_type)
+{
+    const char *helper;
+
+    helper = (op == '+') ? "__fadd" :
+             (op == '-') ? "__fsub" :
+             (op == '*') ? "__fmul" : "__fdiv";
+
+    /* spill the float RHS above the 16-bit LHS word */
+    emit("\tpush de\n\tpush hl\n");                  /* [LHS16][RHSf] */
+    /* reload the 16-bit LHS (now at SP+4) and widen it to float */
+    emit("\tld hl,4\n\tadd hl,sp\n");
+    emit("\tld e,(hl)\n\tinc hl\n\tld d,(hl)\n\tex de,hl\n");
+    emit_convert_int_to_float(lhs_type);              /* DE:HL = (float)LHS */
+    emit("\tpush de\n\tpush hl\n");                  /* [LHS16][RHSf][LHSf] */
+    /* reload the spilled RHS float (now the 4 bytes at SP+4) */
+    emit("\tld hl,4\n\tadd hl,sp\n");
+    emit("\tld e,(hl)\n\tinc hl\n\tld d,(hl)\n\tinc hl\n");
+    emit("\tld a,(hl)\n\tinc hl\n\tld h,(hl)\n\tld l,a\n");
+    emit("\tex de,hl\n");                            /* DE:HL = RHS float */
+    emit("\tpush de\n\tpush hl\n");                  /* [LHS16][RHSf][LHSf][RHSf] */
+    emit_runtime_call(helper);                        /* deep=LHS,top=RHS -> LHS op RHS */
+    /* clean all 14 pushed bytes without disturbing DE:HL (the result) */
+    emit("\tpop bc\n\tpop bc\n\tpop bc\n\tpop bc\n\tpop bc\n\tpop bc\n\tpop bc\n");
+    g_expr_type = TYPE_FLOAT;
+    g_long_from16 = 0;
+}
+
+/*
+ * Arithmetic fallback for a float RHS that the predicted common type put at
+ * long (e.g. "longvar + (fa * fb)"): the snippet/peek pre-analysis classified
+ * the operation as long, but the RHS actually generated a float.  On entry the
+ * 32-bit long LHS is on top of the stack (pushed by the caller as push de;push
+ * hl) and the float RHS is in DE:HL.  Widen the long LHS to float, evaluate in
+ * canonical deep=LHS / top=RHS order so the result is LHS op RHS, and leave it
+ * in DE:HL with the stack fully balanced.  op is one of '+','-','*','/'.
+ */
+static void gen_float_binop_long_lhs(int op, int lhs_type)
+{
+    const char *helper;
+
+    helper = (op == '+') ? "__fadd" :
+             (op == '-') ? "__fsub" :
+             (op == '*') ? "__fmul" : "__fdiv";
+
+    /* spill the float RHS above the 4-byte long LHS */
+    emit("\tpush de\n\tpush hl\n");                  /* [LHSlong][RHSf] */
+    /* reload the long LHS (now at SP+4) into DE:HL and widen it to float */
+    emit("\tld hl,4\n\tadd hl,sp\n");
+    emit("\tld e,(hl)\n\tinc hl\n\tld d,(hl)\n\tinc hl\n");
+    emit("\tld a,(hl)\n\tinc hl\n\tld h,(hl)\n\tld l,a\n");
+    emit("\tex de,hl\n");                            /* DE:HL = LHS long */
+    emit_convert_int_to_float(lhs_type);              /* DE:HL = (float)LHS */
+    emit("\tpush de\n\tpush hl\n");                  /* [LHSlong][RHSf][LHSf] */
+    /* reload the spilled RHS float (now the 4 bytes at SP+4) */
+    emit("\tld hl,4\n\tadd hl,sp\n");
+    emit("\tld e,(hl)\n\tinc hl\n\tld d,(hl)\n\tinc hl\n");
+    emit("\tld a,(hl)\n\tinc hl\n\tld h,(hl)\n\tld l,a\n");
+    emit("\tex de,hl\n");                            /* DE:HL = RHS float */
+    emit("\tpush de\n\tpush hl\n");                  /* [LHSlong][RHSf][LHSf][RHSf] */
+    emit_runtime_call(helper);                        /* deep=LHS,top=RHS -> LHS op RHS */
+    /* clean all 16 pushed bytes without disturbing DE:HL (the result) */
+    emit("\tpop bc\n\tpop bc\n\tpop bc\n\tpop bc\n\tpop bc\n\tpop bc\n\tpop bc\n\tpop bc\n");
+    g_expr_type = TYPE_FLOAT;
+    g_long_from16 = 0;
+}
+
 void gen_mul(void)
 {
     int op;
@@ -867,20 +946,37 @@ void gen_mul(void)
             lhs_w = g_long_from16;      /* widen kind of the LHS operand */
             emit("\tpush de\n\tpush hl\n");
             gen_unary();
-            emit_cast_16_to_common(g_expr_type, common_type);
-            rhs_w = g_long_from16;      /* widen kind of the RHS operand */
-
-            mulhelp = (op == '*') ? long_mul_widen_helper(lhs_w, rhs_w) : 0;
-            if (mulhelp) {
-                /* Same 8-byte stack convention as gen_binop32's l32call, but
-                 * the 16x16 helper reads only the two pushed low words. */
-                emit("\tpush de\n\tpush hl\n");
-                emit_runtime_call(mulhelp);
-                emit("\tld b,d\n\tld c,e\n\tex de,hl\n");
-                emit("\tld hl,8\n\tadd hl,sp\n\tld sp,hl\n");
-                emit("\tex de,hl\n\tld d,b\n\tld e,c\n");
+            if (type_is_float(g_expr_type)) {
+                /* The RHS generated a float though the predicted common type
+                 * was long (a parenthesized/compound/member float that
+                 * peek_simple_unary_type could not see).  Float dominates:
+                 * widen the stacked long LHS and operate as float.  Modulo
+                 * has no float form. */
+                if (op == '%') {
+                    error_float_unsupported("float modulo not supported");
+                    emit("\tpop bc\n\tpop bc\n\tld hl,0\n");
+                    common_type = TYPE_INT;
+                } else {
+                    gen_float_binop_long_lhs(op, common_type);
+                    common_type = TYPE_FLOAT;
+                }
             } else {
-                gen_binop32(op, common_type);
+                emit_cast_16_to_common(g_expr_type, common_type);
+                rhs_w = g_long_from16;      /* widen kind of the RHS operand */
+
+                mulhelp = (op == '*') ? long_mul_widen_helper(lhs_w, rhs_w) : 0;
+                if (mulhelp) {
+                    /* Same 8-byte stack convention as gen_binop32's l32call,
+                     * but the 16x16 helper reads only the two pushed low
+                     * words. */
+                    emit("\tpush de\n\tpush hl\n");
+                    emit_runtime_call(mulhelp);
+                    emit("\tld b,d\n\tld c,e\n\tex de,hl\n");
+                    emit("\tld hl,8\n\tadd hl,sp\n\tld sp,hl\n");
+                    emit("\tex de,hl\n\tld d,b\n\tld e,c\n");
+                } else {
+                    gen_binop32(op, common_type);
+                }
             }
         } else {
             emit("\tpush hl\n");
@@ -888,6 +984,17 @@ void gen_mul(void)
             if (type_is_long(g_expr_type)) {
                 common_type = common_arith_type(lhs_type, g_expr_type);
                 gen_binop32_promote_16lhs(op, lhs_type, common_type);
+            } else if (type_is_float(g_expr_type)) {
+                /* RHS is float but peek predicted 16-bit (parenthesized or
+                 * compound operand).  Trust the computed type. */
+                if (op == '%') {
+                    error_float_unsupported("float modulo not supported");
+                    emit("\tpop bc\n\tld hl,0\n");
+                    common_type = TYPE_INT;
+                } else {
+                    gen_float_binop_16lhs(op, lhs_type);
+                    common_type = TYPE_FLOAT;
+                }
             } else {
                 emit("\tex de,hl\n\tpop hl\n");
                 gen_binop_typed(op, common_type);
@@ -1056,14 +1163,27 @@ void gen_add(void)
             emit_cast_16_to_common(lhs_type, common_type);
             emit("\tpush de\n\tpush hl\n");
             gen_mul();
-            emit_cast_16_to_common(g_expr_type, common_type);
-            gen_binop32(op, common_type);
+            if (type_is_float(g_expr_type)) {
+                /* RHS generated a float though the predicted common type was
+                 * long; float dominates.  Widen the stacked long LHS and add
+                 * or subtract as float. */
+                gen_float_binop_long_lhs(op, common_type);
+                common_type = TYPE_FLOAT;
+            } else {
+                emit_cast_16_to_common(g_expr_type, common_type);
+                gen_binop32(op, common_type);
+            }
         } else {
             emit("\tpush hl\n");
             gen_mul();
             if (type_is_long(g_expr_type)) {
                 common_type = common_arith_type(lhs_type, g_expr_type);
                 gen_binop32_promote_16lhs(op, lhs_type, common_type);
+            } else if (type_is_float(g_expr_type)) {
+                /* RHS is float but peek predicted 16-bit (parenthesized or
+                 * compound operand).  Trust the computed type. */
+                gen_float_binop_16lhs(op, lhs_type);
+                common_type = TYPE_FLOAT;
             } else {
                 emit("\tex de,hl\n\tpop hl\n");
                 gen_binop_typed(op, common_type);
@@ -1241,6 +1361,81 @@ void emit_float_compare_call(int op)
     g_expr_type = TYPE_INT;
 }
 
+/*
+ * Compare fallback for a long RHS that peek_simple_unary_type mis-predicted as
+ * 16-bit (e.g. a parenthesized or compound "y + la").  The 16-bit LHS is the
+ * top word of the stack and the long RHS is in DE:HL.  Widen the LHS and
+ * compare as 32-bit with the operands swapped: the RHS becomes gen_cmp32's
+ * stacked left operand, so the relop is inverted (== / != are commutative, so
+ * the swap is also correct for them).  Result int 0/1 in HL.
+ */
+static void gen_cmp_promote_16lhs(int op, int lhs_type)
+{
+    int ct = common_arith_type(lhs_type, g_expr_type);
+    emit("\tpop bc\n");
+    emit("\tpush de\n\tpush hl\n");
+    emit("\tld h,b\n\tld l,c\n");
+    emit_cast_16_to_common(lhs_type, ct);
+    gen_cmp32(invert_relop_for_swap(op), ct);
+}
+
+/*
+ * Compare fallback for a float RHS that peek_simple_unary_type mis-predicted as
+ * 16-bit (e.g. a parenthesized "fa * fb").  The 16-bit LHS is the top word of
+ * the stack and the float RHS is in DE:HL.  Convert the LHS to float and lay
+ * out canonical deep=LHS / top=RHS so emit_float_compare_call computes the
+ * relation LHS op RHS.  Result int 0/1 in HL; the stack is fully balanced.
+ */
+void gen_float_cmp_16lhs(int op, int lhs_type)
+{
+    /* spill the float RHS above the 16-bit LHS word */
+    emit("\tpush de\n\tpush hl\n");                  /* [LHS16][RHSf] */
+    /* reload the 16-bit LHS (now at SP+4) and widen it to float */
+    emit("\tld hl,4\n\tadd hl,sp\n");
+    emit("\tld e,(hl)\n\tinc hl\n\tld d,(hl)\n\tex de,hl\n");
+    emit_convert_int_to_float(lhs_type);              /* DE:HL = (float)LHS */
+    emit("\tpush de\n\tpush hl\n");                  /* [LHS16][RHSf][LHSf] */
+    /* reload the spilled RHS float (now the 4 bytes at SP+4) */
+    emit("\tld hl,4\n\tadd hl,sp\n");
+    emit("\tld e,(hl)\n\tinc hl\n\tld d,(hl)\n\tinc hl\n");
+    emit("\tld a,(hl)\n\tinc hl\n\tld h,(hl)\n\tld l,a\n");
+    emit("\tex de,hl\n");                            /* DE:HL = RHS float */
+    emit("\tpush de\n\tpush hl\n");                  /* [LHS16][RHSf][LHSf][RHSf] */
+    emit_float_compare_call(op);                      /* pops LHSf+RHSf; HL = 0/1 */
+    emit("\tpop bc\n\tpop bc\n\tpop bc\n");          /* discard LHS16 + RHS spill */
+    g_expr_type = TYPE_INT;
+}
+
+/*
+ * Compare fallback for a float RHS that the predicted common type put at long
+ * (e.g. "longvar < (fa * fb)" or "longvar < s->f").  On entry the 32-bit long
+ * LHS is on top of the stack (pushed by the caller as push de;push hl) and the
+ * float RHS is in DE:HL.  Widen the long LHS to float and lay out canonical
+ * deep=LHS / top=RHS so emit_float_compare_call computes LHS op RHS.  Result
+ * int 0/1 in HL; the stack is fully balanced.
+ */
+void gen_float_cmp_long_lhs(int op, int lhs_type)
+{
+    /* spill the float RHS above the 4-byte long LHS */
+    emit("\tpush de\n\tpush hl\n");                  /* [LHSlong][RHSf] */
+    /* reload the long LHS (now at SP+4) into DE:HL and widen it to float */
+    emit("\tld hl,4\n\tadd hl,sp\n");
+    emit("\tld e,(hl)\n\tinc hl\n\tld d,(hl)\n\tinc hl\n");
+    emit("\tld a,(hl)\n\tinc hl\n\tld h,(hl)\n\tld l,a\n");
+    emit("\tex de,hl\n");                            /* DE:HL = LHS long */
+    emit_convert_int_to_float(lhs_type);              /* DE:HL = (float)LHS */
+    emit("\tpush de\n\tpush hl\n");                  /* [LHSlong][RHSf][LHSf] */
+    /* reload the spilled RHS float (now the 4 bytes at SP+4) */
+    emit("\tld hl,4\n\tadd hl,sp\n");
+    emit("\tld e,(hl)\n\tinc hl\n\tld d,(hl)\n\tinc hl\n");
+    emit("\tld a,(hl)\n\tinc hl\n\tld h,(hl)\n\tld l,a\n");
+    emit("\tex de,hl\n");                            /* DE:HL = RHS float */
+    emit("\tpush de\n\tpush hl\n");                  /* [LHSlong][RHSf][LHSf][RHSf] */
+    emit_float_compare_call(op);                      /* pops LHSf+RHSf; HL = 0/1 */
+    emit("\tpop bc\n\tpop bc\n\tpop bc\n\tpop bc\n"); /* discard LHSlong + RHS spill */
+    g_expr_type = TYPE_INT;
+}
+
 void gen_rel(void)
 {
     int op;
@@ -1269,26 +1464,22 @@ void gen_rel(void)
             emit_cast_16_to_common(lhs_type, common_type);
             emit("\tpush de\n\tpush hl\n");
             gen_shift();
-            emit_cast_16_to_common(g_expr_type, common_type);
-            gen_binop32_typed(op, common_type);
+            if (type_is_float(g_expr_type)) {
+                /* RHS generated a float though the predicted common type was
+                 * long (hidden float the peek could not see).  Widen the
+                 * stacked long LHS and compare as float. */
+                gen_float_cmp_long_lhs(op, common_type);
+            } else {
+                emit_cast_16_to_common(g_expr_type, common_type);
+                gen_binop32_typed(op, common_type);
+            }
         } else {
             emit("\tpush hl\n");
             gen_shift();
             if (type_is_long(g_expr_type)) {
-                /*
-                 * peek_simple_unary_type only sees the first term of the RHS,
-                 * so a compound RHS such as "y + la" (long) was mis-predicted
-                 * as 16-bit.  The RHS is actually long in DE:HL while only the
-                 * 16-bit LHS was pushed; widen the LHS and compare as 32-bit
-                 * with the operands swapped (the RHS becomes gen_cmp32's
-                 * stacked left operand, so the relop is inverted).
-                 */
-                int ct = common_arith_type(lhs_type, g_expr_type);
-                emit("\tpop bc\n");
-                emit("\tpush de\n\tpush hl\n");
-                emit("\tld h,b\n\tld l,c\n");
-                emit_cast_16_to_common(lhs_type, ct);
-                gen_cmp32(invert_relop_for_swap(op), ct);
+                gen_cmp_promote_16lhs(op, lhs_type);
+            } else if (type_is_float(g_expr_type)) {
+                gen_float_cmp_16lhs(op, lhs_type);
             } else {
                 emit("\tex de,hl\n\tpop hl\n");
                 gen_binop_typed(op, common_type);
@@ -1327,24 +1518,22 @@ void gen_eq(void)
             emit_cast_16_to_common(lhs_type, common_type);
             emit("\tpush de\n\tpush hl\n");
             gen_rel();
-            emit_cast_16_to_common(g_expr_type, common_type);
-            gen_binop32_typed(op, common_type);
+            if (type_is_float(g_expr_type)) {
+                /* RHS generated a float though the predicted common type was
+                 * long (hidden float the peek could not see).  Widen the
+                 * stacked long LHS and compare as float. */
+                gen_float_cmp_long_lhs(op, common_type);
+            } else {
+                emit_cast_16_to_common(g_expr_type, common_type);
+                gen_binop32_typed(op, common_type);
+            }
         } else {
             emit("\tpush hl\n");
             gen_rel();
             if (type_is_long(g_expr_type)) {
-                /*
-                 * Equality with a compound long RHS (e.g. "y + la") that
-                 * peek_simple_unary_type mis-predicted as 16-bit.  Widen the
-                 * 16-bit LHS and compare as 32-bit; == / != are commutative,
-                 * so the swapped-operand form is equivalent.
-                 */
-                int ct = common_arith_type(lhs_type, g_expr_type);
-                emit("\tpop bc\n");
-                emit("\tpush de\n\tpush hl\n");
-                emit("\tld h,b\n\tld l,c\n");
-                emit_cast_16_to_common(lhs_type, ct);
-                gen_cmp32(invert_relop_for_swap(op), ct);
+                gen_cmp_promote_16lhs(op, lhs_type);
+            } else if (type_is_float(g_expr_type)) {
+                gen_float_cmp_16lhs(op, lhs_type);
             } else {
                 emit("\tex de,hl\n\tpop hl\n");
                 gen_binop_typed(op, common_type);
@@ -1460,7 +1649,13 @@ void gen_bor(void)
 
 void emit_test_expr_nonzero(int expr_type, int true_label, int branch_when_true)
 {
-    if (type_is_long(expr_type))
+    if (type_is_float(expr_type))
+        /* A float is false only for +0.0 and -0.0.  Mask the sign bit (bit 7
+         * of D) so -0.0 (0x80000000) tests as zero too, then OR the remaining
+         * magnitude bytes: A==0 iff the value is +/-0.0.  The float lives in
+         * DE:HL with D holding the sign/exponent MSB. */
+        emit("\tld a,d\n\tand 7fh\n\tor e\n\tor h\n\tor l\n");
+    else if (type_is_long(expr_type))
         emit("\tld a,h\n\tor l\n\tor d\n\tor e\n");
     else
         emit("\tld a,h\n\tor l\n");
@@ -1529,6 +1724,399 @@ void gen_lor(void)
     }
 }
 
+/*
+ * ---------------------------------------------------------------------------
+ * Type-only expression oracle.
+ *
+ * typeof_conditional_arm() resolves the C type of the conditional-expression
+ * beginning at the current token WITHOUT emitting code and WITHOUT advancing
+ * the parser: the public entry saves and restores all lexer/token state, so a
+ * bug in the walker can only produce a wrong *type verdict*, never corrupt the
+ * token stream that real codegen re-parses afterwards.
+ *
+ * The internal to_* ladder mirrors the codegen gen_* precedence ladder
+ * one-for-one, so the type it reports matches what codegen ultimately produces
+ * under the usual arithmetic conversions (float dominates long dominates
+ * unsigned dominates int) and the pointer-arithmetic rules.  Unlike
+ * peek_simple_unary_type, which classifies only a single leading unary
+ * operand, the oracle recurses through parentheses, casts, every binary level
+ * and nested conditionals, so a float hidden arbitrarily deep is resolved:
+ *   (float)y      x + fa*fb      s->f      a ? 1 : b ? 2 : 3.5f
+ *
+ * gen_conditional uses it to decide whether a conditional expression's result
+ * is float - and therefore whether the already-generated selected arm must be
+ * converted to float - without needing the false arm's type before the false
+ * arm is generated.
+ * ---------------------------------------------------------------------------
+ */
+static int to_comma(void);
+static int to_assign(void);
+static int to_conditional(void);
+static int to_unary(void);
+
+/* Usual-arithmetic-conversion balance for the two arms of ?:, including the
+ * pointer cases common_arith_type does not model. */
+static int to_balance(int a, int b)
+{
+    if (type_is_float(a) || type_is_float(b))
+        return TYPE_FLOAT;
+    if (type_ptr_depth(a) > 0)
+        return a;
+    if (type_ptr_depth(b) > 0)
+        return b;
+    return common_arith_type(a, b);
+}
+
+static int to_postfix(void)
+{
+    int tt;
+    int is_arr;
+    int dim_count;
+    int base_type;
+    int nsubs;
+    struct Sym *s;
+
+    if (tok.kind == TOK_NUM) {
+        if (tok.val > 0xffffL || tok.val < -32768L || g_tok_long_suffix)
+            tt = TYPE_LONG;
+        else
+            tt = TYPE_INT;
+        if (g_tok_unsigned_suffix)
+            tt |= TYPE_UNSIGNED;
+        next_token();
+        return promote_int_type(tt);
+    }
+    if (tok.kind == TOK_CHARLIT) { next_token(); return TYPE_INT; }
+    if (tok.kind == TOK_FLOATLIT) { next_token(); return TYPE_FLOAT; }
+    if (tok.kind == TOK_STR || tok.kind == TOK_WSTR) {
+        int wide = (tok.kind == TOK_WSTR);
+        while (tok.kind == TOK_STR || tok.kind == TOK_WSTR)
+            next_token();
+        return (wide ? TYPE_INT : TYPE_CHAR) | TYPE_PTR;
+    }
+
+    /* Resolve the primary, seeding the array-tracking state used by the
+     * shared postfix-suffix walk below. */
+    if (tok.kind == '(') {
+        next_token();
+        tt = to_comma();          /* inner expression: already value-decayed */
+        if (tok.kind == ')')
+            next_token();
+        is_arr = 0;
+        dim_count = 0;
+        base_type = tt;
+        nsubs = 0;
+    } else if (tok.kind == TOK_ID) {
+        s = find_sym(tok.text);
+        if (!s) {
+            /* enum constant or unknown identifier behaves like int */
+            next_token();
+            return TYPE_INT;
+        }
+        /* Port of peek_simple_unary_type's id + subscript/member chain. */
+        tt = s->type;
+        is_arr = s->is_array;
+        dim_count = s->dim_count;
+        base_type = s->type;
+        nsubs = 0;
+        next_token();
+    } else {
+        return TYPE_INT;
+    }
+
+    for (;;) {
+        if (tok.kind == '[') {
+            skip_balanced_bracket('[', ']');
+            nsubs++;
+            if (is_arr) {
+                if (dim_count > 0 && nsubs < dim_count)
+                    tt = type_add_ptr(base_type);
+                else
+                    tt = base_type;
+                if (dim_count <= 0 || nsubs >= dim_count)
+                    is_arr = 0;
+                continue;
+            } else if (dim_count > 0 && type_ptr_depth(base_type) > 0) {
+                if (nsubs <= dim_count)
+                    tt = type_add_ptr(type_decay_ptr(base_type));
+                else
+                    tt = type_decay_ptr(base_type);
+                continue;
+            } else {
+                tt = type_decay_ptr(tt);
+                continue;
+            }
+        }
+        if (tok.kind == '.' || tok.kind == TOK_ARROW) {
+            struct FieldDef *fd;
+            int sid;
+            next_token();
+            if (tok.kind != TOK_ID)
+                break;
+            sid = base_struct_id_from_type(tt);
+            fd = find_field_def(sid, tok.text);
+            if (!fd)
+                break;
+            tt = fd->is_array ? fd->elem_type : fd->type;
+            is_arr = fd->is_array;
+            dim_count = fd->dim_count;
+            base_type = fd->elem_type;
+            nsubs = 0;
+            next_token();
+            continue;
+        }
+        if (tok.kind == '(') {
+            /* Call: through a pointer yields int (this compiler only
+             * models int-returning function pointers); a plain function
+             * symbol's stored type is already its return type. */
+            skip_balanced_bracket('(', ')');
+            if (type_ptr_depth(tt) > 0)
+                tt = TYPE_INT;
+            is_arr = 0;
+            continue;
+        }
+        if (tok.kind == TOK_INC || tok.kind == TOK_DEC) {
+            next_token();
+            continue;
+        }
+        break;
+    }
+
+    /* An array expression that was never fully subscripted decays to a
+     * pointer-to-element in value context, exactly as gen_primary does
+     * (g_expr_type = type_add_ptr(val_type)).  Without this a bare float
+     * array such as `fa` in `c ? fp : fa` was reported as float, which made
+     * the conditional oracle mis-convert the pointer arms to float. */
+    if (is_arr)
+        tt = type_add_ptr(tt);
+    return tt;
+}
+
+static int to_unary(void)
+{
+    int t;
+
+    if (paren_starts_cast()) {
+        int ct;
+        int sz;
+        expect('(');
+        parse_type_name_decl(&ct, &sz);
+        expect(')');
+        (void)to_unary();             /* cast operand; its type is discarded */
+        return ct;                    /* a cast value has the cast's type */
+    }
+    if (tok.kind == '!') { next_token(); (void)to_unary(); return TYPE_INT; }
+    if (tok.kind == '~') { next_token(); return promote_int_type(to_unary()); }
+    if (tok.kind == '-' || tok.kind == '+') { next_token(); return promote_int_type(to_unary()); }
+    if (tok.kind == '*') {
+        next_token();
+        t = type_decay_ptr(to_unary());
+        if ((t & 15) == TYPE_VOID)
+            t = TYPE_CHAR;
+        return t;
+    }
+    if (tok.kind == '&') { next_token(); return type_add_ptr(to_unary()); }
+    if (tok.kind == TOK_INC || tok.kind == TOK_DEC) { next_token(); return to_unary(); }
+    if (tok.kind == TOK_SIZEOF) {
+        next_token();
+        if (tok.kind == '(') {
+            next_token();
+            if (starts_type()) {
+                int tt;
+                int ss;
+                parse_type_name_decl(&tt, &ss);
+                if (tok.kind == ')')
+                    next_token();
+            } else {
+                (void)to_comma();
+                if (tok.kind == ')')
+                    next_token();
+            }
+        } else {
+            (void)to_unary();
+        }
+        return TYPE_INT | TYPE_UNSIGNED;
+    }
+    return to_postfix();
+}
+
+static int to_mul(void)
+{
+    int t = to_unary();
+    while (tok.kind == '*' || tok.kind == '/' || tok.kind == '%') {
+        next_token();
+        t = common_arith_type(t, to_unary());
+    }
+    return t;
+}
+
+static int to_add(void)
+{
+    int t = to_mul();
+    while (tok.kind == '+' || tok.kind == '-') {
+        int op = tok.kind;
+        int r;
+        next_token();
+        r = to_mul();
+        if (type_ptr_depth(t) > 0) {
+            if (op == '-' && type_ptr_depth(r) > 0)
+                t = TYPE_INT;             /* ptr - ptr -> ptrdiff (int) */
+            /* else ptr +/- int -> ptr (t unchanged) */
+        } else if (op == '+' && type_ptr_depth(r) > 0) {
+            t = r;                        /* int + ptr -> ptr */
+        } else {
+            t = common_arith_type(t, r);
+        }
+    }
+    return t;
+}
+
+static int to_shift(void)
+{
+    int t = to_add();
+    while (tok.kind == TOK_SHL || tok.kind == TOK_SHR) {
+        next_token();
+        (void)to_add();
+        t = promote_int_type(t);          /* result is the promoted left operand */
+    }
+    return t;
+}
+
+static int to_rel(void)
+{
+    int t = to_shift();
+    while (tok.kind == '<' || tok.kind == '>' || tok.kind == TOK_LE || tok.kind == TOK_GE) {
+        next_token();
+        (void)to_shift();
+        t = TYPE_INT;
+    }
+    return t;
+}
+
+static int to_eq(void)
+{
+    int t = to_rel();
+    while (tok.kind == TOK_EQ || tok.kind == TOK_NE) {
+        next_token();
+        (void)to_rel();
+        t = TYPE_INT;
+    }
+    return t;
+}
+
+static int to_band(void)
+{
+    int t = to_eq();
+    while (tok.kind == '&') {
+        next_token();
+        t = common_arith_type(t, to_eq());
+    }
+    return t;
+}
+
+static int to_bxor(void)
+{
+    int t = to_band();
+    while (tok.kind == '^') {
+        next_token();
+        t = common_arith_type(t, to_band());
+    }
+    return t;
+}
+
+static int to_bor(void)
+{
+    int t = to_bxor();
+    while (tok.kind == '|') {
+        next_token();
+        t = common_arith_type(t, to_bxor());
+    }
+    return t;
+}
+
+static int to_land(void)
+{
+    int t = to_bor();
+    while (tok.kind == TOK_ANDAND) {
+        next_token();
+        (void)to_bor();
+        t = TYPE_INT;
+    }
+    return t;
+}
+
+static int to_lor(void)
+{
+    int t = to_land();
+    while (tok.kind == TOK_OROR) {
+        next_token();
+        (void)to_land();
+        t = TYPE_INT;
+    }
+    return t;
+}
+
+static int to_conditional(void)
+{
+    int t = to_lor();
+    if (tok.kind == '?') {
+        int mt;
+        int ft;
+        next_token();
+        mt = to_comma();              /* middle arm is a full expression */
+        if (tok.kind == ':')
+            next_token();
+        ft = to_conditional();        /* false arm is a conditional-expression */
+        t = to_balance(mt, ft);
+    }
+    return t;
+}
+
+static int to_assign(void)
+{
+    int t = to_conditional();
+    /* An assignment's value has the (unconverted) type of its left operand,
+     * which is the conditional-expression just parsed. */
+    if (is_assignment_token(tok.kind)) {
+        next_token();
+        (void)to_assign();
+    }
+    return t;
+}
+
+static int to_comma(void)
+{
+    int t = to_assign();
+    while (tok.kind == ',') {
+        next_token();
+        t = to_assign();
+    }
+    return t;
+}
+
+static int typeof_conditional_arm(void)
+{
+    long save_pos = posi;
+    long save_tok_start = tok_start_pos;
+    int save_line = line_no;
+    int save_tok_line = tok_line;
+    int save_long_suffix = g_tok_long_suffix;
+    int save_unsigned_suffix = g_tok_unsigned_suffix;
+    struct Token save_tok = tok;
+    int t;
+
+    t = to_conditional();
+
+    posi = save_pos;
+    tok_start_pos = save_tok_start;
+    line_no = save_line;
+    tok_line = save_tok_line;
+    g_tok_long_suffix = save_long_suffix;
+    g_tok_unsigned_suffix = save_unsigned_suffix;
+    tok = save_tok;
+    return t;
+}
+
 void gen_conditional(void)
 {
     int lfalse;
@@ -1536,6 +2124,7 @@ void gen_conditional(void)
     int true_type;
     int false_type;
     int need_long_result;
+    int result_is_float;
 
     gen_lor();
 
@@ -1543,40 +2132,49 @@ void gen_conditional(void)
         lfalse = new_label();
         lend = new_label();
 
-        if (type_is_long(g_expr_type))
-            emit("\tld a,h\n\tor l\n\tor d\n\tor e\n");
-        else
-            emit("\tld a,h\n\tor l\n");
-        emit_jp_label("jp z,", lfalse);
+        emit_test_expr_nonzero(g_expr_type, lfalse, 0);
 
         gen_expr();
         true_type = g_expr_type;
         if (type_is_struct_object(true_type))
             error_here("unsupported struct conditional expression");
 
+        expect(':');
+
         /*
-         * C's conditional operator applies the usual conversions between the
-         * second and third operands.  DCC does not have a full typed IR, so a
-         * narrow true arm used with a long false arm could leave DE stale.
-         *
-         * Example from tarray.c:
-         *     int32_t cap = (end_of_row > beyond) ? beyond : end_of_row;
-         *
-         * beyond is 16-bit size_t, end_of_row is 32-bit int32_t.  Without
-         * extending the true arm, selecting beyond stores a garbage high word.
-         *
-         * Extending a 16-bit true arm here is safe when the whole expression is
-         * ultimately 16-bit: callers/stores that want int use HL and ignore DE.
+         * C's conditional operator applies the usual arithmetic conversions
+         * between the second and third operands, so if either arm is float the
+         * whole expression is float.  The true arm has already been generated
+         * (its value is in DE:HL); resolve the not-yet-generated false arm's
+         * type with the side-effect-free oracle so the already-generated arm
+         * can be converted to float when needed.  The oracle restores parser
+         * state, so the real false-arm generation below is unaffected.
          */
-        need_long_result = type_is_long(true_type);
-        if (!type_is_long(true_type) && !type_is_float(true_type)) {
-            emit_extend_to_long((true_type & TYPE_UNSIGNED) ||
-                                (true_type & (TYPE_PTR | TYPE_PTR2)));
+        result_is_float = type_is_float(true_type) ||
+                          type_is_float(typeof_conditional_arm());
+
+        need_long_result = 0;
+
+        if (result_is_float) {
+            if (!type_is_float(true_type))
+                emit_convert_int_to_float(true_type);
+        } else {
+            /*
+             * DCC has no full typed IR, so a narrow true arm used with a long
+             * false arm could leave DE stale.  Speculatively widen a 16-bit
+             * true arm to long; that is safe when the whole expression is
+             * ultimately 16-bit because consumers read HL and ignore DE.
+             * (tarray.c: int32_t cap = (end_of_row > beyond) ? beyond : end_of_row;)
+             */
+            need_long_result = type_is_long(true_type);
+            if (!type_is_long(true_type)) {
+                emit_extend_to_long((true_type & TYPE_UNSIGNED) ||
+                                    (true_type & (TYPE_PTR | TYPE_PTR2)));
+            }
         }
 
         emit_jp_label("jp", lend);
 
-        expect(':');
         emit_label(lfalse);
 
         gen_conditional();
@@ -1584,18 +2182,25 @@ void gen_conditional(void)
         if (type_is_struct_object(false_type))
             error_here("unsupported struct conditional expression");
 
-        if (type_is_long(false_type))
-            need_long_result = 1;
+        if (result_is_float) {
+            if (!type_is_float(false_type))
+                emit_convert_int_to_float(false_type);
+        } else {
+            if (type_is_long(false_type))
+                need_long_result = 1;
 
-        if (need_long_result && !type_is_long(false_type) && !type_is_float(false_type)) {
-            emit_extend_to_long((false_type & TYPE_UNSIGNED) ||
-                                (false_type & (TYPE_PTR | TYPE_PTR2)));
-            false_type = (false_type & TYPE_UNSIGNED) ? (TYPE_LONG | TYPE_UNSIGNED) : TYPE_LONG;
+            if (need_long_result && !type_is_long(false_type)) {
+                emit_extend_to_long((false_type & TYPE_UNSIGNED) ||
+                                    (false_type & (TYPE_PTR | TYPE_PTR2)));
+                false_type = (false_type & TYPE_UNSIGNED) ? (TYPE_LONG | TYPE_UNSIGNED) : TYPE_LONG;
+            }
         }
 
         emit_label(lend);
 
-        if (need_long_result) {
+        if (result_is_float) {
+            g_expr_type = TYPE_FLOAT;
+        } else if (need_long_result) {
             if ((true_type & TYPE_UNSIGNED) || (false_type & TYPE_UNSIGNED))
                 g_expr_type = TYPE_LONG | TYPE_UNSIGNED;
             else

--- a/tctxflt.c
+++ b/tctxflt.c
@@ -1,0 +1,367 @@
+/*
+ * tctxflt.c - parenthesized/compound float operands in arithmetic and compares.
+ *
+ * Regression for the "peek blind spot" class: peek_simple_unary_type only
+ * inspects the first token of a binary operator's right-hand side, so a
+ * parenthesized or otherwise compound RHS such as  x + (fa * fb)  was
+ * mis-predicted as 16-bit and the float operand was dropped.  The fix makes
+ * the post-generation type (g_expr_type) authoritative: after the RHS is
+ * generated, an actual float operand routes through the float helpers in both
+ * value context (gen_add/gen_mul) and comparison context (gen_rel/gen_eq and
+ * the if-condition direct-branch path).
+ *
+ * Each value is forced through a function call so the operands are real
+ * runtime values (not constant-folded) and the compound RHS is genuinely
+ * parenthesized at the point the operator is generated.
+ *
+ * Prints exactly one summary line so runall captures a stable result.
+ */
+#include <stdio.h>
+
+static int fails;
+
+static void chk(long got, long want, const char *name)
+{
+    if (got != want) {
+        printf("FAIL %s got=%ld want=%ld\n", name, got, want);
+        fails++;
+    }
+}
+
+/* ---- value context: int LHS, parenthesized float RHS ---- */
+
+static long add_pf(int x, float a, float b)   { return (long)(x + (a * b)); }
+static long sub_pf(int x, float a, float b)   { return (long)(x - (a * b)); }   /* non-commutative */
+static long mul_pf(int x, float a, float b)   { return (long)(x * (a + b)); }
+static long div_pf(int x, float a, float b)   { return (long)(x / (a + b)); }   /* non-commutative */
+
+/* ---- value context: unsigned LHS, parenthesized float RHS ---- */
+static long uadd_pf(unsigned u, float a, float b) { return (long)(u + (a * b)); }
+
+/* ---- compare context (value of relational expression) ---- */
+static int lt_pf(int x, float a, float b)     { return x < (a * b); }
+static int ge_pf(int x, float a, float b)     { return x >= (a * b); }
+static int eq_pf(int x, float a, float b)     { return x == (a + b); }
+static int ne_pf(int x, float a, float b)     { return x != (a + b); }
+
+/* ---- compare context inside an if-condition (direct-branch path) ---- */
+static int if_lt_pf(int x, float a, float b)
+{
+    if (x < (a * b))
+        return 1;
+    return 0;
+}
+
+static int if_gt_pf(int x, float a, float b)
+{
+    if (x > (a * b))
+        return 100;
+    return 0;
+}
+
+/* ---- direct-branch context with a float HIDDEN from the snippet pre-scan ----
+ * These are not float literals or float-typed identifiers, so the condition
+ * pre-scan cannot classify them as float; the codegen must fall back on the
+ * type computed after generating the operand.
+ */
+struct flt_box { int i; float f; };
+
+/* RHS cast-to-float */
+static int if_rhs_cast_lt(int x, int y) { if (x < (float)y) return 1; return 0; }
+static int if_rhs_cast_eq(int x, int y) { if (x == (float)y) return 1; return 0; }
+/* LHS cast-to-float (variable RHS) */
+static int if_lhs_cast_lt(int x, int y) { if ((float)x < y) return 1; return 0; }
+/* LHS cast-to-float, integer constant RHS (the constant-RHS fast path) */
+static int if_lhs_cast_const(int x) { if ((float)x < 10) return 1; return 0; }
+/* RHS struct-member float (hidden, not a cast) */
+static int if_rhs_memb_lt(int x, struct flt_box *s) { if (x < s->f) return 1; return 0; }
+/* LHS struct-member float */
+static int if_lhs_memb_lt(struct flt_box *s, int x) { if (s->f < x) return 1; return 0; }
+
+/* ---- long operand mixed with a hidden float (the long-branch blind spot) ----
+ * Here one side is a 32-bit long, so the snippet/peek pre-analysis predicts a
+ * long common type; the other side is a hidden float (a cast, a typedef cast,
+ * or a struct member).  The codegen must promote the long to float once the
+ * operand's real type is known instead of casting the float bits to long.
+ * Both the direct-branch (if) path and the value path are covered, including
+ * unsigned long (which needs the unsigned long->float conversion).
+ */
+typedef float flt_t;
+
+static int l_lt_cast(long l, int y)  { if (l < (float)y) return 1; return 0; }
+static int l_ge_cast(long l, int y)  { if (l >= (float)y) return 1; return 0; }
+static int l_eq_cast(long l, int y)  { if (l == (float)y) return 1; return 0; }
+static int cast_lt_l(int x, long l)  { if ((float)x < l) return 1; return 0; }
+static int l_lt_memb(long l, struct flt_box *s) { if (l < s->f) return 1; return 0; }
+static int memb_gt_l(struct flt_box *s, long l) { if (s->f > l) return 1; return 0; }
+static int l_lt_tdef(long l, int y) { if (l < (flt_t)y) return 1; return 0; }
+static int ul_lt_cast(unsigned long u, int y) { if (u < (float)y) return 1; return 0; }
+static int l_lt_pf(long l, float a, float b)   { return l < (a * b); }
+static long l_sub_pf(long l, float a, float b) { return (long)(l - (a * b)); }
+
+/* ---- hidden float CONSTANT in an ordered direct branch ----
+ * The long-vs-constant inline compare (try_emit_long_cmp_const_branch) and the
+ * all-constant relational fold must NOT treat a cast-to-float constant as an
+ * integer.  (float)16777217L rounds to 16777216.0f in single precision, so
+ * 2^24 is NOT less than it.  The integer-only constant folder would compare
+ * 16777216 < 16777217 and wrongly answer "true"; the codegen must convert the
+ * long to float and compare with single-precision rounding instead.
+ */
+static int l_lt_fk(long l)     { if (l < (float)16777217L) return 1; return 0; }
+static int l_ge_fk(long l)     { if (l >= (float)16777217L) return 1; return 0; }
+static int l_lt_fkexpr(long l) { if (l < (float)(16777216L + 1L)) return 1; return 0; }
+static int allconst_lt_fk(void){ if (16777216L < (float)16777217L) return 1; return 0; }
+
+/* ---- float truth-value testing in if / ! / ?: / && / || ----
+ * A float is true iff its magnitude is nonzero; +0.0 and -0.0 are both false.
+ * The condition test must inspect the whole 32-bit payload (sign bit masked),
+ * not just the low word HL, or e.g. 1.0f (0x3F800000, low word 0) reads false.
+ */
+static int truth_if(float f)         { if (f) return 1; return 0; }
+static int truth_not(float f)        { return !f; }
+static int truth_tern(float f)       { return f ? 1 : 0; }
+static int truth_and(float f, int x) { return (f && x) ? 1 : 0; }
+static int truth_or(float f, int x)  { return (f || x) ? 1 : 0; }
+static int truth_memb(struct flt_box *s) { if (s->f) return 1; return 0; }
+
+/* (float) cast inside an integer constant expression must round in single
+ * precision: (long)(float)16777217L is 16777216, not 16777217. */
+static long cfk_static = (long)(float)16777217L;
+static int  cfk_arr[(int)(float)5];
+enum { CFK_ENUM = (int)(float)5 };
+
+/* ---- conditional operator with mixed float / non-float arms ----
+ * The usual arithmetic conversions make the whole ?: float if either result
+ * arm is float.  The true arm is generated before the false arm is parsed, so
+ * the codegen must look ahead and convert the selected arm to the common float
+ * type; otherwise an integer arm leaves raw integer bits where a float is
+ * expected.  Covers int/float, float/int, long/float, a float hidden in a
+ * compound arm, and a float hidden in a nested conditional arm.
+ */
+static long cond_if(int c)            { return (long)(c ? 2 : 3.5f); }
+static long cond_fi(int c)            { return (long)(c ? 2.5f : 3); }
+static long cond_lf(int c)            { return (long)(c ? 16777216L : 3.5f); }
+static long cond_compound(int c, float f) { return (long)(c ? 2 : (f + 1.0f)); }
+static long cond_nested(int a, int b) { return (long)(a ? 1 : b ? 2 : 3.5f); }
+
+/* The type oracle resolves a float reachable only through a struct member or a
+ * cast buried inside a NESTED ternary arm - shapes a shallow token scan misses
+ * but a full type walk catches.  s->f / (float)y make the whole expression
+ * float, so the selected integer arm is converted. */
+static long cond_nmemb(int a, int b, struct flt_box *s) { return (long)(a ? 1 : b ? 2 : s->f); }
+static long cond_ncast(int a, int b, int y) { return (long)(a ? 1 : b ? 2 : (float)y); }
+
+/* A bare float ARRAY expression decays to float* in value context; the oracle
+ * must report the conditional arm as pointer, not float, or a ternary of float
+ * arrays passed to a float* parameter pushes float bits instead of the pointer. */
+static float cflt_a[4];
+static float *cflt_p;
+static long use_fptr(float *p) { return (long)p[1]; }
+static long cond_arr_ptr(int c) { return use_fptr(c ? cflt_p : cflt_a); }
+
+/* ---- value context: long vs hidden float, ALL six relops ----
+ * Only "<" was covered above; each relop has its own gen_rel/gen_eq long-branch
+ * float fallback, so exercise gt/le/ge/eq/ne too. a*b = 10.0. */
+static int l_gt_pf(long l, float a, float b) { return l > (a * b); }
+static int l_le_pf(long l, float a, float b) { return l <= (a * b); }
+static int l_ge_pf(long l, float a, float b) { return l >= (a * b); }
+static int l_eq_pf(long l, float a, float b) { return l == (a * b); }
+static int l_ne_pf(long l, float a, float b) { return l != (a * b); }
+
+/* ---- non-commutative long+float arithmetic (only subtract was covered) ---- */
+static long l_mul_pf(long l, float a, float b) { return (long)(l * (a + b)); }
+static long l_div_pf(long l, float a, float b) { return (long)(l / (a + b)); }
+/* result float threads through a chain of mixed ops */
+static long chain_pf(long l, float a, float b) { return (long)(l + (a * b) + 2.0f); }
+/* negative long mixed with hidden float: signed long->float conversion */
+static int neg_l_lt(long l, int y) { if (l < (float)y) return 1; return 0; }
+static long neg_l_add(long l, float a, float b) { return (long)(l + (a * b)); }
+
+/* ---- float truthiness in loop conditions + via array elem / func return ----
+ * if/!/?:/&&/|| were covered above; while/for/do-while are distinct statement
+ * paths, and the operand can hide a float behind an array index or a call. */
+static float tf_arr[2];
+static float tf_ret(int y) { return (float)y; }
+static int truth_while(float f) { int n = 0; while (f) { n++; f = 0.0f; } return n; }
+static int truth_for(float f) { int n = 0; int i; for (i = 0; f && i < 3; i++) n++; return n; }
+static int truth_do(float f, int lim) { int n = 0; do { n++; if (n >= lim) f = 0.0f; } while (f); return n; }
+static int truth_elem(float *a, int i) { if (a[i]) return 1; return 0; }
+static int truth_call(int y) { if (tf_ret(y)) return 1; return 0; }
+static int truth_not_memb(struct flt_box *s) { return !s->f; }
+
+/* ---- (float) cast in more integer-constant-expression contexts ----
+ * negative, unsigned, and a case label all flow through parse_const_long_primary. */
+static long cfk_neg = (long)(float)(-16777217L);
+static long cfk_un = (long)(unsigned)(float)5;
+static int cfk_case(long v) { switch (v) { case (long)(float)16777216L: return 1; default: return 0; } }
+
+/* ---- conditional operator: oracle precision cases ----
+ * float-returning call arm (leaf float), comparison-result arm (stays int),
+ * float only in a nested CONDITION (result arms all int -> stays int-correct). */
+static long cond_callarm(int c, int y) { return (long)(c ? 2 : tf_ret(y)); }
+static int cond_cmparm(int c, int x) { return c ? 1 : (x < 5); }
+static long cond_condfloat(int c, float f) { return (long)(c ? 7 : (f > 0.0f ? 8 : 9)); }
+
+/* ---- conditional array-decay: more shapes the oracle must report as pointer ----
+ * true-arm array, struct array field, multidim row, cast-to-pointer arm, and a
+ * string-literal arm (char*, never float). */
+struct ad_row { float v[3]; int n; };
+static float ad_a[4];
+static float *ad_p;
+static struct ad_row ad_rows[2];
+static float ad_m[2][3];
+static long ad_true_arm(int c) { float *p; p = c ? ad_a : ad_p; return (long)p[1]; }
+static long ad_field(int c) { float *p; p = c ? ad_rows[0].v : ad_rows[1].v; return (long)p[1]; }
+static long ad_multidim(int c) { float *p; p = c ? ad_m[0] : ad_m[1]; return (long)p[1]; }
+static int ad_castptr(int c, float *q) { float *p; p = c ? (float *)0 : q; return p == q; }
+static int ad_strarm(int c, char *s) { char *p; p = c ? "hi" : s; return p[0]; }
+
+int main(void)
+{
+    struct flt_box box;
+
+    fails = 0;
+    box.i = 0;
+    box.f = 10.0f;
+
+    /* value arithmetic: 3 + 2.5*4.0 = 13 ; 3 - 10 = -7 ; 3*(2.5+1.5)=12 ; 30/(2.5+0.5)=10 */
+    chk(add_pf(3, 2.5f, 4.0f), 13L, "add_pf");
+    chk(sub_pf(3, 2.5f, 4.0f), -7L, "sub_pf");
+    chk(mul_pf(3, 2.5f, 1.5f), 12L, "mul_pf");
+    chk(div_pf(30, 2.5f, 0.5f), 10L, "div_pf");
+    chk(uadd_pf(5u, 2.0f, 3.0f), 11L, "uadd_pf");
+
+    /* relational value context */
+    chk(lt_pf(3, 2.5f, 4.0f), 1L, "lt_pf");     /* 3 < 10 */
+    chk(lt_pf(20, 2.5f, 4.0f), 0L, "lt_pf2");   /* 20 < 10 -> 0 */
+    chk(ge_pf(20, 2.5f, 4.0f), 1L, "ge_pf");    /* 20 >= 10 */
+    chk(eq_pf(7, 3.0f, 4.0f), 1L, "eq_pf");     /* 7 == 7.0 */
+    chk(ne_pf(7, 3.0f, 4.0f), 0L, "ne_pf");     /* 7 != 7.0 -> 0 */
+
+    /* if-condition direct-branch context */
+    chk(if_lt_pf(3, 2.5f, 4.0f), 1L, "if_lt_pf");    /* 3 < 10 */
+    chk(if_lt_pf(20, 2.5f, 4.0f), 0L, "if_lt_pf2");  /* 20 < 10 -> 0 */
+    chk(if_gt_pf(20, 2.5f, 4.0f), 100L, "if_gt_pf"); /* 20 > 10 */
+    chk(if_gt_pf(3, 2.5f, 4.0f), 0L, "if_gt_pf2");   /* 3 > 10 -> 0 */
+
+    /* direct-branch context, float hidden from the snippet pre-scan */
+    chk(if_rhs_cast_lt(3, 10), 1L, "if_rhs_cast_lt");     /* 3 < 10.0 */
+    chk(if_rhs_cast_lt(20, 10), 0L, "if_rhs_cast_lt2");   /* 20 < 10.0 -> 0 */
+    chk(if_rhs_cast_eq(7, 7), 1L, "if_rhs_cast_eq");      /* 7 == 7.0 */
+    chk(if_rhs_cast_eq(8, 7), 0L, "if_rhs_cast_eq2");     /* 8 == 7.0 -> 0 */
+    chk(if_lhs_cast_lt(3, 10), 1L, "if_lhs_cast_lt");     /* 3.0 < 10 */
+    chk(if_lhs_cast_lt(20, 10), 0L, "if_lhs_cast_lt2");   /* 20.0 < 10 -> 0 */
+    chk(if_lhs_cast_const(3), 1L, "if_lhs_cast_const");   /* 3.0 < 10 */
+    chk(if_lhs_cast_const(20), 0L, "if_lhs_cast_const2"); /* 20.0 < 10 -> 0 */
+    chk(if_rhs_memb_lt(3, &box), 1L, "if_rhs_memb_lt");   /* 3 < 10.0 */
+    chk(if_rhs_memb_lt(20, &box), 0L, "if_rhs_memb_lt2"); /* 20 < 10.0 -> 0 */
+    chk(if_lhs_memb_lt(&box, 20), 1L, "if_lhs_memb_lt");  /* 10.0 < 20 */
+    chk(if_lhs_memb_lt(&box, 3), 0L, "if_lhs_memb_lt2");  /* 10.0 < 3 -> 0 */
+
+    /* long mixed with a hidden float: direct-branch path (long-branch blind spot) */
+    chk(l_lt_cast(3L, 10), 1L, "l_lt_cast");     chk(l_lt_cast(20L, 10), 0L, "l_lt_cast2");
+    chk(l_ge_cast(10L, 10), 1L, "l_ge_cast");    chk(l_ge_cast(9L, 10), 0L, "l_ge_cast2");
+    chk(l_eq_cast(7L, 7), 1L, "l_eq_cast");      chk(l_eq_cast(8L, 7), 0L, "l_eq_cast2");
+    chk(cast_lt_l(3, 10L), 1L, "cast_lt_l");     chk(cast_lt_l(20, 10L), 0L, "cast_lt_l2");
+    chk(l_lt_memb(3L, &box), 1L, "l_lt_memb");   chk(l_lt_memb(20L, &box), 0L, "l_lt_memb2");
+    chk(memb_gt_l(&box, 3L), 1L, "memb_gt_l");   chk(memb_gt_l(&box, 20L), 0L, "memb_gt_l2");
+    chk(l_lt_tdef(3L, 10), 1L, "l_lt_tdef");     chk(l_lt_tdef(20L, 10), 0L, "l_lt_tdef2");
+    chk(ul_lt_cast(5UL, 10), 1L, "ul_lt_cast");  chk(ul_lt_cast(0x80000000UL, 1), 0L, "ul_lt_cast2");
+    /* long mixed with a hidden float: value path */
+    chk(l_lt_pf(3L, 2.5f, 4.0f), 1L, "l_lt_pf"); chk(l_lt_pf(20L, 2.5f, 4.0f), 0L, "l_lt_pf2");
+    chk(l_sub_pf(100L, 2.5f, 4.0f), 90L, "l_sub_pf");
+
+    /* hidden float CONSTANT in an ordered direct branch (no integer mis-fold).
+     * (float)16777217L rounds to 16777216.0f, so 2^24 is not < it. */
+    chk(l_lt_fk(16777216L), 0L, "l_lt_fk");        /* 2^24 < 16777216.0f -> 0 */
+    chk(l_lt_fk(16777215L), 1L, "l_lt_fk2");       /* 2^24-1 < 16777216.0f -> 1 */
+    chk(l_ge_fk(16777216L), 1L, "l_ge_fk");        /* 2^24 >= 16777216.0f -> 1 */
+    chk(l_lt_fkexpr(16777216L), 0L, "l_lt_fkexpr");/* cast of const expr, same -> 0 */
+    chk(allconst_lt_fk(), 0L, "allconst_lt_fk");   /* 16777216.0f < 16777216.0f -> 0 */
+
+    /* float truth-value testing: nonzero is true, +/-0.0 is false */
+    chk(truth_if(1.0f), 1L, "truth_if_one");       /* low word 0, must still be true */
+    chk(truth_if(0.0f), 0L, "truth_if_zero");
+    chk(truth_if(-0.0f), 0L, "truth_if_negzero");  /* -0.0 is false */
+    chk(truth_not(0.0f), 1L, "truth_not_zero");
+    chk(truth_not(2.0f), 0L, "truth_not_two");
+    chk(truth_tern(1.0f), 1L, "truth_tern_one");
+    chk(truth_tern(0.0f), 0L, "truth_tern_zero");
+    chk(truth_and(1.0f, 1), 1L, "truth_and_TT");
+    chk(truth_and(0.0f, 1), 0L, "truth_and_FT");
+    chk(truth_or(0.0f, 0), 0L, "truth_or_FF");
+    chk(truth_or(0.0f, 1), 1L, "truth_or_FT");
+    chk(truth_memb(&box), 1L, "truth_memb");       /* box.f == 10.0 */
+
+    /* (float) cast in an integer constant expression rounds in single prec */
+    chk(cfk_static, 16777216L, "cfk_static");
+    chk((long)(sizeof(cfk_arr) / sizeof(cfk_arr[0])), 5L, "cfk_arr_dim");
+    chk((long)CFK_ENUM, 5L, "cfk_enum");
+
+    /* conditional operator: mixed float / non-float arms convert to float */
+    chk(cond_if(1), 2L, "cond_if_T");   chk(cond_if(0), 3L, "cond_if_F");   /* 3.5f -> 3 */
+    chk(cond_fi(1), 2L, "cond_fi_T");   chk(cond_fi(0), 3L, "cond_fi_F");   /* 2.5f -> 2 */
+    chk(cond_lf(1), 16777216L, "cond_lf_T"); chk(cond_lf(0), 3L, "cond_lf_F");
+    chk(cond_compound(0, 2.0f), 3L, "cond_compound"); /* 2.0+1.0 -> 3 */
+    chk(cond_nested(1, 0), 1L, "cond_nested_a");
+    chk(cond_nested(0, 1), 2L, "cond_nested_b");
+    chk(cond_nested(0, 0), 3L, "cond_nested_c"); /* 3.5f -> 3 */
+    chk(cond_nmemb(0, 0, &box), 10L, "cond_nmemb"); /* box.f 10.0 -> 10 */
+    chk(cond_ncast(0, 0, 5), 5L, "cond_ncast");     /* (float)5 -> 5 */
+    cflt_a[0] = 4.0f; cflt_a[1] = 7.0f; cflt_p = cflt_a;
+    chk(cond_arr_ptr(1), 7L, "cond_arr_ptr_T");     /* bare float array decays to float* */
+    chk(cond_arr_ptr(0), 7L, "cond_arr_ptr_F");
+
+    /* value-context long vs hidden float: all six relops (a*b = 10.0) */
+    chk(l_gt_pf(20L, 2.5f, 4.0f), 1L, "l_gt_pf");  chk(l_gt_pf(5L, 2.5f, 4.0f), 0L, "l_gt_pf2");
+    chk(l_le_pf(10L, 2.5f, 4.0f), 1L, "l_le_pf");  chk(l_le_pf(11L, 2.5f, 4.0f), 0L, "l_le_pf2");
+    chk(l_ge_pf(10L, 2.5f, 4.0f), 1L, "l_ge_pf");  chk(l_ge_pf(9L, 2.5f, 4.0f), 0L, "l_ge_pf2");
+    chk(l_eq_pf(10L, 2.5f, 4.0f), 1L, "l_eq_pf");  chk(l_eq_pf(11L, 2.5f, 4.0f), 0L, "l_eq_pf2");
+    chk(l_ne_pf(11L, 2.5f, 4.0f), 1L, "l_ne_pf");  chk(l_ne_pf(10L, 2.5f, 4.0f), 0L, "l_ne_pf2");
+
+    /* non-commutative long+float arithmetic + chained + negative */
+    chk(l_mul_pf(3L, 2.5f, 1.5f), 12L, "l_mul_pf");   /* 3 * 4.0 */
+    chk(l_div_pf(30L, 2.0f, 1.0f), 10L, "l_div_pf");  /* 30 / 3.0 */
+    chk(chain_pf(3L, 2.5f, 4.0f), 15L, "chain_pf");   /* 3 + 10.0 + 2.0 */
+    chk(neg_l_lt(-20L, -10), 1L, "neg_l_lt");   chk(neg_l_lt(-5L, -10), 0L, "neg_l_lt2");
+    chk(neg_l_add(-20L, 2.5f, 4.0f), -10L, "neg_l_add"); /* -20 + 10.0 */
+
+    /* float truthiness in loop conditions + hidden via array elem / call / !member */
+    tf_arr[0] = 0.0f; tf_arr[1] = 2.0f;
+    chk(truth_while(1.0f), 1L, "truth_while_one");  chk(truth_while(0.0f), 0L, "truth_while_zero");
+    chk(truth_for(1.0f), 3L, "truth_for_one");      chk(truth_for(0.0f), 0L, "truth_for_zero");
+    chk(truth_do(1.0f, 3), 3L, "truth_do_three");   chk(truth_do(0.0f, 3), 1L, "truth_do_zero");
+    chk(truth_elem(tf_arr, 1), 1L, "truth_elem_nz"); chk(truth_elem(tf_arr, 0), 0L, "truth_elem_z");
+    chk(truth_call(3), 1L, "truth_call_nz");        chk(truth_call(0), 0L, "truth_call_z");
+    chk(truth_not_memb(&box), 0L, "truth_not_memb"); /* !10.0 -> 0 */
+
+    /* (float) cast in more integer-constant contexts */
+    chk(cfk_neg, -16777216L, "cfk_neg");            /* (float)-16777217 rounds */
+    chk(cfk_un, 5L, "cfk_un");
+    chk((long)cfk_case(16777216L), 1L, "cfk_case_hit");
+    chk((long)cfk_case(16777217L), 0L, "cfk_case_miss");
+
+    /* conditional operator: oracle precision cases */
+    chk(cond_callarm(1, 9), 2L, "cond_callarm_T"); chk(cond_callarm(0, 9), 9L, "cond_callarm_F");
+    chk((long)cond_cmparm(0, 3), 1L, "cond_cmparm_lt"); chk((long)cond_cmparm(0, 9), 0L, "cond_cmparm_ge");
+    chk((long)cond_cmparm(1, 9), 1L, "cond_cmparm_sel");
+    chk(cond_condfloat(1, 1.0f), 7L, "cond_condfloat_T");
+    chk(cond_condfloat(0, 1.0f), 8L, "cond_condfloat_F8");
+    chk(cond_condfloat(0, -1.0f), 9L, "cond_condfloat_F9");
+
+    /* conditional array-decay shapes: each arm denotes float* (or char*), not float */
+    ad_a[0] = 1.0f; ad_a[1] = 7.0f; ad_p = ad_a;
+    ad_rows[0].v[1] = 2.0f; ad_rows[1].v[1] = 5.0f;
+    ad_m[0][1] = 2.0f; ad_m[1][1] = 5.0f;
+    chk(ad_true_arm(1), 7L, "ad_true_arm_T"); chk(ad_true_arm(0), 7L, "ad_true_arm_F");
+    chk(ad_field(1), 2L, "ad_field_T");       chk(ad_field(0), 5L, "ad_field_F");
+    chk(ad_multidim(1), 2L, "ad_multidim_T"); chk(ad_multidim(0), 5L, "ad_multidim_F");
+    chk((long)ad_castptr(1, ad_a), 0L, "ad_castptr_T"); chk((long)ad_castptr(0, ad_a), 1L, "ad_castptr_F");
+    chk((long)ad_strarm(1, "Z"), (long)'h', "ad_strarm_T"); chk((long)ad_strarm(0, "Z"), (long)'Z', "ad_strarm_F");
+
+    if (fails == 0)
+        printf("tctxflt passed with great success\n");
+    else
+        printf("tctxflt FAILED with %d error(s)\n", fails);
+    return 0;
+}


### PR DESCRIPTION
**⚠️ Merge order: this PR must merge AFTER c99-for-init-scope and block-scope-stack.
Required order: (1) c99-for-init-scope → (2) block-scope-stack → (3) this PR (expr-type-authoritative). It is branched off block-scope-stack and will not apply cleanly to main until both predecessors land.**


codegen: make the post-generation type authoritative; add a type oracle; fix float/long/const-fold blind spots

Situation before this PR
------------------------
dcc is a single-pass, syntax-directed compiler with no AST: code generation is
interleaved with parsing, so it must choose 16-bit / 32-bit / float code for an
operand *before* that operand is generated. It did this with a shallow
source-text lookahead (peek_simple_unary_type / snippet_simple_type) that
inspects only the first token or two of the upcoming operand.

That shallow guess is the root of a recurring "type blind-spot" bug class: any
type hidden behind parentheses, a cast, a struct member, an array decay, or a
nested conditional was mis-predicted, and wrong-width code was emitted -- a
float operand silently dropped to 16 bits, a long high word lost, or a pointer
treated as a float. Concretely, the following all miscompiled:

  * float hidden in a parenthesized/compound binary operand, e.g.
    x + (fa * fb), in both value and compare context;
  * a long mixed with a hidden float (cast, typedef cast, or struct member) in
    comparisons and in +/-/*// arithmetic, including unsigned long;
  * a hidden float CONSTANT in an ordered direct branch or an all-constant
    compare: the integer-only constant folder evaluated (float)16777217L as the
    integer 16777217, ignoring single-precision rounding, so
    16777216L < (float)16777217L was wrongly true;
  * a (float) cast inside an integer constant expression (static initializer,
    array bound, enum value, case label) -- same missing single-precision
    rounding;
  * float truth-value testing: if/while/for/do-while/?:/!/&&/|| tested only the
    low word in HL, so a nonzero float whose low word is 0 (e.g. 1.0f =
    0x3F800000) read as false, and -0.0f was not treated as false;
  * the conditional operator with mixed float / non-float arms: the selected
    integer arm was left as raw integer bits where a float was expected;
  * a bare float array in a ?: arm was typed as float instead of float*, so a
    ternary of float arrays passed to a float* parameter pushed float bits
    instead of the pointer.

What this PR fixes
------------------
* Authoritative computed type. After an operand is generated, the actual
  result type (g_expr_type) -- not the predictive peek -- drives float/long
  fallbacks in gen_mul/gen_add and gen_rel/gen_eq, plus the if-condition
  direct-branch path. Shared helpers convert a stacked 16-bit or long LHS to
  float (or widen to 32-bit) when the RHS turns out wider than predicted.

* Single-precision constant rounding. The cf_* folder declines to fold a cast
  to float (forcing the runtime float path), and the integer constant-
  expression parser rounds (float) casts through host single precision, so
  constant and direct-branch float comparisons match runtime semantics.

* Float truthiness. emit_test_expr_nonzero now tests the whole 32-bit float
  payload with the sign bit masked, so every nonzero float is true and both
  +0.0 and -0.0 are false; the ternary and ! paths route through it.

* Conditional operator. gen_conditional applies the usual arithmetic
  conversions: if either arm is float the whole expression is float and the
  selected arm is converted before the branches join.

* Type oracle (the architectural addition). A side-effect-free, type-only walk
  of the full expression grammar -- typeof_conditional_arm() plus the to_*
  precedence ladder in dcc_ops.c -- resolves an operand's C type without
  emitting code and without advancing the parser (it snapshots and restores all
  lexer/token state, so a walker bug can only mis-report a type, never desync
  the parser). It is a "1.5-pass" technique: complete whole-expression type
  information with no AST and no second code-generating pass. gen_conditional
  uses it to decide whether a ?: is float, which fixes floats hidden behind a
  cast / struct member / nested ?: arm and gives correct array-to-pointer decay.

* Tests + docs. New regression test tctxflt.c covers every case above
  (value/compare/branch float blind spots, long+float, const-fold rounding,
  float truthiness across all condition forms, mixed-arm and array-decay
  ternaries); wired into runall.sh / runall.bat with a baseline entry. The C89
  reference guide gains float precision / %-is-integer-only / float-truthiness
  gotchas, and src/dcc/README.md documents the type-oracle architecture.

Verified: full runall.sh ntvcm is green in both peephole and non-peephole
modes -- the filtered diff (excluding __DATE__/__TIME__) is empty, so every
existing app's output is unchanged; only previously-miscompiled programs change.