### PR TITLE
docs(skill): restructure c89-cpm-z80 skill by-exception; add 8.3 file…

### DIFF
--- a/.github/skills/c89-cpm-z80/SKILL.md
+++ b/.github/skills/c89-cpm-z80/SKILL.md
@@ -1,116 +1,92 @@
 ---
 name: c89-cpm-z80
-description: 'Write, build, test, and debug C89 code for the dcc compiler targeting CP/M 2.2 on the Z80 (e.g. run under the ntvcm Altair 8800 emulator). Use when working on .c/.h sources compiled with dcc, or when the task mentions dcc, CP/M, CP/M 2.2, Z80, ntvcm, DCCRTL, ma.sh, VT100/ANSI terminal apps for CP/M, or the no-double single-precision-float constraint. dcc is TRUE C89 (prototypes, void, const, typedef, enum, and K&R definitions all accepted) and also accepts some C99 conveniences (for-init declarations, // line comments, block-scoped variables, inline). Hard constraints to respect: no double (32-bit float is the only floating type), 16-bit int/short, 32-bit long, 16-bit pointers, 16-bit size_t. Full library/printf/scanf inventory and hard-won pitfalls are in the reference files.'
+description: 'Write, build, test, and debug C89 code for the dcc compiler targeting CP/M 2.2 on the Z80 (run under the ntvcm Altair 8800 emulator). Use for .c/.h sources compiled with dcc, or tasks mentioning dcc, CP/M, CP/M 2.2, Z80, ntvcm, DCCRTL, ma.sh, or VT100/ANSI CP/M terminal apps. Treat dcc as standard C89 plus a few C99 conveniences (for-init decls, // comments, block scope, inline-ignored) EXCEPT for the deviations this skill documents: no double (32-bit float is the only floating type), 16-bit int/short/pointer/size_t, 32-bit long, signed char, and a subset library (no atof/strtod; no locale/signal/time). Full library/printf/scanf inventory and pitfalls are in the reference files.'
 argument-hint: 'Describe the C89/CP-M task (write code, build, run under ntvcm, debug a failure)'
 ---
 
 # C89 for dcc (CP/M 2.2 / Z80)
 
-dcc is a C89 compiler that emits Z80 assembly for CP/M 2.2.
-The runtime is [DCCRTL.MAC](DCCRTL.MAC). Programs run on
-real CP/M hardware or an emulator such as **ntvcm** (Altair 8800).
+dcc is a cross-compiler (runs on the host) that emits Z80 assembly for CP/M 2.2.
+The runtime is [DCCRTL.MAC](DCCRTL.MAC); programs run on real hardware or an
+emulator such as **ntvcm** (Altair 8800).
+
+**Assume standard C89 plus the C99 conveniences listed below.** This skill
+documents only where dcc *deviates* from what an experienced C programmer
+expects — anything not listed here behaves as standard C89/C99.
 
 ## When to use
 
-- Writing, porting, or reviewing C source intended to be compiled by `dcc`.
+- Writing, porting, or reviewing C compiled by `dcc`.
 - Building/running/debugging a dcc program (`ma.sh`, `ntvcm`).
-- Any task touching CP/M file I/O, VT100/ANSI console UIs, or DCCRTL.
+- CP/M file I/O, VT100/ANSI console UIs, or DCCRTL work.
 
-## Golden rules
+## Deviations from standard C
 
-1. **No `double`. Ever.** `float` (32-bit IEEE single) is the *only* floating
-   type. The `double` keyword is not recognised — using it is a compile error.
-   Write `float`, and use `f`-suffixed literals (`3.14f`). Unsuffixed float
-   constants are already `float`, not `double`.
-2. **`int` is 16-bit** (±32767). Use `long` (32-bit) + `%ld` when you need
-   more range. Watch for silent overflow in loops, sizes, and accumulators.
-3. **Pointers and `size_t` are 16-bit.** `ptrdiff_t` is `int`. Flat 64 KB space.
-4. **`char` is signed by default.** Use `unsigned char` for byte/`>=0x80` work.
-5. **The library is a subset.** No `atof`/`strtod` (both return `double`), no
-   `<locale.h>`/`<signal.h>`/`<time.h>`. `<math.h>` now has the full
-   single-precision set (trig, exp/log, hyperbolic, decomposition); `strtol`/
-   `strtoul`/`strtok` are present. See
-   [references/library.md](./references/library.md) before assuming a function exists.
-6. **`%f` needs `-ffloatio`.** Float `printf` formatting isn't linked unless you
-   pass that flag. Without it, `%f` won't work.
-7. **CP/M filenames are 8.3, uppercase.** The `.COM` is named after the source
-   (`foo.c` → `FOO.COM`); run it as `ntvcm FOO`.
+**Types — a 16-bit machine:**
 
-## Type model
+| Type | dcc | Note |
+| ---- | --- | ---- |
+| `int` / `short` | 16-bit | overflow at ±32767; use `long` + `%ld` for range |
+| `long` | 32-bit | |
+| `float` | 32-bit | **the only floating type** |
+| `double` / `long double` | — | **not a keyword; using it is a compile error** |
+| pointer / `size_t` / `ptrdiff_t` / `wchar_t` | 16-bit | flat 64 KB space |
+| `char` | 8-bit **signed** | use `unsigned char` for bytes ≥ 0x80 / table indices |
+| `FILE` | `int` | |
 
-At a glance: `char` 8-bit (signed), `short`/`int` 16-bit, `long` 32-bit,
-`float` 32-bit (the only floating type), pointers / `size_t` / `ptrdiff_t` /
-`wchar_t` all 16-bit, `FILE` is `int`. Full annotated table in
-[references/library.md](./references/library.md).
+Multi-byte values are little-endian (Z80-native).
 
-## Language support
+**Floating point is single-precision only:**
 
-dcc is C89 at heart but **accepts a handful of C99 conveniences**: `for`-init
-declarations with real loop scope (`for (int i = 0; ...)`), `//` line comments,
-block-scoped variable storage (inner `{ ... }` declarations shadow outer ones),
-and `inline` (parsed, ignored). Details below.
+- Write `float`; unsuffixed constants (`3.14`) are already `float`, not `double`.
+- No `float`→`double` promotion in varargs (there is no double), so
+  `printf("%f", x)` consumes a 32-bit `float` directly — but **requires the
+  `-ffloatio` build flag**; without it `%f` silently does nothing.
+- `<math.h>` provides the full single-precision set (`sinf`/`expf`/`powf`/… each
+  with an unsuffixed alias that stays single-precision), but the transcendentals
+  are ~5–6-digit polynomial approximations.
+- No `atof`/`strtod` (both return `double`) — parse decimals yourself
+  (`strtol`/`strtoul` handle integers). Worked parser in pitfalls.md.
 
-- **31 of 32 C89 keywords.** Only `double` is missing. Everything else
-  (`struct`, `union`, `enum`, `typedef`, `const`, `volatile`, `sizeof`, all
-  control flow, all storage classes) is recognised.
-- **Inert but accepted:** `const` (constant-folds initializers only; not
-  read-only memory), `volatile` (ignored), `register` (hint only), `auto`
-  (no-op). `inline` is accepted as a C99 extension and ignored.
-- **C99 `for`-init declarations are supported** with real loop scope:
-  `for (int i = 0; i < n; i++)` declares `i` only for the loop, so it shadows
-  (does not clobber) an outer same-named variable and is invisible after the
-  loop. Multiple declarators (`for (int i = 0, j = n; ...)`) and pointer/array
-  declarators scope the same way.
-- **Block scope is fully modeled.** A variable declared in an inner `{ ... }`
-  block (including `if`/`while`/`for`/`switch` bodies) shadows an outer
-  same-named local or parameter for that block only and is invisible once the
-  block ends — sibling blocks may safely reuse a name, and an inner block may
-  shadow a `for`-init loop variable.
-- **C99 `//` line comments are supported** alongside C89 `/* ... */` block
-  comments — including trailing comments on `#define` lines (stripped like
-  block comments before macro replacement). Both forms are correctly ignored
-  inside string and character literals (e.g. `"http://..."` stays intact).
-- **K&R function definitions are accepted** (dcc's typing is lenient), but
-  prefer prototypes for new code. Mixed decls/statements and block-local
-  variables are fine (real C89).
-- **Full C89 operator set**, including bitwise `&` `|` `^` `~` `<<` `>>` and
-  their compound forms (`&=` `|=` `^=` `<<=` `>>=`). `>>` is **arithmetic**
-  (sign-extending) on signed operands and **logical** (zero-fill) on unsigned —
-  use `unsigned`/`unsigned long` when you need a guaranteed zero-fill shift.
-  Shifts act at the operand width (16-bit for `int`; cast/promote to `long`
-  for wider shifts).
-- No other C99/C11 features (`restrict`, `_Bool`, VLAs, compound literals,
-  designated initializers).
+**The library is a subset.** A missing function is a **link** error
+(`unresolved external`), not a compile error, so check
+[references/library.md](./references/library.md) before assuming one exists.
+Notably absent: `atof`/`strtod`, `<locale.h>`/`<signal.h>`/`<time.h>`, and
+some stdio entries (`fgetc`, `ungetc`, `rename`, …).
 
-## Identifier significance
+**printf/scanf are a subset.** No `+`/space/`#` flags and no `*`
+width/precision; scanf is integer/string only (no `%f`, scansets, `%n`, `%p`).
+Conversion tables in library.md.
 
-C89 guarantees significance of at least **31 characters** for internal
-identifiers and at least **6** (case-insensitive) for external (global /
-function) ones. dcc satisfies both, so you never need to shorten names for the
-toolchain (this is *not* BDS C's 7-char rule):
+**No stack/heap guard.** Heap and stack share memory and can collide silently.
+Size the stack with `-stack N` (default 512); keep big buffers `static`/global.
 
-- Internal names (locals, `static` file-scope names) keep their full spelling.
-- External names stay distinct well past the 6 characters C89 requires (verified
-  to at least the first 13 characters in this toolchain). Only externals sharing
-  a very long prefix (~16+ identical leading characters, far beyond what C89
-  promises or normal code uses) can silently collide at link time; make such a
-  one-file helper `static` if it ever matters.
+**Source filenames MUST be 8.3 and uppercase-safe** (≤ 8-char base, ≤ 3-char
+extension, no extra dots). `foo.c` → `FOO.COM`, run as `ntvcm FOO`. A source
+whose name violates 8.3 (e.g. `my_long_name.c`, `parse.test.c`) won't build —
+ntvcm reports `argument is not a valid CP/M 8.3 filename`; rename the file when
+you see that error.
 
-## Floating point: single precision only
+**Missing `<...>` headers are silently ignored** — calls fall back to implicit
+`int` and still link via the runtime, with no type-checking. A missing
+`"..."` header is fatal. If standard calls compile but misbehave, check that
+`-I` actually resolves the dcc headers.
 
-- `float` is 32-bit; there is no `double` or `long double`.
-- `<math.h>` provides a full single-precision library: rounding/remainder/roots
-  (`fabsf`, `floorf`, `ceilf`, `sqrtf`, `fmodf`, `nextafterf`), exp/log
-  (`expf`, `logf`, `log10f`, `powf`), trig (`sinf`, `cosf`, `tanf`, `asinf`,
-  `acosf`, `atanf`, `atan2f`), hyperbolic (`sinhf`, `coshf`, `tanhf`), and
-  decomposition (`frexpf`, `ldexpf`, `modff`) — each with an **unsuffixed alias**
-  (`sin`, `cos`, `exp`, `pow`, …) that stays single-precision. The
-  transcendentals are polynomial approximations (~5–6 digits), not full `float`
-  accuracy.
-- No `atof`/`strtod`. To parse decimals to `float`, write a small parser
-  (`strtol`/`strtoul` handle integers).
-- `printf("%f", x)` requires the `-ffloatio` compile flag and consumes a 32-bit
-  `float` (there is no float→double default promotion, because there's no double).
+## C99 conveniences dcc accepts (beyond C89)
+
+These behave as standard C99: `for`-init declarations with loop scope, `//` line
+comments, block-scoped declarations (inner blocks shadow outer names), and
+`inline` (parsed, ignored). `const`/`volatile`/`register`/`auto` are accepted
+but inert (`const` constant-folds initializers only — not read-only memory).
+K&R function definitions are still accepted; prefer prototypes for new code.
+
+Not present: any other C99/C11 feature (`restrict`, `_Bool`, VLAs, compound
+literals, designated initializers).
+
+**Identifiers:** full internal significance; externals stay distinct well past
+C89's 6-char minimum (verified to ~13 chars), and only ~16+ identical leading
+characters can silently collide at link time — make such a one-file helper
+`static` if it ever matters. (This is *not* BDS C's 7-char rule.)
 
 ## Build and run
 
@@ -129,6 +105,11 @@ export DCC=./dcc DCCPEEP=./dccpeep DCCRTLSTRIP=./dccrtlstrip
 ntvcm FOO             # run it (uppercase, no extension)
 ntvcm FOO ARG1 ARG2   # with CP/M command-line args
 ```
+
+> The source name passed to `ma.sh` must be 8.3-clean (base ≤ 8 chars,
+> extension ≤ 3, no extra dots). ntvcm reports
+> `argument is not a valid CP/M 8.3 filename` for a non-conforming name —
+> rename the file when you see it.
 
 **Useful `dcc` options:** `-o file` (output .mac), `-c`/`-module` (linkable
 module), `-f`/`-ffloatio` (float printf), `-stack N`/`-s N`/`--stack N` (reserve
@@ -155,37 +136,25 @@ resolves the dcc headers.
 Notes: M80 needs CRLF (`ma.sh` converts). `RTLMIN.MAC` is generated per-app by
 `dccrtlstrip` during the build — don't hand-edit it.
 
-## Top pitfalls (details in references/pitfalls.md)
+## Top pitfalls
 
-- **No `double`** — `float` is the only floating type; no `atof`/`strtod`.
-  (`<math.h>` *does* now provide single-precision transcendentals.)
-- **`%f` silently does nothing without `-ffloatio`.**
-- **16-bit `int`/`size_t` overflow** in sizes/indices/accumulators — promote to
-  `long` (and `%ld`).
-- **`char` is signed** — use `unsigned char` for bytes `>= 0x80` and table indices.
-- **CP/M filenames are 8.3** and ntvcm asserts on extensions `> 3` chars — delete
-  stray `.DS_Store` before running a directory-enumerating program.
-- **No stack/heap guard** — size the stack with `-stack N`; keep big buffers
-  `static`/global.
-
-See [references/pitfalls.md](./references/pitfalls.md) for worked examples and
-[references/library.md](./references/library.md) for the full function inventory,
-`printf`/`scanf` conversion tables, and which headers/functions are absent.
+The deviations above are the pitfalls. For worked examples (the `float` decimal
+parser, `%f`/`-ffloatio`, 16-bit overflow, signed `char`, CP/M 8.3 names, the
+stack/heap collision) see [references/pitfalls.md](./references/pitfalls.md);
+for the full function inventory and `printf`/`scanf` conversion tables see
+[references/library.md](./references/library.md).
 
 ## Workflow
 
-1. **Confirm the constraint surface.** If the code uses floating point, plan for
-   single precision (no `double`); if it parses decimals, plan a `float` parser
-   (no `atof`). If it needs `time`/`signal`/`locale`, those headers don't exist.
+1. **Plan for the deviations.** Floating point → single precision (no `double`);
+   decimal parsing → a `float` parser (no `atof`); `time`/`signal`/`locale` →
+   don't exist.
 2. **Check the library** in [references/library.md](./references/library.md)
-   before calling anything you haven't verified — a missing function is a link
-   error (`unresolved external`), not a compile error.
+   before calling anything unverified — a missing function is a link error,
+   not a compile error.
 3. **Match repo conventions.** Read a nearby working program first. In the dcc
-   repo, the authoritative, exhaustive reference is
+   repo, the exhaustive reference is
    [dcc-c89-reference-guide.md](dcc-c89-reference-guide.md) at the repo root.
-4. **Write idiomatic C89** for the 16-bit model; prefer `long`/`%ld` where range
-   matters; use `unsigned char` for byte work.
-5. **Build and run**: `./ma.sh <name> peep && ntvcm <NAME>`. Add `-ffloatio`
-   (via the program's build path) if you use `%f`.
-6. **Verify behaviour** by running the program under `ntvcm` (redirect stdin
-   for interactive apps). Compare against expected output for your own program.
+4. **Build and run**: `./ma.sh <name> peep && ntvcm <NAME>` (add the `-ffloatio`
+   path if you use `%f`); redirect stdin for interactive apps and compare
+   against expected output.

--- a/.github/skills/c89-cpm-z80/references/library.md
+++ b/.github/skills/c89-cpm-z80/references/library.md
@@ -6,8 +6,12 @@ function (implicit `int`), referencing something the runtime doesn't provide
 fails at **link** time (`unresolved external`), not compile time. The shipped
 headers are a hand-written minimal subset, so an entry point can exist in the
 runtime without a prototype (the heap symbols `_brk`/`_hlimit` are the deliberate
-case) — declare those yourself. This file lists what the runtime actually
-provides, plus the `printf`/`scanf` conversion subset.
+case) — declare those yourself.
+
+**Assume standard C89 behaviour for every function listed as implemented.** This
+file documents only the deviations: the subset boundary (what's present /
+absent), dcc **extensions** beyond C89, the supported `printf`/`scanf`
+conversions, and a few behavioural quirks.
 
 > Inside the dcc repo, `dcc-c89-reference-guide.md` at the repo root is the
 > exhaustive source; this file is the portable summary for use anywhere.
@@ -20,35 +24,16 @@ provides, plus the `printf`/`scanf` conversion subset.
 > found is **silently ignored** (calls fall back to implicit `int`), whereas a
 > missing `"..."` header is fatal.
 
-## Type sizes
+## Type sizes and byte order
 
-| Type            | Size    | Notes                                            |
-| --------------- | ------- | ------------------------------------------------ |
-| `char`          | 8 bits  | **signed** by default                            |
-| `short`, `int`  | 16 bits | `int` is 16-bit — overflow at ±32767             |
-| `long`          | 32 bits | use `%ld` / the `l` length modifier              |
-| `float`         | 32 bits | **the only floating type — no `double`**         |
-| pointer         | 16 bits | flat CP/M address space                          |
-| `size_t`        | 16 bits | unsigned `int`                                   |
-| `ptrdiff_t`     | 16 bits | `int`                                            |
-| `wchar_t`       | 16 bits | `unsigned int` (for `L"..."`)                    |
-| `FILE`          | 16 bits | `typedef int FILE` — streams are small handles   |
+The full type table is in SKILL.md (16-bit `int`/ptr/`size_t`, 32-bit `long`,
+32-bit `float` as the only floating type, signed `char`, `FILE` is `int`).
+`wchar_t` is 16-bit (`unsigned int`, for `L"..."`).
 
-### Byte order (endianness)
-
-All multi-byte types are stored **little-endian** in memory (Z80-native): the
-least-significant byte is at the lowest address.
-
-- `short`/`int`/pointer (2 bytes): byte 0 = bits 0–7, byte 1 = bits 8–15.
-- `long` (4 bytes): byte 0 = bits 0–7 … byte 3 = bits 24–31.
-- `float` (4-byte IEEE-754 single): byte 0 = least-significant mantissa byte;
-  byte 3 = sign bit + top exponent bits.
-
-So `((unsigned char *)&n)[0]` is always the low byte. This matters when you
-`fread`/`fwrite` binary records (on-disk order is little-endian), alias a value
-through a `union` or `char *`, or hand-build multi-byte BDOS/FCB fields. (The
-runtime's internal `DE:HL` register pairing with `DE` = high word is just a
-calling convention, not the memory layout.)
+Multi-byte values are **little-endian** (Z80-native): `((unsigned char *)&n)[0]`
+is the low byte. Matters for `fread`/`fwrite` of binary records, `union`/`char *`
+aliasing, and hand-built BDOS/FCB fields. (The runtime's internal `DE:HL`
+pairing with `DE` = high word is a calling convention, not the memory layout.)
 
 ## Useful constants
 
@@ -117,17 +102,10 @@ formatting engine and conversion subset as `printf`, so you can write your own
 `rand`, `srand`. `div_t`/`ldiv_t`, `EXIT_SUCCESS`/`EXIT_FAILURE`, `RAND_MAX`
 (32767).
 
-- Heap shares memory with the stack — there is **no stack/heap guard** (size the
-  stack with `-stack`; keep big buffers `static`/global).
-- `realloc(NULL,n)` == `malloc(n)`; `realloc(p,0)` frees and returns `NULL`.
-- `qsort`/`bsearch` take the standard comparator `int cmp(const void *a, const void *b)`;
-  on equal keys `bsearch` may return any matching element.
-- `atoi`/`atol` skip leading space, accept `+`/`-`, stop at first non-digit;
-  overflow wraps modulo the type width.
-- `strtol`/`strtoul` are the full C89 conversions: base 2..36 (0 = auto-detect
-  `0x`/`0` prefixes), optional sign, `endptr` reports the unused tail, and they
-  set `errno` to `ERANGE` and clamp to `LONG_MAX`/`LONG_MIN`/`ULONG_MAX` on
-  overflow. `strtoul` also accepts a leading `-` (value negated modulo 2^32).
+- These behave per standard C89 (`malloc`/`realloc`/`free`, `qsort`/`bsearch`
+  with `int cmp(const void *, const void *)`, `atoi`/`atol`, `strtol`/`strtoul`
+  full base-2..36 conversions). Quirk: heap shares memory with the stack —
+  **no stack/heap guard** (size with `-stack`; keep big buffers `static`/global).
 - `inp(port)`/`outp(port,val)` are a **dcc extension** (declared in
   `<stdlib.h>`, not C89): direct Z80 8-bit port I/O. `inp` runs `IN A,(port)`
   and returns the byte zero-extended to `int` (0..255); `outp` runs
@@ -227,10 +205,10 @@ integers, or a small hand-written `float` parser for decimals.
 
 ## setjmp.h / stdarg.h / stddef.h
 
-- `setjmp`/`longjmp`; `jmp_buf` is 8 bytes (return address, SP, IX).
-- `va_start`, `va_arg`, `va_end`; `va_list` is a `char *` walking the frame.
-- `size_t`, `ptrdiff_t`, `wchar_t`, `NULL`, `offsetof(type, member)`
-  (compiler builtin `__offsetof`; supports nested members and constant indexes).
+Standard C89 (`setjmp`/`longjmp`, `va_start`/`va_arg`/`va_end`, `size_t`/
+`ptrdiff_t`/`wchar_t`/`NULL`/`offsetof`). dcc specifics: `jmp_buf` is 8 bytes
+(return address, SP, IX); `va_list` is a `char *` walking the frame; `offsetof`
+is the builtin `__offsetof` (supports nested members and constant indexes).
 
 ## unistd.h / fcntl.h (low-level CP/M file I/O)
 
@@ -245,9 +223,8 @@ Flags from `<fcntl.h>`: `O_RDONLY` (0), `O_WRONLY` (1), `O_RDWR` (2),
 
 ## errno.h / assert.h
 
-- `extern int errno;` (single-threaded). Pair with `perror`/`strerror`.
-- `assert(expr)` prints to `stderr` and `exit(1)` when false; `#define NDEBUG`
-  to compile out.
+Standard C89: `extern int errno;`, `assert(expr)` (compile out with `NDEBUG`).
+File errnos: `ENOENT`, `EACCES`, `EMFILE`, `ENOSPC`, … (plus `EDOM`/`ERANGE`).
 
 ## CP/M BDOS escape hatch
 

--- a/.github/skills/c89-cpm-z80/references/pitfalls.md
+++ b/.github/skills/c89-cpm-z80/references/pitfalls.md
@@ -1,19 +1,13 @@
-# dcc C89 pitfalls and idioms
+# dcc C89 pitfalls — worked examples
 
-Genuine, general gotchas when writing or porting C89 for dcc (CP/M 2.2 / Z80).
-Each has a symptom and a fix.
+SKILL.md lists the deviations from standard C; this file adds symptom→fix
+detail and code for the ones that need it. (Anything not covered behaves as
+standard C89.)
 
-## No `double` (the headline constraint)
+## Parsing a decimal string to `float` (no `atof`/`strtod`)
 
-- `double` is not a recognised keyword — using it is a **compile error**. Use
-  `float` (32-bit) everywhere.
-- Unsuffixed floating constants like `3.14` are already `float`, not `double`.
-- There is no `float`→`double` promotion in variadic calls (there is no
-  double), so `printf("%f", x)` consumes a 32-bit `float` directly.
-- No `atof`/`strtod` (both return `double`). `<math.h>` *does* provide the
-  single-precision transcendentals (`sinf`/`cosf`/`expf`/`logf`/`powf`/… with
-  unsuffixed aliases), and `strtol`/`strtoul` parse integers — but for
-  decimal-string→`float` you still parse it yourself:
+`atof`/`strtod` are absent (both return `double`). `strtol`/`strtoul` parse
+integers; for decimal-string→`float`, parse it yourself:
 
 ```c
 /* minimal signed decimal -> float */
@@ -32,43 +26,41 @@ static float parse_f(const char *s)
 
 ## `%f` needs the `-ffloatio` build flag
 
-Float `printf` formatting is only linked when you compile with `-f` /
-`-ffloatio`. Without it, `%f` produces nothing useful — so any program that
-prints floats must be built with that flag.
+Symptom: `printf("%f", x)` produces nothing useful. Float formatting is only
+linked when you compile with `-f` / `-ffloatio`, so any program that prints
+floats must be built with that flag.
 
 ## 16-bit `int` (and `size_t`)
 
-`int`/`short` are 16-bit (±32767), and `size_t` is 16-bit too, so a single
-object or allocation can't exceed ~64 KB.
-
-- Use `long` + `%ld` for counters, sizes, or accumulators that can exceed ±32767.
-- File offsets are `long` (`ftell`/`fseek`/`lseek`, `off_t`) — don't truncate
-  them into an `int`.
+Symptom: a loop counter, size, index, or accumulator silently wraps past
+±32767. `size_t` is 16-bit too, so a single object/allocation can't exceed
+~64 KB. Fixes: use `long` + `%ld` for anything that can exceed the range; keep
+file offsets in `long` (`ftell`/`fseek`/`lseek`, `off_t`) — never truncate them
+into an `int`.
 
 ## `char` is signed
 
-Bytes ≥ 0x80 read as negative, so `c == 0xE9` is never true and table
-indexing / sign-extension can misbehave. Use `unsigned char` for raw bytes and
-when indexing a table by character value.
+Symptom: a byte ≥ 0x80 reads as negative, so `c == 0xE9` is never true and
+table indexing / sign-extension misbehaves. Fix: use `unsigned char` for raw
+bytes and when indexing a table by character value.
 
 ## CP/M filenames: 8.3, uppercase, extension ≤ 3 chars
 
-- Source `foo.c` builds `FOO.COM`; run it as `ntvcm FOO` (uppercase, no ext).
-- ntvcm's filename mapper **asserts on any extension longer than 3 characters**,
-  so delete stray `.DS_Store` files before directory-enumeration tests or a full
-  `runall.sh` (VS Code / file search may hide them).
+**The source filename itself must conform to 8.3**, or the build fails.
+Symptom: a `.c` whose base name is longer than 8 chars, whose extension is
+longer than 3 chars, or that contains extra dots (e.g. `my_long_name.c`,
+`parse.test.c`) won't build — ntvcm prints
+`argument is not a valid CP/M 8.3 filename`. Fix: rename the source so its base
+≤ 8 chars and extension ≤ 3 chars before building. `foo.c` builds `FOO.COM`;
+run it as `ntvcm FOO` (uppercase, no ext).
 
-## printf / scanf are a subset
-
-- `printf`: no `+`, space, or `#` flags, and no `*` (run-time) width/precision —
-  bake widths into the format string (`%6d`, `%-8s`, `%.4d`); write `0x`
-  prefixes literally.
-- `scanf` / `sscanf` / `fscanf`: integer and string only — no `%f`/`%e`/`%g`,
-  scansets (`%[...]`), `%n`, or `%p`.
+ntvcm's filename mapper also **asserts on any on-disk extension longer than 3
+characters**, so delete stray `.DS_Store` files before directory-enumeration
+tests or a full `runall.sh` (VS Code / file search may hide them).
 
 ## No stack/heap guard
 
-The heap grows up from BSS, the stack grows down, and nothing stops them
-colliding. Reserve stack with `-stack N` (default 512) for deep recursion or
-large automatic arrays, and prefer `static`/global for big buffers.
-(`spsmash.c` shows an optional manual stack-depth check.)
+The heap grows up, the stack grows down, and nothing stops them colliding.
+Reserve stack with `-stack N` (default 512) for deep recursion or large
+automatic arrays, and prefer `static`/global for big buffers. (`spsmash.c`
+shows an optional manual stack-depth check.)


### PR DESCRIPTION
…name reminder

Rewrite the c89-cpm-z80 skill to assume standard C89/C99 and document only dcc's deviations, cutting redundant restatements of standard semantics:

- SKILL.md: replace overlapping Golden rules / Type model / Language support / Identifier / Floating-point / Top-pitfalls sections with a single "Deviations from standard C" section plus a concise C99-conveniences note.
- library.md: keep the subset inventory, absent lists, extensions, and printf/scanf conversion tables; trim restated standard behaviour and dedupe the type table against SKILL.md.
- pitfalls.md: keep worked examples (float parser, %f/-ffloatio, overflow, signed char, no guard); convert the rest to terse symptom->fix entries.

Add a reminder across SKILL.md and pitfalls.md that source filenames must conform to CP/M 8.3 (base <= 8, ext <= 3, no extra dots) or ntvcm reports "argument is not a valid CP/M 8.3 filename".

Net ~30% fewer tokens with no loss of any genuine constraint.