### PR TITLE
fix codegen for multidimensional arrays embedded in structs

### DIFF
--- a/baseline_test_dcc.txt
+++ b/baseline_test_dcc.txt
@@ -4253,3 +4253,5 @@ checks=32 failures=0
 RESULT: PASS
 test tfarrsub
 PASS field_arr_subscript
+test t2darr
+PASS multidim_array

--- a/runall.bat
+++ b/runall.bat
@@ -23,7 +23,7 @@ set _applist=sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong ^
              tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom ^
              tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield ^
              pint cobint forint bint fint cint adaint tstretst tportio tlongidx tforsco ^
-             tforblk tcmt99 tc99scpe tctxflt tmathf tstrconv tfarrsub
+             tforblk tcmt99 tc99scpe tctxflt tmathf tstrconv tfarrsub t2darr
 
 echo --- optimized (ma peep) ---
 set "outputfile=test_dcc.txt"

--- a/runall.sh
+++ b/runall.sh
@@ -22,7 +22,7 @@ APPLIST="sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong \
          tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom \
          tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield \
          pint cobint forint bint fint cint adaint tstretst tportio tlongidx tforsco \
-         tforblk tcmt99 tc99scpe tctxflt tmathf tstrconv tfarrsub"
+         tforblk tcmt99 tc99scpe tctxflt tmathf tstrconv tfarrsub t2darr"
 
 run_args() {
     case "$1" in

--- a/src/dcc/dcc_expr.c
+++ b/src/dcc/dcc_expr.c
@@ -1157,6 +1157,37 @@ int try_parse_const_subscript(long *out)
     return 0;
 }
 
+/*
+ * Snapshot the current_field_array_* dimension metadata into caller-owned
+ * locals.  An index expression evaluated via gen_expr() may perform its own
+ * struct field accesses, which overwrite these globals; capturing them before
+ * any index is evaluated keeps multidimensional field-array strides correct.
+ */
+static void snapshot_field_array_dims(int *dim_count, int *dims)
+{
+    int di;
+    *dim_count = current_field_array_dim_count;
+    for (di = 0; di < 4; ++di)
+        dims[di] = current_field_array_dims[di];
+}
+
+/*
+ * Byte stride of array index `index_count` (0-based) for a field array whose
+ * base element size is `base_size` and whose dimensions are the snapshot
+ * `dim_count`/`dims`.  For a[d0][d1]...[dn-1], advancing index k moves by
+ * base_size * d[k+1] * ... * d[n-1] bytes.
+ */
+static int field_array_index_stride(int base_size, int dim_count,
+                                    const int *dims, int index_count)
+{
+    int stride;
+    int di;
+    stride = base_size;
+    for (di = index_count + 1; di < dim_count; ++di)
+        stride *= dims[di];
+    return stride;
+}
+
 void gen_lvalue_addr(int *ptype)
 {
     current_field_bit_width = 0;
@@ -1174,6 +1205,8 @@ void gen_lvalue_addr(int *ptype)
     int cur_type;
     int arrow;
     int field_is_array;
+    int fa_dimc;
+    int fa_dims[4];
 
     if (tok.kind == TOK_ID) {
         strncpy(name, tok.text, sizeof(name) - 1);
@@ -1273,6 +1306,7 @@ void gen_lvalue_addr(int *ptype)
             }
         }
 
+        snapshot_field_array_dims(&fa_dimc, fa_dims);
         while (accept('[')) {
             cur_type = ptype ? *ptype : s->type;
 
@@ -1285,7 +1319,9 @@ void gen_lvalue_addr(int *ptype)
                 if (try_parse_const_subscript(&const_index)) {
 
                 if (addr_is_array)
-                    elem_size = type_size(cur_type);
+                    elem_size = field_array_index_stride(type_size(cur_type),
+                                                         fa_dimc, fa_dims,
+                                                         addr_array_index_count);
                 else
                     elem_size = sym_pointer_array_index_elem_size(s, cur_type, addr_array_index_count);
 
@@ -1300,7 +1336,9 @@ void gen_lvalue_addr(int *ptype)
                 expect(']');
 
                 if (addr_is_array)
-                    elem_size = type_size(cur_type);
+                    elem_size = field_array_index_stride(type_size(cur_type),
+                                                         fa_dimc, fa_dims,
+                                                         addr_array_index_count);
                 else
                     elem_size = sym_pointer_array_index_elem_size(s, cur_type, addr_array_index_count);
 
@@ -1313,7 +1351,7 @@ void gen_lvalue_addr(int *ptype)
 
             if (addr_is_array) {
                 addr_array_index_count++;
-                if (addr_array_index_count >= current_field_array_dim_count)
+                if (addr_array_index_count >= fa_dimc)
                     addr_is_array = 0;
             } else {
                 cur_type = type_decay_ptr(cur_type);
@@ -1342,6 +1380,7 @@ void gen_lvalue_addr(int *ptype)
                 ptype[0] = cur_type;
             }
 
+            snapshot_field_array_dims(&fa_dimc, fa_dims);
             while (accept('[')) {
                 cur_type = ptype ? *ptype : s->type;
 
@@ -1353,7 +1392,9 @@ void gen_lvalue_addr(int *ptype)
 
                     if (try_parse_const_subscript(&const_index)) {
                         if (addr_is_array)
-                            elem_size = type_size(cur_type);
+                            elem_size = field_array_index_stride(type_size(cur_type),
+                                                                 fa_dimc, fa_dims,
+                                                                 addr_array_index_count);
                         else
                             elem_size = type_index_elem_size(cur_type);
                         emit_add_const_to_hl(const_index * elem_size);
@@ -1366,7 +1407,9 @@ void gen_lvalue_addr(int *ptype)
                         expr_result_dead = old_dead;
                         expect(']');
                         if (addr_is_array)
-                            elem_size = type_size(cur_type);
+                            elem_size = field_array_index_stride(type_size(cur_type),
+                                                                 fa_dimc, fa_dims,
+                                                                 addr_array_index_count);
                         else
                             elem_size = type_index_elem_size(cur_type);
                         scale_hl_by_elem_size(elem_size);
@@ -1378,7 +1421,7 @@ void gen_lvalue_addr(int *ptype)
 
                 if (addr_is_array) {
                     addr_array_index_count++;
-                    if (addr_array_index_count >= current_field_array_dim_count)
+                    if (addr_array_index_count >= fa_dimc)
                         addr_is_array = 0;
                 } else {
                     cur_type = type_decay_ptr(cur_type);
@@ -2671,7 +2714,8 @@ void gen_primary(void)
     int cur_type;
     int arrow;
     int field_is_array;
-    int di;
+    int fa_dimc;
+    int fa_dims[4];
 
     if (tok.kind == TOK_ID && strcmp(tok.text, "__offsetof") == 0) {
         int ov;
@@ -3125,6 +3169,7 @@ void gen_primary(void)
             val_array_index_count = 0;
         }
 
+        snapshot_field_array_dims(&fa_dimc, fa_dims);
         while (accept('[')) {
             indexed = 1;
             cur_type = val_type;
@@ -3138,13 +3183,9 @@ void gen_primary(void)
                 if (try_parse_const_subscript(&const_index)) {
 
                 if (val_is_array) {
-                    elem_size = current_field_array_elem_size ? current_field_array_elem_size : type_size(cur_type);
-                    if (current_field_array_dim_count > 0) {
-                        for (di = val_array_index_count + 1;
-                             di < current_field_array_dim_count;
-                             ++di)
-                            elem_size *= current_field_array_dims[di];
-                    }
+                    elem_size = field_array_index_stride(type_size(cur_type),
+                                                         fa_dimc, fa_dims,
+                                                         val_array_index_count);
                 } else {
                     elem_size = type_index_elem_size(cur_type);
                 }
@@ -3156,13 +3197,9 @@ void gen_primary(void)
                 expect(']');
 
                 if (val_is_array) {
-                    elem_size = type_size(cur_type);
-                    if (current_field_array_dim_count > 0) {
-                        for (di = val_array_index_count + 1;
-                             di < current_field_array_dim_count;
-                             ++di)
-                            elem_size *= current_field_array_dims[di];
-                    }
+                    elem_size = field_array_index_stride(type_size(cur_type),
+                                                         fa_dimc, fa_dims,
+                                                         val_array_index_count);
                 } else {
                     elem_size = type_index_elem_size(cur_type);
                 }
@@ -3176,7 +3213,7 @@ void gen_primary(void)
 
             if (val_is_array) {
                 val_array_index_count++;
-                if (val_array_index_count >= current_field_array_dim_count)
+                if (val_array_index_count >= fa_dimc)
                     val_is_array = 0;
             } else {
                 val_type = type_decay_ptr(cur_type);
@@ -3198,6 +3235,7 @@ void gen_primary(void)
             val_is_array = field_is_array;
             val_array_index_count = 0;
 
+            snapshot_field_array_dims(&fa_dimc, fa_dims);
             while (accept('[')) {
                 indexed = 1;
                 cur_type = val_type;
@@ -3210,13 +3248,9 @@ void gen_primary(void)
 
                     if (try_parse_const_subscript(&const_index)) {
                         if (val_is_array) {
-                            elem_size = current_field_array_elem_size ? current_field_array_elem_size : type_size(cur_type);
-                            if (current_field_array_dim_count > 0) {
-                                for (di = val_array_index_count + 1;
-                                     di < current_field_array_dim_count;
-                                     ++di)
-                                    elem_size *= current_field_array_dims[di];
-                            }
+                            elem_size = field_array_index_stride(type_size(cur_type),
+                                                                 fa_dimc, fa_dims,
+                                                                 val_array_index_count);
                         } else {
                             elem_size = type_index_elem_size(cur_type);
                         }
@@ -3227,13 +3261,9 @@ void gen_primary(void)
                         expect(']');
 
                         if (val_is_array) {
-                            elem_size = type_size(cur_type);
-                            if (current_field_array_dim_count > 0) {
-                                for (di = val_array_index_count + 1;
-                                     di < current_field_array_dim_count;
-                                     ++di)
-                                    elem_size *= current_field_array_dims[di];
-                            }
+                            elem_size = field_array_index_stride(type_size(cur_type),
+                                                                 fa_dimc, fa_dims,
+                                                                 val_array_index_count);
                         } else {
                             elem_size = type_index_elem_size(cur_type);
                         }
@@ -3247,7 +3277,7 @@ void gen_primary(void)
 
                 if (val_is_array) {
                     val_array_index_count++;
-                    if (val_array_index_count >= current_field_array_dim_count)
+                    if (val_array_index_count >= fa_dimc)
                         val_is_array = 0;
                 } else {
                     val_type = type_decay_ptr(cur_type);

--- a/tests/t2darr.c
+++ b/tests/t2darr.c
@@ -1,0 +1,152 @@
+/* t2darr.c - dcc regression: multidimensional arrays embedded in structs.
+ * Expected output: PASS multidim_array
+ *
+ * Bare-local multidimensional arrays (e.g. local int a[3][4]) already worked
+ * because they index through sym_array_index_elem_size.  The bug was in the
+ * struct-FIELD array path in dcc_expr.c:
+ *
+ *   1) gen_lvalue_addr (the write/address path) never multiplied the first
+ *      index by the inner dimensions, so `mx.cell[i][j] = v` scaled index i
+ *      by the base element size instead of by sizeof(inner row).
+ *   2) Both gen_lvalue_addr and gen_primary read current_field_array_dim_count
+ *      / current_field_array_dims AFTER evaluating a non-constant index.  An
+ *      index that performs its own struct field access (e.g. mx.cell[mx.r])
+ *      clobbers those globals, so the stride collapsed to the base size.
+ *
+ * The fix snapshots the dimension metadata before any index is evaluated and
+ * applies the full inner-dimension stride on every path.  This test exercises
+ * 2D/3D char and int field arrays, constant and variable indices, indices that
+ * are themselves struct-member reads (the clobber case), and a 2D array nested
+ * inside an array of structs.
+ */
+#include <stdio.h>
+
+struct Mat {
+    unsigned char cell[3][4];   /* 2D byte array, row stride 4 */
+    int r;
+    int c;
+};
+
+struct IMat {
+    int v[3][4];                /* 2D int array, row stride 4*2 = 8 */
+    int r;
+    int c;
+};
+
+struct Cube {
+    int data[2][3][4];          /* 3D int array */
+    int a;
+    int b;
+    int d;
+};
+
+struct Cell {
+    unsigned char g[2][2];
+    int tag;
+};
+
+struct Grid {
+    struct Cell cells[3];       /* array of structs, each holding a 2D array */
+};
+
+static struct Mat  mx;
+static struct IMat im;
+static struct Cube cu;
+static struct Grid gr;
+
+static int failures;
+
+static void check(const char *name, int got, int expected)
+{
+    if (got != expected) {
+        printf("FAIL %s got %d expected %d\n", name, got, expected);
+        failures++;
+    }
+}
+
+/* Index supplied by a function call: clobbers the field-array dim globals
+ * between parsing the subscript and scaling it. */
+static int row_of(void) { return mx.r; }
+static int col_of(void) { return mx.c; }
+
+int main(void)
+{
+    int i, j, k;
+
+    /* --- 2D byte field array: constant indices, write then read --- */
+    mx.cell[0][0] = 1;
+    mx.cell[1][0] = 15;
+    mx.cell[2][3] = 42;
+    mx.cell[1][2] = 99;
+
+    check("char c[0][0]", (int)mx.cell[0][0], 1);
+    check("char c[1][0]", (int)mx.cell[1][0], 15);
+    check("char c[2][3]", (int)mx.cell[2][3], 42);
+    check("char c[1][2]", (int)mx.cell[1][2], 99);
+
+    /* fill via nested variable loops, verify with constants */
+    for (i = 0; i < 3; i++)
+        for (j = 0; j < 4; j++)
+            mx.cell[i][j] = (unsigned char)(i * 4 + j);
+    check("char loopfill[2][3]", (int)mx.cell[2][3], 11);
+    check("char loopfill[1][1]", (int)mx.cell[1][1], 5);
+
+    /* index by sibling struct members (clobber path), write + read */
+    mx.r = 2; mx.c = 1;
+    mx.cell[mx.r][mx.c] = 77;
+    check("char member-idx const-read", (int)mx.cell[2][1], 77);
+    check("char member-idx var-read",   (int)mx.cell[mx.r][mx.c], 77);
+
+    /* index by function call (also clobbers globals) */
+    mx.r = 1; mx.c = 3;
+    mx.cell[row_of()][col_of()] = 55;
+    check("char fncall-idx", (int)mx.cell[1][3], 55);
+
+    /* --- 2D int field array (2-byte element, row stride 8 bytes) --- */
+    im.v[0][0] = 1000;
+    im.v[1][0] = 2000;
+    im.v[2][3] = 3003;
+    im.v[1][2] = 1202;
+
+    check("int v[0][0]", im.v[0][0], 1000);
+    check("int v[1][0]", im.v[1][0], 2000);
+    check("int v[2][3]", im.v[2][3], 3003);
+    check("int v[1][2]", im.v[1][2], 1202);
+
+    im.r = 2; im.c = 2;
+    im.v[im.r][im.c] = 4242;
+    check("int member-idx const-read", im.v[2][2], 4242);
+    check("int member-idx var-read",   im.v[im.r][im.c], 4242);
+
+    /* --- 3D int field array --- */
+    for (i = 0; i < 2; i++)
+        for (j = 0; j < 3; j++)
+            for (k = 0; k < 4; k++)
+                cu.data[i][j][k] = i * 100 + j * 10 + k;
+
+    check("3d d[0][0][0]", cu.data[0][0][0], 0);
+    check("3d d[1][2][3]", cu.data[1][2][3], 123);
+    check("3d d[1][0][0]", cu.data[1][0][0], 100);
+    check("3d d[0][2][1]", cu.data[0][2][1], 21);
+
+    cu.a = 1; cu.b = 2; cu.d = 3;
+    check("3d member-idx", cu.data[cu.a][cu.b][cu.d], 123);
+
+    /* --- 2D array nested in an array of structs --- */
+    gr.cells[0].g[0][0] = 10;
+    gr.cells[1].g[1][0] = 21;
+    gr.cells[2].g[0][1] = 32;
+    gr.cells[1].g[1][1] = 23;
+
+    check("nest c0 g[0][0]", (int)gr.cells[0].g[0][0], 10);
+    check("nest c1 g[1][0]", (int)gr.cells[1].g[1][0], 21);
+    check("nest c2 g[0][1]", (int)gr.cells[2].g[0][1], 32);
+    check("nest c1 g[1][1]", (int)gr.cells[1].g[1][1], 23);
+
+    if (failures) {
+        printf("FAIL multidim_array (%d failures)\n", failures);
+        return 1;
+    }
+    printf("PASS multidim_array\n");
+    return 0;
+}

--- a/tests/tfarrsub.c
+++ b/tests/tfarrsub.c
@@ -16,6 +16,14 @@
  *
  * (A) and (B) were the adaint TTT.ADA bug; (C) is a proactive fix for the
  * symmetric rvalue path.
+ *
+ * Extended coverage added later (same clobber class, different strides/shapes):
+ *  D) direct embedded int array (2-byte stride) indexed by a sibling member.
+ *  E) direct embedded struct-element array (multi-byte stride), member index.
+ *  F) indirect (pointer-indexed) struct with a 2-byte-stride int field,
+ *     member index on the inner-subscript paths.
+ *  G) index expression is a function call that reads a struct field, so it
+ *     clobbers current_field_array_elem_size between parse and scaling.
  */
 #include <stdio.h>
 
@@ -43,9 +51,46 @@ struct Direct {
     int n;
 };
 
+/* For (D): direct embedded 2-byte-stride (int) array indexed by a sibling
+ * member.  Exercises elem_size = type_size(int) = 2 on the rvalue/lvalue
+ * first-subscript paths (the byte array above can't catch a stride bug). */
+struct IntVec {
+    int vals[MAXPARAM];
+    int n;
+};
+
+/* For (E): direct embedded array whose element is itself a struct
+ * (multi-byte stride), indexed by a sibling member.  Verifies the stride
+ * comes from type_size(struct Pair), not a clobbered global. */
+struct Pair {
+    unsigned char a;
+    unsigned char b;
+    int w;
+};
+struct PairVec {
+    struct Pair pairs[MAXPARAM];
+    int n;
+};
+
+/* For (F): indirect (pointer-indexed) struct array with a 2-byte-stride int
+ * field indexed by a struct member — the inner-subscript paths in both
+ * gen_lvalue_addr and gen_primary with a non-unit element size. */
+struct Row {
+    int vals[MAXPARAM];
+    int count;
+};
+struct Grid {
+    struct Row *rows;
+    int nrows;
+};
+
 static struct Func funcs[4];
 static struct State state;
 static struct Direct ds;
+static struct IntVec iv;
+static struct PairVec pv;
+static struct Row rows_storage[3];
+static struct Grid grid;
 
 static int failures;
 
@@ -77,6 +122,39 @@ static void set_direct(int val)
 {
     ds.arr[ds.n] = (unsigned char)val;
     ds.n++;
+}
+
+/* Covers (D): direct 2-byte-stride array, member index on write. */
+static void set_intvec(int val)
+{
+    iv.vals[iv.n] = val;
+    iv.n++;
+}
+
+/* Covers (E): direct struct-element array, member index on write into a
+ * sub-field of the indexed element. */
+static void set_pair(int av, int bv, int wv)
+{
+    pv.pairs[pv.n].a = (unsigned char)av;
+    pv.pairs[pv.n].b = (unsigned char)bv;
+    pv.pairs[pv.n].w = wv;
+    pv.n++;
+}
+
+/* Covers (F): indirect 2-byte-stride array, member index on write. */
+static void set_grid(int gi, int val)
+{
+    struct Grid *G;
+    G = &grid;
+    G->rows[gi].vals[G->rows[gi].count] = val;
+    G->rows[gi].count++;
+}
+
+/* Covers (G): index is a function call that itself reads a struct field, so
+ * it clobbers current_field_array_elem_size between parse and scaling. */
+static int iv_index(void)
+{
+    return iv.n - 1;
 }
 
 int main(void)
@@ -118,6 +196,52 @@ int main(void)
     /* (C): read ds.arr[ds.n - 1] via struct-member index (first subscript while) */
     check("dir read[0]",  (int)ds.arr[ds.n - 2], 77);
     check("dir read[1]",  (int)ds.arr[ds.n - 1], 88);
+
+    /* --- (D) direct 2-byte-stride (int) embedded array --- */
+    iv.n = 0;
+    set_intvec(1001);
+    set_intvec(2002);
+    set_intvec(3003);
+
+    check("ivec write[0]", iv.vals[0], 1001);
+    check("ivec write[1]", iv.vals[1], 2002);
+    check("ivec write[2]", iv.vals[2], 3003);
+    /* read with member index: a stride bug here would read a neighbouring
+     * int (off by 2 bytes) and return the wrong element. */
+    check("ivec read[0]",  iv.vals[iv.n - 3], 1001);
+    check("ivec read[1]",  iv.vals[iv.n - 2], 2002);
+    check("ivec read[2]",  iv.vals[iv.n - 1], 3003);
+
+    /* (G): index is a function call clobbering the elem-size global. */
+    check("ivec fncall idx", iv.vals[iv_index()], 3003);
+
+    /* --- (E) direct struct-element (multi-byte stride) embedded array --- */
+    pv.n = 0;
+    set_pair(10, 11, 1200);
+    set_pair(20, 21, 2200);
+
+    check("pair a[0]", (int)pv.pairs[0].a, 10);
+    check("pair b[0]", (int)pv.pairs[0].b, 11);
+    check("pair w[0]", pv.pairs[0].w,      1200);
+    check("pair a[1]", (int)pv.pairs[1].a, 20);
+    check("pair w[1]", pv.pairs[1].w,      2200);
+    /* read element fields via member index (struct-sized stride). */
+    check("pair read a", (int)pv.pairs[pv.n - 1].a, 20);
+    check("pair read w", pv.pairs[pv.n - 1].w,      2200);
+
+    /* --- (F) indirect 2-byte-stride array via pointer-indexed struct --- */
+    grid.rows = rows_storage;
+    grid.nrows = 0;
+    grid.rows[0].count = 0;
+    set_grid(0, 555);
+    set_grid(0, 666);
+
+    check("grid count",   grid.rows[0].count,  2);
+    check("grid write[0]", grid.rows[0].vals[0], 555);
+    check("grid write[1]", grid.rows[0].vals[1], 666);
+    /* read with member index on the indirect inner-subscript path. */
+    check("grid read[0]", grid.rows[0].vals[grid.rows[0].count - 2], 555);
+    check("grid read[1]", grid.rows[0].vals[grid.rows[0].count - 1], 666);
 
     if (failures) {
         printf("FAIL field_arr_subscript (%d failures)\n", failures);


### PR DESCRIPTION
Subscripting a multidimensional array that is a struct field (e.g. mx.cell[i][j] for a struct member unsigned char cell[3][4]) produced wrong addresses on the write/address path and whenever an index expression was non-constant.

Two defects in src/dcc/dcc_expr.c:

  1) gen_lvalue_addr (the lvalue/address path) scaled the first index
     by the base element size only, never by the inner dimensions, so
     mx.cell[2][1] computed offset 2*1+1 instead of 2*4+1. Bare-local
     2D arrays were unaffected because they index through
     sym_array_index_elem_size.

  2) Both gen_lvalue_addr and gen_primary read the
     current_field_array_dim_count / current_field_array_dims globals
     AFTER evaluating a non-constant index via gen_expr(). An index that
     performs its own struct field access (e.g. mx.cell[mx.r]) clobbers
     those globals, collapsing the stride to the base size. The variable
     case previously appeared to work only because the write and read
     paths were clobbered identically.

Fix: snapshot the dimension metadata before any index is evaluated (snapshot_field_array_dims) and compute the full inner-dimension stride on every subscript path (field_array_index_stride). Applied to all four field-subscript loops across both functions; the snapshot also drives the array-exhaustion check.

Add tests/t2darr.c covering 2D/3D char and int field arrays with constant, variable, struct-member, and function-call indices, plus a 2D array nested in an array of structs; wire it into runall.sh / runall.bat and the baseline. Extend tests/tfarrsub.c with int/struct/pointer-stride and function-call-index cases for the related elem-size clobber class.