### PR TITLE
printf: add '0' zero-pad flag, fix %x/%X case; add OO + zero-pad tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,16 @@
 /build
 /test_dcc.txt
 /test_dccu.txt
+
+# Generated MkDocs site
+/docs/site/
+/docs/docs/en/images/table.jpg
+
+# Python cache artifacts
+__pycache__/
+*.py[cod]
+
+# Generated runtime size reports
+/dccrtl-size-report.md
+/dccrtl-all-publics.md
+/dccrtl-all-publics.json

--- a/DCCRTL.MAC
+++ b/DCCRTL.MAC
@@ -2616,6 +2616,7 @@ pf_percent:
         ld      (pf_width),a
         ld      (pf_prec),a
         ld      (pf_left),a
+        ld      (pf_zero),a
 
 pf_pct_next:
         ld      a,(hl)
@@ -2637,13 +2638,27 @@ pf_pct_next:
         cp      'z'
         jp      z,pf_pct_z
 
-        ; Decimal field width: %2d / %3u / %8s etc.
+        ; Decimal field width: %2d / %3u / %8s etc.  A leading '0' (before any
+        ; width digit) is the '0' zero-pad flag, not a width digit.
         cp      '0'
         jp      c,pf_pct_done_width
         cp      '9'+1
         jp      nc,pf_pct_done_width
 
+        cp      '0'
+        jr      nz,pf_pct_acc
+        ld      a,(pf_width)
+        or      a
+        jr      nz,pf_pct_zero_digit    ; width already started: '0' is a digit
+        ld      a,1
+        ld      (pf_zero),a             ; leading '0' = zero-pad flag
+        jp      pf_pct_next
+pf_pct_zero_digit:
+        xor     a                       ; treat as digit value 0
+        jr      pf_pct_acc2
+pf_pct_acc:
         sub     '0'
+pf_pct_acc2:
         ld      (pf_digit),a
         push    de              ; DE is the vararg byte offset; preserve it.
         ld      a,(pf_width)
@@ -2715,9 +2730,9 @@ pf_pct_done_width:
         cp      'i'
         jp      z,pf_d
         cp      'x'
-        jp      z,pf_x
+        jp      z,pf_xl
         cp      'X'
-        jp      z,pf_x
+        jp      z,pf_xu
         cp      'l'
         jp      z,pf_l
         cp      'f'
@@ -2759,6 +2774,75 @@ pf_pad_loop:
         call    pf_emit_a
         dec     d
         jr      nz,pf_pad_loop
+        ret
+
+; pf_zsetup: apply the '0' zero-pad flag to the upcoming integer conversion.
+; IN:  A = sign length (0, or 1 when a '-' will be emitted).
+; If the '0' flag is active, the field is not left-justified, and no explicit
+; precision was given (C89/C99 7.19.6.1: a precision makes the '0' flag ignored
+; for integer conversions), convert the field width into a zero-fill precision
+; of (width - signlen) and clear the width so pf_pad_a emits no leading spaces.
+; The sign counts toward the width.  Preserves HL/DE/BC.
+pf_zsetup:
+        push    hl
+        push    de
+        ld      e,a             ; E = sign length
+        ld      a,(pf_zero)
+        or      a
+        jr      z,pf_zs_done
+        ld      a,(pf_left)
+        or      a
+        jr      nz,pf_zs_done   ; '-' flag overrides '0'
+        ld      a,(pf_prec)
+        or      a
+        jr      nz,pf_zs_done   ; explicit precision -> '0' ignored
+        ld      a,(pf_width)
+        sub     e               ; width - signlen
+        jr      c,pf_zs_clrw    ; width <= signlen: nothing to zero-fill
+        jr      z,pf_zs_clrw
+        ld      (pf_prec),a     ; zero-fill digits up to (width - signlen)
+pf_zs_clrw:
+        xor     a
+        ld      (pf_width),a    ; suppress space padding (zeros fill the field)
+pf_zs_done:
+        pop     de
+        pop     hl
+        ret
+
+; pf_efflen: A = max(pf_digit, pf_prec) = the digit-field length that will
+; actually be emitted (precision zero-fill can make it wider than the raw digit
+; count).  pf_pad_a must size the space padding from this, not from pf_digit
+; alone, or "%8.3d" over-pads.  Clobbers A/E only; preserves HL/BC.
+pf_efflen:
+        ld      a,(pf_prec)
+        ld      e,a
+        ld      a,(pf_digit)
+        cp      e
+        ret     nc              ; digit count >= prec
+        ld      a,e             ; prec is larger
+        ret
+
+; pf_zfd: emit precision zero-fill then the prebuilt decimal digits.
+; IN:  HL -> first digit, pf_digit = digit count, pf_prec = zero-fill target.
+; Emits (pf_prec - pf_digit) leading '0's (when positive) then the digits.
+; Shared tail for %d/%u/%ld/%lu so precision and the '0' flag behave uniformly.
+pf_zfd:
+        ld      a,(pf_prec)
+        or      a
+        jr      z,pf_zfd_print  ; no precision/zero-fill: just print the digits
+        ld      d,a             ; D = prec (DE preserved across pf_emit_a)
+        ld      a,(pf_digit)
+        sub     d               ; A = digit_count - prec
+        jr      nc,pf_zfd_print ; digit_count >= prec: no fill
+        neg                     ; A = prec - digit_count (zeros needed)
+        ld      d,a
+pf_zfd_zloop:
+        ld      a,'0'
+        call    pf_emit_a       ; push de/pop de preserves D
+        dec     d
+        jr      nz,pf_zfd_zloop
+pf_zfd_print:
+        call    pf_emit_z
         ret
 
 pf_c:
@@ -2820,10 +2904,14 @@ pf_u:
         call    pf_arg_hl
         push    de
         call    pf_build_u      ; A = digit count, HL -> first digit (built once)
+        ld      (pf_digit),a
         push    hl
-        call    pf_pad_a        ; emit (width - count) leading spaces
+        xor     a               ; unsigned: no sign
+        call    pf_zsetup       ; honour the '0' zero-pad flag
+        call    pf_efflen       ; A = max(digits, precision)
+        call    pf_pad_a        ; emit (width - field) leading spaces
         pop     hl
-        call    pf_emit_z       ; emit the prebuilt digits
+        call    pf_zfd          ; precision/zero-fill then emit the digits
         pop     de
         pop     hl
         jp      pf_loop
@@ -2847,39 +2935,36 @@ pf_d:
         call    pf_build_u
         ld      (pf_digit),a    ; save digit count of |value|
         push    hl              ; save pointer to first digit
+        ld      a,1             ; sign length = 1 ('-')
+        call    pf_zsetup       ; honour the '0' zero-pad flag
+        call    pf_efflen       ; A = max(digits, precision)
         inc     a               ; width includes the '-'
         call    pf_pad_a
         ld      a,'-'
         call    pf_emit_a
-        jr      pf_d_zfill
+        jr      pf_d_tail
 pf_d_pos:
         call    pf_build_u
         ld      (pf_digit),a    ; save digit count
         push    hl              ; save pointer to first digit
+        xor     a               ; sign length = 0
+        call    pf_zsetup
+        call    pf_efflen       ; A = max(digits, precision)
         call    pf_pad_a
-pf_d_zfill:
-        ; Zero-fill for precision: print (prec - digit_count) leading zeros
-        ld      a,(pf_prec)
-        or      a
-        jr      z,pf_d_print    ; prec=0: no zero-fill
-        ld      d,a             ; D = prec (DE preserved across pf_emit_a)
-        ld      a,(pf_digit)
-        sub     d               ; A = digit_count - prec
-        jr      nc,pf_d_print   ; digit_count >= prec: no fill
-        neg                     ; A = prec - digit_count (zeros needed)
-        ld      d,a
-pf_d_zero_loop:
-        ld      a,'0'
-        call    pf_emit_a       ; push de/pop de preserves D
-        dec     d
-        jr      nz,pf_d_zero_loop
-pf_d_print:
+pf_d_tail:
         pop     hl              ; HL -> first digit
-        call    pf_emit_z
+        call    pf_zfd          ; precision/zero-fill then emit digits
         pop     de
         pop     hl
         jp      pf_loop
 
+pf_xu:
+        ld      a,1                     ; %X -> uppercase A-F
+        ld      (pf_hexup),a
+        jr      pf_x
+pf_xl:
+        xor     a                       ; %x -> lowercase a-f
+        ld      (pf_hexup),a
 pf_x:
         push    hl
         call    pf_arg_hl
@@ -2900,7 +2985,9 @@ pf_l:
         cp      'u'
         jp      z,pf_lu
         cp      'x'
-        jp      z,pf_lx
+        jp      z,pf_lxl
+        cp      'X'
+        jp      z,pf_lxu
         cp      's'
         jp      z,pf_ls
         call    pf_emit_a
@@ -2961,19 +3048,27 @@ pf_ld:
         ; Negative: negate, build digits once, then print with '-'
         call    pf_neg32
         call    pf_build_u32    ; A = count, HL -> first digit
+        ld      (pf_digit),a
         push    hl
+        ld      a,1             ; sign length = 1 ('-')
+        call    pf_zsetup       ; honour the '0' zero-pad flag
+        call    pf_efflen       ; A = max(digits, precision)
         inc     a               ; +1 for '-'
         call    pf_pad_a
         ld      a,'-'
         call    pf_emit_a
-        jr      pf_ld_emit
+        jr      pf_ld_tail
 pf_ld_pos:
         call    pf_build_u32    ; A = count, HL -> first digit
+        ld      (pf_digit),a
         push    hl
+        xor     a               ; sign length = 0
+        call    pf_zsetup
+        call    pf_efflen       ; A = max(digits, precision)
         call    pf_pad_a
-pf_ld_emit:
+pf_ld_tail:
         pop     hl
-        call    pf_emit_z
+        call    pf_zfd          ; precision/zero-fill then emit digits
         pop     de
         pop     hl
         jp      pf_loop
@@ -2984,14 +3079,25 @@ pf_lu:
         call    pf_arg_dehl
         push    de
         call    pf_build_u32    ; A = count, HL -> first digit
+        ld      (pf_digit),a
         push    hl
+        xor     a               ; unsigned: no sign
+        call    pf_zsetup
+        call    pf_efflen       ; A = max(digits, precision)
         call    pf_pad_a
         pop     hl
-        call    pf_emit_z
+        call    pf_zfd
         pop     de
         pop     hl
         jp      pf_loop
 
+pf_lxu:
+        ld      a,1                     ; %lX -> uppercase A-F
+        ld      (pf_hexup),a
+        jr      pf_lx
+pf_lxl:
+        xor     a                       ; %lx -> lowercase a-f
+        ld      (pf_hexup),a
 pf_lx:
         ; Unsigned 32-bit hex (%lx): 8 hex digits, high word first
         push    hl
@@ -3139,7 +3245,17 @@ pf_hex_nib:
         add     a,'0'
         cp      '9'+1
         jr      c,pfh1
+        ; A-F (or a-f): base 'A' is '9'+1+7; for lowercase add a further 20h.
         add     a,7
+        push    af
+        ld      a,(pf_hexup)
+        or      a
+        jr      nz,pfh_up
+        pop     af
+        add     a,20h           ; lowercase a-f for %x/%lx
+        jr      pfh1
+pfh_up:
+        pop     af              ; uppercase A-F for %X/%lX
 pfh1:
         call    pf_emit_a
         ret
@@ -3151,6 +3267,10 @@ pf_digit:
 pf_prec:
         db      0
 pf_left:
+        db      0
+pf_zero:
+        db      0
+pf_hexup:
         db      0
 
 pf_decbuf:

--- a/baseline_test_dcc.txt
+++ b/baseline_test_dcc.txt
@@ -114,10 +114,10 @@ test tprintf
 12345
 32767
 0000
-00FF
+00ff
 0123
-0ABC
-7FFF
+0abc
+7fff
 A
 a
 0
@@ -132,8 +132,8 @@ world
 [    42]
 [   abc]
 [ hello]
-[  00FF]
-[  0ABC]
+[  00ff]
+[  0abc]
 1 2 3
 ans=42
 ABC
@@ -147,31 +147,31 @@ tprintf ok
 test ts
 top of app
 print an int 27
-sizeof uint8_t: 1, result 00FF
-sizeof uint8_t: 1, result 00FF
-sizeof uint8_t: 1, result 007F
-sizeof uint8_t: 1, result 007F
-sizeof uint16_t: 2, result FFFF
-sizeof uint16_t: 2, result FFFF
-sizeof uint16_t: 2, result 7FFF
-sizeof uint16_t: 2, result 7FFF
-sizeof long: 4, result FFFFFFFF
-sizeof long: 4, result FFFFFFFF
-sizeof ulong: 4, result 7FFFFFFF
-sizeof ulong: 4, result 7FFFFFFF
+sizeof uint8_t: 1, result 00ff
+sizeof uint8_t: 1, result 00ff
+sizeof uint8_t: 1, result 007f
+sizeof uint8_t: 1, result 007f
+sizeof uint16_t: 2, result ffff
+sizeof uint16_t: 2, result ffff
+sizeof uint16_t: 2, result 7fff
+sizeof uint16_t: 2, result 7fff
+sizeof long: 4, result ffffffff
+sizeof long: 4, result ffffffff
+sizeof ulong: 4, result 7fffffff
+sizeof ulong: 4, result 7fffffff
 now test left shifts
-sizeof uint8_t: 1, result 00FE
-sizeof uint8_t: 1, result 00FE
-sizeof uint8_t: 1, result 00FE
-sizeof uint8_t: 1, result 00FE
-sizeof uint16_t: 2, result FFFE
-sizeof uint16_t: 2, result FFFE
-sizeof uint16_t: 2, result FFFE
-sizeof uint16_t: 2, result FFFE
-sizeof long: 4, result FFFFFFFE
-sizeof long: 4, result FFFFFFFE
-sizeof ulong: 4, result FFFFFFFE
-sizeof ulong: 4, result FFFFFFFE
+sizeof uint8_t: 1, result 00fe
+sizeof uint8_t: 1, result 00fe
+sizeof uint8_t: 1, result 00fe
+sizeof uint8_t: 1, result 00fe
+sizeof uint16_t: 2, result fffe
+sizeof uint16_t: 2, result fffe
+sizeof uint16_t: 2, result fffe
+sizeof uint16_t: 2, result fffe
+sizeof long: 4, result fffffffe
+sizeof long: 4, result fffffffe
+sizeof ulong: 4, result fffffffe
+sizeof ulong: 4, result fffffffe
 now test comparisons
 t, f, t, f, t
 t, f, t, f, t
@@ -183,8 +183,8 @@ f, f, f, t, t
 testing printf
   string: 'hello'
   char: 'h'
-  int: 27, 001B
-  negative int: -27, FFE5
+  int: 27, 001b
+  negative int: -27, ffe5
 ts completed with great success
 test tcmp
 uint8_t:
@@ -3479,65 +3479,65 @@ finding XYZ files
 cp/m enumerate directory completed with great success
 test tbits
 uint8_t:
-  and 0003, or 0007, xor 0004, nota 00F8, notb 00FC
-  and 0005, or 00FF, xor 00FA, nota 00F8, notb 0002
-  and 0001, or 00FB, xor 00FA, nota 0006, notb 00FC
-  and 00F9, or 00FD, xor 0004, nota 0006, notb 0002
-  and 00FF, or 00FF, xor 0000, nota 0000, notb 0000
-  and 0003, or 00F7, xor 00F4, nota 0008, notb 00FC
-  and 00F5, or 00FF, xor 000A, nota 0008, notb 0002
-  and 0001, or 000B, xor 000A, nota 00F6, notb 00FC
-  and 0009, or 0009, xor 0000, nota 00F6, notb 00F6
+  and 0003, or 0007, xor 0004, nota 00f8, notb 00fc
+  and 0005, or 00ff, xor 00fa, nota 00f8, notb 0002
+  and 0001, or 00fb, xor 00fa, nota 0006, notb 00fc
+  and 00f9, or 00fd, xor 0004, nota 0006, notb 0002
+  and 00ff, or 00ff, xor 0000, nota 0000, notb 0000
+  and 0003, or 00f7, xor 00f4, nota 0008, notb 00fc
+  and 00f5, or 00ff, xor 000a, nota 0008, notb 0002
+  and 0001, or 000b, xor 000a, nota 00f6, notb 00fc
+  and 0009, or 0009, xor 0000, nota 00f6, notb 00f6
 int8_t:
-  and 0003, or 0007, xor 0004, nota FFF8, notb FFFC
-  and 0005, or FFFF, xor FFFA, nota FFF8, notb 0002
-  and 0001, or FFFB, xor FFFA, nota 0006, notb FFFC
-  and FFF9, or FFFD, xor 0004, nota 0006, notb 0002
-  and FFFF, or FFFF, xor 0000, nota 0000, notb 0000
-  and 0003, or FFF7, xor FFF4, nota 0008, notb FFFC
-  and FFF5, or FFFF, xor 000A, nota 0008, notb 0002
-  and 0001, or 000B, xor 000A, nota FFF6, notb FFFC
-  and 0009, or 0009, xor 0000, nota FFF6, notb FFF6
+  and 0003, or 0007, xor 0004, nota fff8, notb fffc
+  and 0005, or ffff, xor fffa, nota fff8, notb 0002
+  and 0001, or fffb, xor fffa, nota 0006, notb fffc
+  and fff9, or fffd, xor 0004, nota 0006, notb 0002
+  and ffff, or ffff, xor 0000, nota 0000, notb 0000
+  and 0003, or fff7, xor fff4, nota 0008, notb fffc
+  and fff5, or ffff, xor 000a, nota 0008, notb 0002
+  and 0001, or 000b, xor 000a, nota fff6, notb fffc
+  and 0009, or 0009, xor 0000, nota fff6, notb fff6
 uint16_t:
-  and 0003, or 0007, xor 0004, nota FFF8, notb FFFC
-  and 0005, or FFFF, xor FFFA, nota FFF8, notb 0002
-  and 0001, or FFFB, xor FFFA, nota 0006, notb FFFC
-  and FFF9, or FFFD, xor 0004, nota 0006, notb 0002
-  and FFFF, or FFFF, xor 0000, nota 0000, notb 0000
-  and 0003, or 00F7, xor 00F4, nota FF08, notb FFFC
-  and 00F5, or FFFF, xor FF0A, nota FF08, notb 0002
-  and 0001, or FF0B, xor FF0A, nota 00F6, notb FFFC
-  and FF09, or FF09, xor 0000, nota 00F6, notb 00F6
+  and 0003, or 0007, xor 0004, nota fff8, notb fffc
+  and 0005, or ffff, xor fffa, nota fff8, notb 0002
+  and 0001, or fffb, xor fffa, nota 0006, notb fffc
+  and fff9, or fffd, xor 0004, nota 0006, notb 0002
+  and ffff, or ffff, xor 0000, nota 0000, notb 0000
+  and 0003, or 00f7, xor 00f4, nota ff08, notb fffc
+  and 00f5, or ffff, xor ff0a, nota ff08, notb 0002
+  and 0001, or ff0b, xor ff0a, nota 00f6, notb fffc
+  and ff09, or ff09, xor 0000, nota 00f6, notb 00f6
 int16_t:
-  and 0003, or 0007, xor 0004, nota FFF8, notb FFFC
-  and 0005, or FFFF, xor FFFA, nota FFF8, notb 0002
-  and 0001, or FFFB, xor FFFA, nota 0006, notb FFFC
-  and FFF9, or FFFD, xor 0004, nota 0006, notb 0002
-  and FFFF, or FFFF, xor 0000, nota 0000, notb 0000
-  and 0003, or 00F7, xor 00F4, nota FF08, notb FFFC
-  and 00F5, or FFFF, xor FF0A, nota FF08, notb 0002
-  and 0001, or FF0B, xor FF0A, nota 00F6, notb FFFC
-  and FF09, or FF09, xor 0000, nota 00F6, notb 00F6
+  and 0003, or 0007, xor 0004, nota fff8, notb fffc
+  and 0005, or ffff, xor fffa, nota fff8, notb 0002
+  and 0001, or fffb, xor fffa, nota 0006, notb fffc
+  and fff9, or fffd, xor 0004, nota 0006, notb 0002
+  and ffff, or ffff, xor 0000, nota 0000, notb 0000
+  and 0003, or 00f7, xor 00f4, nota ff08, notb fffc
+  and 00f5, or ffff, xor ff0a, nota ff08, notb 0002
+  and 0001, or ff0b, xor ff0a, nota 00f6, notb fffc
+  and ff09, or ff09, xor 0000, nota 00f6, notb 00f6
 uint32_t:
-  and 00000003, or 00000007, xor 00000004, nota FFFFFFF8, notb FFFFFFFC
-  and 00000005, or FFFFFFFF, xor FFFFFFFA, nota FFFFFFF8, notb 00000002
-  and 00000001, or FFFFFFFB, xor FFFFFFFA, nota 00000006, notb FFFFFFFC
-  and FFFFFFF9, or FFFFFFFD, xor 00000004, nota 00000006, notb 00000002
-  and FFFFFFFF, or FFFFFFFF, xor 00000000, nota 00000000, notb 00000000
-  and 00000003, or 000000F7, xor 000000F4, nota FFFFFF08, notb FFFFFFFC
-  and 000000F5, or FFFFFFFF, xor FFFFFF0A, nota FFFFFF08, notb 00000002
-  and 00000001, or FFFFFF0B, xor FFFFFF0A, nota 000000F6, notb FFFFFFFC
-  and FFFFFF09, or FFFFFF09, xor 00000000, nota 000000F6, notb 000000F6
+  and 00000003, or 00000007, xor 00000004, nota fffffff8, notb fffffffc
+  and 00000005, or ffffffff, xor fffffffa, nota fffffff8, notb 00000002
+  and 00000001, or fffffffb, xor fffffffa, nota 00000006, notb fffffffc
+  and fffffff9, or fffffffd, xor 00000004, nota 00000006, notb 00000002
+  and ffffffff, or ffffffff, xor 00000000, nota 00000000, notb 00000000
+  and 00000003, or 000000f7, xor 000000f4, nota ffffff08, notb fffffffc
+  and 000000f5, or ffffffff, xor ffffff0a, nota ffffff08, notb 00000002
+  and 00000001, or ffffff0b, xor ffffff0a, nota 000000f6, notb fffffffc
+  and ffffff09, or ffffff09, xor 00000000, nota 000000f6, notb 000000f6
 int32_t:
-  and 00000003, or 00000007, xor 00000004, nota FFFFFFF8, notb FFFFFFFC
-  and 00000005, or FFFFFFFF, xor FFFFFFFA, nota FFFFFFF8, notb 00000002
-  and 00000001, or FFFFFFFB, xor FFFFFFFA, nota 00000006, notb FFFFFFFC
-  and FFFFFFF9, or FFFFFFFD, xor 00000004, nota 00000006, notb 00000002
-  and FFFFFFFF, or FFFFFFFF, xor 00000000, nota 00000000, notb 00000000
-  and 00000003, or 000000F7, xor 000000F4, nota FFFFFF08, notb FFFFFFFC
-  and 000000F5, or FFFFFFFF, xor FFFFFF0A, nota FFFFFF08, notb 00000002
-  and 00000001, or FFFFFF0B, xor FFFFFF0A, nota 000000F6, notb FFFFFFFC
-  and FFFFFF09, or FFFFFF09, xor 00000000, nota 000000F6, notb 000000F6
+  and 00000003, or 00000007, xor 00000004, nota fffffff8, notb fffffffc
+  and 00000005, or ffffffff, xor fffffffa, nota fffffff8, notb 00000002
+  and 00000001, or fffffffb, xor fffffffa, nota 00000006, notb fffffffc
+  and fffffff9, or fffffffd, xor 00000004, nota 00000006, notb 00000002
+  and ffffffff, or ffffffff, xor 00000000, nota 00000000, notb 00000000
+  and 00000003, or 000000f7, xor 000000f4, nota ffffff08, notb fffffffc
+  and 000000f5, or ffffffff, xor ffffff0a, nota ffffff08, notb 00000002
+  and 00000001, or ffffff0b, xor ffffff0a, nota 000000f6, notb fffffffc
+  and ffffff09, or ffffff09, xor 00000000, nota 000000f6, notb 000000f6
 tbits completed with great success
 test tfo
 filelen: 0
@@ -4255,3 +4255,22 @@ test tfarrsub
 PASS field_arr_subscript
 test t2darr
 PASS multidim_array
+test too
+too: OO-style C stress test for dcc
+shapes:
+  #1 Rectangle area=24.00 perim=20.00
+  #2 Circle    area=78.54 perim=31.41
+  #3 Triangle  area=6.00 perim=12.00
+dispatch table:
+  query[0]=area query[1]=perim
+world:
+  total area before scale=108.54
+  total area after 200% scale=434.16
+multidim:
+  board weight=138 cells checksum=222
+aggregates:
+  list area sum=108.54 bst sum=45 height=4
+ran 25 checks, 0 failures
+too passed with great success
+test tzpad
+tzpad passed with great success

--- a/runall.bat
+++ b/runall.bat
@@ -23,7 +23,7 @@ set _applist=sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong ^
              tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom ^
              tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield ^
              pint cobint forint bint fint cint adaint tstretst tportio tlongidx tforsco ^
-             tforblk tcmt99 tc99scpe tctxflt tmathf tstrconv tfarrsub t2darr
+             tforblk tcmt99 tc99scpe tctxflt tmathf tstrconv tfarrsub t2darr too tzpad
 
 echo --- optimized (ma peep) ---
 set "outputfile=test_dcc.txt"

--- a/runall.sh
+++ b/runall.sh
@@ -22,7 +22,7 @@ APPLIST="sieve e ttt tstruct trw tstr tbug tprintf ts tcmp tunary tlong \
          tunion2 tbitfld tcnstfld tpromo tkandr tc89ini2 tdecl tctype tifcom \
          tptrdiff tmulpow2 toffset tc89fini tmod3216 tpromo2 tunaryp tstfield \
          pint cobint forint bint fint cint adaint tstretst tportio tlongidx tforsco \
-         tforblk tcmt99 tc99scpe tctxflt tmathf tstrconv tfarrsub t2darr"
+         tforblk tcmt99 tc99scpe tctxflt tmathf tstrconv tfarrsub t2darr too tzpad"
 
 run_args() {
     case "$1" in

--- a/tests/too.c
+++ b/tests/too.c
@@ -1,0 +1,644 @@
+/* too.c - "object-oriented C" stress test for the dcc compiler.
+ *
+ * Wired into the runall harness (runall.sh / runall.bat); also build/run
+ * standalone with:
+ *     ./ma.sh too peep   &&  ntvcm TOO
+ *     ./ma.sh too nopeep &&  ntvcm TOO
+ *
+ * The point of this program is to lean hard on the parts of dcc that are easy
+ * to get wrong on a 16-bit, single-pass, syntax-directed code generator:
+ *
+ *   - vtable polymorphism: structs of function pointers reached as
+ *     self->vt->method(self), plus arrays/tables of function pointers.
+ *   - single inheritance by first-member embedding, with up-casts
+ *     (Derived* -> Shape*) and down-casts (Shape* -> Derived*).
+ *   - polymorphic containers: arrays of base pointers, pointer-to-pointer
+ *     iteration, and a visitor callback applied across the collection.
+ *   - multidimensional data crossing call boundaries: pointer-to-2D-array
+ *     parameters (Tile (*b)[COLS]), 2D arrays embedded in structs reached
+ *     through a pointer (the dcc_expr.c field-array stride path), and 2D
+ *     arrays nested inside an array of structs.
+ *   - self-referential aggregates: an intrusive linked list and a recursive
+ *     binary search tree allocated from a static object pool.
+ *   - 32-bit fixed-point arithmetic (areas/perimeters scaled by 100) so the
+ *     whole thing stays deterministic without float / -ffloatio.
+ *
+ * Every interesting value is checked against a hand-computed expected result;
+ * the program prints a running log and finishes with either
+ *     too passed with great success
+ * or a non-zero exit and a FAIL line.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/* tiny self-checking harness                                          */
+/* ------------------------------------------------------------------ */
+
+static int g_checks;
+static int g_fails;
+
+static void check_l(const char *name, long got, long expected)
+{
+    g_checks++;
+    if (got != expected) {
+        g_fails++;
+        printf("  FAIL %s: got %ld expected %ld\n", name, got, expected);
+    }
+}
+
+static void check_i(const char *name, int got, int expected)
+{
+    check_l(name, (long)got, (long)expected);
+}
+
+static void check_s(const char *name, const char *got, const char *expected)
+{
+    g_checks++;
+    if (strcmp(got, expected) != 0) {
+        g_fails++;
+        printf("  FAIL %s: got \"%s\" expected \"%s\"\n", name, got, expected);
+    }
+}
+
+/* print a fixed-point (value * 100) quantity as N.NN */
+static void put_fixed(long v100)
+{
+    long whole = v100 / 100;
+    long frac = v100 % 100;
+    if (frac < 0)
+        frac = -frac;
+    printf("%ld.%02ld", whole, frac);
+}
+
+/* integer square root of a non-negative long */
+static long isqrt_l(long n)
+{
+    long x, y;
+
+    if (n <= 0)
+        return 0;
+    x = n;
+    y = (x + 1) / 2;
+    while (y < x) {
+        x = y;
+        y = (x + n / x) / 2;
+    }
+    return x;
+}
+
+/* ------------------------------------------------------------------ */
+/* polymorphic Shape hierarchy (vtable dispatch + embedded base)       */
+/* ------------------------------------------------------------------ */
+
+struct Shape;   /* forward declaration for the vtable signatures */
+
+typedef long (*area_fn)(const struct Shape *self);
+typedef long (*perim_fn)(const struct Shape *self);
+typedef void (*scale_fn)(struct Shape *self, int pct);
+
+typedef struct ShapeVTable {
+    const char *name;
+    area_fn   area;     /* fixed-point area  * 100 */
+    perim_fn  perim;    /* fixed-point perim * 100 */
+    scale_fn  scale;    /* scale every linear dimension by pct/100 */
+} ShapeVTable;
+
+typedef struct Shape {
+    const ShapeVTable *vt;   /* virtual dispatch table (must work through ptr) */
+    int id;
+} Shape;
+
+/* generic dispatchers - the only code that "knows" about Shape */
+static long shape_area(const Shape *s)  { return s->vt->area(s); }
+static long shape_perim(const Shape *s) { return s->vt->perim(s); }
+static void shape_scale(Shape *s, int pct) { s->vt->scale(s, pct); }
+
+static void shape_describe(const Shape *s)
+{
+    printf("  #%d %-9s area=", s->id, s->vt->name);
+    put_fixed(shape_area(s));
+    printf(" perim=");
+    put_fixed(shape_perim(s));
+    printf("\n");
+}
+
+/* ---- Rectangle ---- */
+
+typedef struct Rectangle {
+    Shape base;     /* MUST be first member for the up-cast to be valid */
+    int w;
+    int h;
+} Rectangle;
+
+static long rect_area(const struct Shape *self)
+{
+    const Rectangle *r = (const Rectangle *)self;   /* down-cast */
+    return (long)r->w * r->h * 100L;
+}
+
+static long rect_perim(const struct Shape *self)
+{
+    const Rectangle *r = (const Rectangle *)self;
+    return (long)(2 * (r->w + r->h)) * 100L;
+}
+
+static void rect_scale(struct Shape *self, int pct)
+{
+    Rectangle *r = (Rectangle *)self;
+    r->w = (int)((long)r->w * pct / 100);
+    r->h = (int)((long)r->h * pct / 100);
+}
+
+static const ShapeVTable RECT_VT = { "Rectangle", rect_area, rect_perim, rect_scale };
+
+static void rect_init(Rectangle *r, int id, int w, int h)
+{
+    r->base.vt = &RECT_VT;
+    r->base.id = id;
+    r->w = w;
+    r->h = h;
+}
+
+/* ---- Circle ---- */
+
+typedef struct Circle {
+    Shape base;
+    int radius;
+} Circle;
+
+/* pi * 10000 == 31416; areas/perims are kept * 100 fixed point */
+static long circ_area(const struct Shape *self)
+{
+    const Circle *c = (const Circle *)self;
+    return 31416L * c->radius * c->radius / 100L;
+}
+
+static long circ_perim(const struct Shape *self)
+{
+    const Circle *c = (const Circle *)self;
+    return 62832L * c->radius / 100L;
+}
+
+static void circ_scale(struct Shape *self, int pct)
+{
+    Circle *c = (Circle *)self;
+    c->radius = (int)((long)c->radius * pct / 100);
+}
+
+static const ShapeVTable CIRC_VT = { "Circle", circ_area, circ_perim, circ_scale };
+
+static void circ_init(Circle *c, int id, int radius)
+{
+    c->base.vt = &CIRC_VT;
+    c->base.id = id;
+    c->radius = radius;
+}
+
+/* ---- right Triangle (legs b,h) ---- */
+
+typedef struct Triangle {
+    Shape base;
+    int b;
+    int h;
+} Triangle;
+
+static long tri_area(const struct Shape *self)
+{
+    const Triangle *t = (const Triangle *)self;
+    return (long)t->b * t->h * 50L;   /* b*h/2, * 100 */
+}
+
+static long tri_perim(const struct Shape *self)
+{
+    const Triangle *t = (const Triangle *)self;
+    long hyp = isqrt_l((long)t->b * t->b + (long)t->h * t->h);
+    return ((long)t->b + t->h + hyp) * 100L;
+}
+
+static void tri_scale(struct Shape *self, int pct)
+{
+    Triangle *t = (Triangle *)self;
+    t->b = (int)((long)t->b * pct / 100);
+    t->h = (int)((long)t->h * pct / 100);
+}
+
+static const ShapeVTable TRI_VT = { "Triangle", tri_area, tri_perim, tri_scale };
+
+static void tri_init(Triangle *t, int id, int b, int h)
+{
+    t->base.vt = &TRI_VT;
+    t->base.id = id;
+    t->b = b;
+    t->h = h;
+}
+
+/* ------------------------------------------------------------------ */
+/* polymorphic container + visitor                                     */
+/* ------------------------------------------------------------------ */
+
+#define MAX_SHAPES 8
+
+typedef struct World {
+    Shape *items[MAX_SHAPES];   /* array of base pointers (up-cast on insert) */
+    int count;
+    long area_accum;            /* mutated by the visitor below */
+} World;
+
+typedef void (*visit_fn)(Shape *s, World *w);
+
+static void world_init(World *w)
+{
+    w->count = 0;
+    w->area_accum = 0;
+}
+
+static void world_add(World *w, Shape *s)
+{
+    if (w->count < MAX_SHAPES)
+        w->items[w->count++] = s;
+}
+
+/* visit each element through a pointer-to-pointer walk */
+static void world_visit(World *w, visit_fn fn)
+{
+    Shape **pp = w->items;
+    Shape **end = w->items + w->count;
+    while (pp < end) {
+        fn(*pp, w);
+        pp++;
+    }
+}
+
+static void accum_area_visitor(Shape *s, World *w)
+{
+    w->area_accum += shape_area(s);
+}
+
+static void scale_all_visitor(Shape *s, World *w)
+{
+    (void)w;
+    shape_scale(s, 200);    /* double every shape */
+}
+
+/* ------------------------------------------------------------------ */
+/* function-pointer dispatch table (a "method selector")              */
+/* ------------------------------------------------------------------ */
+
+typedef long (*query_fn)(const Shape *s);
+
+typedef struct Query {
+    const char *label;
+    query_fn fn;
+} Query;
+
+static const Query QUERIES[] = {
+    { "area",  shape_area },
+    { "perim", shape_perim }
+};
+
+static long run_query(const Shape *s, int which)
+{
+    return QUERIES[which].fn(s);
+}
+
+/* ------------------------------------------------------------------ */
+/* multidimensional data across call boundaries                        */
+/* ------------------------------------------------------------------ */
+
+#define ROWS 3
+#define COLS 4
+
+typedef struct Tile {
+    char ch;
+    int weight;
+} Tile;
+
+typedef struct Board {
+    Tile grid[ROWS][COLS];   /* 2D array of structs embedded in a struct */
+    int generation;
+} Board;
+
+static void board_fill(Board *bd)
+{
+    int r, c;
+    for (r = 0; r < ROWS; r++) {
+        for (c = 0; c < COLS; c++) {
+            bd->grid[r][c].ch = (char)('A' + r * COLS + c);
+            bd->grid[r][c].weight = r * 10 + c;   /* field 2D array via ptr */
+        }
+    }
+    bd->generation = 1;
+}
+
+/* pointer-to-2D-array parameter: b decays to Tile(*)[COLS] */
+static long board_weight(Tile (*b)[COLS], int rows)
+{
+    long sum = 0;
+    int r, c;
+    for (r = 0; r < rows; r++)
+        for (c = 0; c < COLS; c++)
+            sum += b[r][c].weight;
+    return sum;
+}
+
+/* return the address of an element of a struct-embedded 2D array */
+static Tile *tile_at(Board *bd, int r, int c)
+{
+    return &bd->grid[r][c];
+}
+
+/* ---- 2D array nested inside an array of structs ---- */
+
+typedef struct Cell {
+    unsigned char g[2][2];
+    int tag;
+} Cell;
+
+#define NCELLS 3
+
+static Cell g_cells[NCELLS];
+
+static void cells_fill(void)
+{
+    int k, i, j;
+    for (k = 0; k < NCELLS; k++) {
+        Cell *cp = &g_cells[k];          /* pointer into array of structs */
+        for (i = 0; i < 2; i++)
+            for (j = 0; j < 2; j++)
+                cp->g[i][j] = (unsigned char)((k * 16 + i * 4 + j) & 255);
+        cp->tag = k * 100;
+    }
+}
+
+static long cells_checksum(void)
+{
+    long sum = 0;
+    int k, i, j;
+    for (k = 0; k < NCELLS; k++) {
+        const Cell *cp = &g_cells[k];
+        for (i = 0; i < 2; i++)
+            for (j = 0; j < 2; j++)
+                sum += cp->g[i][j];
+    }
+    return sum;
+}
+
+/* ------------------------------------------------------------------ */
+/* self-referential aggregates: intrusive list + BST from a pool       */
+/* ------------------------------------------------------------------ */
+
+typedef struct Node {
+    Shape *shape;
+    struct Node *next;
+} Node;
+
+#define MAX_NODES 8
+static Node g_nodes[MAX_NODES];
+static int g_node_used;
+
+static Node *node_new(Shape *s)
+{
+    Node *n = &g_nodes[g_node_used++];
+    n->shape = s;
+    n->next = 0;
+    return n;
+}
+
+/* push-front build, returns new head */
+static Node *list_push(Node *head, Shape *s)
+{
+    Node *n = node_new(s);
+    n->next = head;
+    return n;
+}
+
+static long list_area_sum(const Node *head)
+{
+    long sum = 0;
+    const Node *p = head;
+    while (p != 0) {
+        sum += shape_area(p->shape);
+        p = p->next;
+    }
+    return sum;
+}
+
+/* ---- binary search tree of ints from a static pool ---- */
+
+typedef struct TNode {
+    int v;
+    struct TNode *l;
+    struct TNode *r;
+} TNode;
+
+#define MAX_TNODES 16
+static TNode g_tpool[MAX_TNODES];
+static int g_tused;
+
+static TNode *tnode_new(int v)
+{
+    TNode *t = &g_tpool[g_tused++];
+    t->v = v;
+    t->l = 0;
+    t->r = 0;
+    return t;
+}
+
+static TNode *bst_insert(TNode *root, int v)
+{
+    if (root == 0)
+        return tnode_new(v);
+    if (v < root->v)
+        root->l = bst_insert(root->l, v);
+    else
+        root->r = bst_insert(root->r, v);
+    return root;
+}
+
+static long bst_inorder_sum(const TNode *root)
+{
+    if (root == 0)
+        return 0;
+    return bst_inorder_sum(root->l) + root->v + bst_inorder_sum(root->r);
+}
+
+static int bst_height(const TNode *root)
+{
+    int hl, hr;
+    if (root == 0)
+        return 0;
+    hl = bst_height(root->l);
+    hr = bst_height(root->r);
+    return 1 + (hl > hr ? hl : hr);
+}
+
+/* ------------------------------------------------------------------ */
+/* drivers                                                             */
+/* ------------------------------------------------------------------ */
+
+static Rectangle g_rect;
+static Circle    g_circ;
+static Triangle  g_tri;
+static World     g_world;
+
+static void test_shapes(void)
+{
+    printf("shapes:\n");
+
+    rect_init(&g_rect, 1, 4, 6);
+    circ_init(&g_circ, 2, 5);
+    tri_init(&g_tri, 3, 3, 4);
+
+    /* dispatch through the base pointer (up-cast) */
+    shape_describe((Shape *)&g_rect);
+    shape_describe((Shape *)&g_circ);
+    shape_describe((Shape *)&g_tri);
+
+    check_l("rect.area",  shape_area((Shape *)&g_rect),  2400L);
+    check_l("rect.perim", shape_perim((Shape *)&g_rect), 2000L);
+    check_l("circ.area",  shape_area((Shape *)&g_circ),  7854L);
+    check_l("circ.perim", shape_perim((Shape *)&g_circ), 3141L);
+    check_l("tri.area",   shape_area((Shape *)&g_tri),    600L);
+    check_l("tri.perim",  shape_perim((Shape *)&g_tri),  1200L);
+
+    /* virtual name through the vtable */
+    check_s("rect.name", ((Shape *)&g_rect)->vt->name, "Rectangle");
+    check_s("circ.name", ((Shape *)&g_circ)->vt->name, "Circle");
+    check_s("tri.name",  ((Shape *)&g_tri)->vt->name,  "Triangle");
+}
+
+static void test_dispatch_table(void)
+{
+    Shape *s = (Shape *)&g_rect;
+    printf("dispatch table:\n");
+    check_l("query.area",  run_query(s, 0), 2400L);
+    check_l("query.perim", run_query(s, 1), 2000L);
+    printf("  query[0]=%s query[1]=%s\n", QUERIES[0].label, QUERIES[1].label);
+}
+
+static void test_world(void)
+{
+    long before, after;
+
+    printf("world:\n");
+    world_init(&g_world);
+    world_add(&g_world, (Shape *)&g_rect);
+    world_add(&g_world, (Shape *)&g_circ);
+    world_add(&g_world, (Shape *)&g_tri);
+    check_i("world.count", g_world.count, 3);
+
+    g_world.area_accum = 0;
+    world_visit(&g_world, accum_area_visitor);
+    before = g_world.area_accum;
+    check_l("world.area_sum", before, 10854L);
+    printf("  total area before scale=");
+    put_fixed(before);
+    printf("\n");
+
+    /* polymorphic mutation, then re-measure: each shape doubled linearly,
+       so areas grow ~4x (circle/rect) and triangle 4x too. */
+    world_visit(&g_world, scale_all_visitor);
+    g_world.area_accum = 0;
+    world_visit(&g_world, accum_area_visitor);
+    after = g_world.area_accum;
+
+    /* rect 8x12 -> 9600; circle r10 -> 31416; tri 6x8 -> 2400 = 43416 */
+    check_l("world.area_after", after, 43416L);
+    printf("  total area after 200%% scale=");
+    put_fixed(after);
+    printf("\n");
+}
+
+static Board g_board;
+
+static void test_multidim(void)
+{
+    Tile *t;
+    long w_struct, w_ptr;
+
+    printf("multidim:\n");
+    board_fill(&g_board);
+
+    /* sum via pointer-to-2D-array parameter (array decay) */
+    w_ptr = board_weight(g_board.grid, ROWS);
+    check_l("board.weight_ptr", w_ptr, 138L);
+
+    /* sum directly through the struct pointer (field 2D array stride) */
+    w_struct = 0;
+    {
+        int r, c;
+        for (r = 0; r < ROWS; r++)
+            for (c = 0; c < COLS; c++)
+                w_struct += g_board.grid[r][c].weight;
+    }
+    check_l("board.weight_struct", w_struct, 138L);
+
+    /* address-of a struct-embedded 2D element returned across a call */
+    t = tile_at(&g_board, 2, 3);
+    check_i("tile_at.weight", t->weight, 23);
+    check_i("tile_at.ch", (int)t->ch, (int)('A' + 2 * COLS + 3));
+
+    cells_fill();
+    check_l("cells.checksum", cells_checksum(), 222L);
+    check_i("cells[2].tag", g_cells[2].tag, 200);
+    printf("  board weight=%ld cells checksum=%ld\n",
+           w_ptr, cells_checksum());
+}
+
+static void test_aggregates(void)
+{
+    Node *head = 0;
+    TNode *root = 0;
+    int seq[9];
+    int i;
+
+    printf("aggregates:\n");
+
+    /* intrusive list of the original (pre-scale) shapes would have changed;
+       rebuild fresh shapes so the area sum is deterministic. */
+    rect_init(&g_rect, 1, 4, 6);
+    circ_init(&g_circ, 2, 5);
+    tri_init(&g_tri, 3, 3, 4);
+
+    g_node_used = 0;
+    head = list_push(head, (Shape *)&g_rect);
+    head = list_push(head, (Shape *)&g_circ);
+    head = list_push(head, (Shape *)&g_tri);
+    check_l("list.area_sum", list_area_sum(head), 10854L);
+    check_i("list.head_id", head->shape->id, 3);
+
+    /* BST insert + recursive traversals */
+    seq[0] = 5; seq[1] = 3; seq[2] = 8; seq[3] = 1; seq[4] = 4;
+    seq[5] = 7; seq[6] = 9; seq[7] = 2; seq[8] = 6;
+    g_tused = 0;
+    for (i = 0; i < 9; i++)
+        root = bst_insert(root, seq[i]);
+
+    check_l("bst.sum", bst_inorder_sum(root), 45L);
+    check_i("bst.root", root->v, 5);
+    check_i("bst.height", bst_height(root), 4);
+    printf("  list area sum=");
+    put_fixed(list_area_sum(head));
+    printf(" bst sum=%ld height=%d\n", bst_inorder_sum(root), bst_height(root));
+}
+
+int main(void)
+{
+    printf("too: OO-style C stress test for dcc\n");
+
+    test_shapes();
+    test_dispatch_table();
+    test_world();
+    test_multidim();
+    test_aggregates();
+
+    printf("ran %d checks, %d failures\n", g_checks, g_fails);
+    if (g_fails == 0) {
+        printf("too passed with great success\n");
+        return 0;
+    }
+    printf("too FAILED\n");
+    return 1;
+}

--- a/tests/tprintf.c
+++ b/tests/tprintf.c
@@ -55,12 +55,12 @@ int main()
     printf("%u\n", 12345);
     printf("%u\n", 32767);
 
-    /* %x hex -- always 4 digits, uppercase A-F */
+    /* %x hex -- always 4 digits, lowercase a-f (C89) */
     printf("%x\n", 0);
-    printf("%x\n", 255);       /* 00FF */
+    printf("%x\n", 255);       /* 00ff */
     printf("%x\n", 291);       /* 0123 */
-    printf("%x\n", 2748);      /* 0ABC */
-    printf("%x\n", 32767);     /* 7FFF */
+    printf("%x\n", 2748);      /* 0abc */
+    printf("%x\n", 32767);     /* 7fff */
 
     /* %c character */
     printf("%c\n", 65);        /* A */
@@ -83,8 +83,8 @@ int main()
     printf("[%6u]\n", 42);     /* [    42] */
     printf("[%6s]\n", "abc");  /* [   abc] */
     printf("[%6s]\n", "hello");/* [ hello] */
-    printf("[%6x]\n", 255);    /* [  00FF] */
-    printf("[%6x]\n", 2748);   /* [  0ABC] */
+    printf("[%6x]\n", 255);    /* [  00ff] */
+    printf("[%6x]\n", 2748);   /* [  0abc] */
 
     /* multiple arguments */
     printf("%d %d %d\n", 1, 2, 3);

--- a/tests/tsprintf.c
+++ b/tests/tsprintf.c
@@ -54,16 +54,16 @@ int main()
     check("0000", buf);
 
     sprintf(buf, "%x", 255);
-    check("00FF", buf);
+    check("00ff", buf);
 
     sprintf(buf, "%x", 291);
     check("0123", buf);
 
     sprintf(buf, "%x", 2748);
-    check("0ABC", buf);
+    check("0abc", buf);
 
     sprintf(buf, "%x", 32767);
-    check("7FFF", buf);
+    check("7fff", buf);
 
     /* %c */
     sprintf(buf, "%c", 65);
@@ -112,10 +112,10 @@ int main()
     check("[ hello]", buf);
 
     sprintf(buf, "[%6x]", 255);
-    check("[  00FF]", buf);
+    check("[  00ff]", buf);
 
     sprintf(buf, "[%6x]", 2748);
-    check("[  0ABC]", buf);
+    check("[  0abc]", buf);
 
     /* multiple arguments */
     sprintf(buf, "%d %d %d", 1, 2, 3);

--- a/tests/tzpad.c
+++ b/tests/tzpad.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <string.h>
+
+static int fails;
+
+static void eq(const char *got, const char *exp, const char *what)
+{
+    if (strcmp(got, exp) != 0) {
+        printf("FAIL %s: got [%s] expected [%s]\n", what, got, exp);
+        fails++;
+    }
+}
+
+int main(void)
+{
+    char b[64];
+
+    /* 16-bit signed */
+    sprintf(b, "%05d", 42);      eq(b, "00042", "d pos");
+    sprintf(b, "%05d", -42);     eq(b, "-0042", "d neg");
+    sprintf(b, "%02d", 12345);   eq(b, "12345", "d width<len");
+    sprintf(b, "%01d", 0);       eq(b, "0", "d zero val");
+    sprintf(b, "%03d", -7);      eq(b, "-07", "d neg small");
+
+    /* 16-bit unsigned */
+    sprintf(b, "%05u", 42U);     eq(b, "00042", "u pos");
+    sprintf(b, "%04u", 60000U);  eq(b, "60000", "u width<len");
+
+    /* hex: %x is lowercase, %X uppercase; both zero-pad to a fixed width */
+    sprintf(b, "%04x", 0x2aU);   eq(b, "002a", "x");
+    sprintf(b, "%04X", 0x2aU);   eq(b, "002A", "X");
+    sprintf(b, "%lx", 0xdeadUL); eq(b, "0000dead", "lx");
+    sprintf(b, "%lX", 0xdeadUL); eq(b, "0000DEAD", "lX");
+
+    /* 32-bit signed long */
+    sprintf(b, "%05ld", 42L);    eq(b, "00042", "ld pos");
+    sprintf(b, "%05ld", -42L);   eq(b, "-0042", "ld neg");
+    sprintf(b, "%08ld", 123456L);eq(b, "00123456", "ld big");
+    sprintf(b, "%02ld", 0L);     eq(b, "00", "ld two");
+    sprintf(b, "%02ld", 5L);     eq(b, "05", "ld frac5");
+
+    /* 32-bit unsigned long */
+    sprintf(b, "%06lu", 1234UL); eq(b, "001234", "lu");
+    sprintf(b, "%010lu", 100000UL); eq(b, "0000100000", "lu big");
+
+    /* '0' flag is correctly suppressed when '-' (left-justify) is present, so
+     * we get spaces not zeros.  (Integer left-justification itself is a
+     * separate pre-existing gap in dcc: %d ignores '-', so it stays
+     * right-justified.  We only assert that NO zero padding leaks in.) */
+    sprintf(b, "%-5d", 42);      eq(b, "   42", "left no zero");
+
+    /* '0' flag ignored when precision given (C semantics): precision wins */
+    sprintf(b, "%08.3d", 5);     eq(b, "     005", "zero+prec");
+
+    /* plain space width still works */
+    sprintf(b, "%5d", 42);       eq(b, "   42", "space width");
+    sprintf(b, "%5ld", 42L);     eq(b, "   42", "space width long");
+
+    /* precision-only zero fill (no width) */
+    sprintf(b, "%.4d", 42);      eq(b, "0042", "prec only");
+    sprintf(b, "%.4u", 42U);     eq(b, "0042", "prec only u");
+    sprintf(b, "%.4ld", 42L);    eq(b, "0042", "prec only ld");
+
+    if (fails == 0)
+        printf("tzpad passed with great success\n");
+    else
+        printf("tzpad FAILED (%d)\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
DCCRTL.MAC printf gains two C89 conformance fixes:

* '0' zero-pad flag: was absent, so %05d/%02ld space-padded. Add a pf_zero flag (a leading '0' before any width digit is the flag, not a width digit) plus helpers pf_zsetup (apply the flag; '0' is ignored when '-' or an explicit precision is present, per 7.19.6.1), pf_zfd (shared precision/zero-fill emit tail) and pf_efflen (size space padding from max(digits, precision)). Applied to %d/%u/%ld/%lu. pf_efflen also fixes a pre-existing width+precision over-pad (%8.3d).

* %x/%X case: %x and %X (and %lx/%lX) shared one uppercase formatter, so %x printed FF instead of ff. Add a pf_hexup flag set by entry shims so %x/%lx are lowercase and %X/%lX uppercase.

Tests:
* tests/too.c - new OO-style C stress test (vtable dispatch, single inheritance by first-member embedding, polymorphic containers and visitors, pointer-to-2D-array params, struct-embedded/ nested 2D arrays, intrusive list and recursive BST from static pools, 32-bit fixed-point math). Uses %02ld and relies on the zero-pad fix.
* tests/tzpad.c - new focused zero-pad/hex matrix (signed/unsigned, 16- and 32-bit, negatives, width<len, '-' overriding '0', precision disabling '0', precision-only, %x/%X/%lx/%lX case).
* tprintf.c / tsprintf.c - update %x expectations to lowercase.

Wire too and tzpad into runall.sh / runall.bat and refresh baseline_test_dcc.txt (172 hex lines re-cased to lowercase, plus the new test blocks). .gitignore: resolve stash-pop conflict. Full runall is green (peep + nopeep).