### PR TITLE
stdio: add buffered console output with setvbuf support

### DIFF
--- a/DCCRTL.MAC
+++ b/DCCRTL.MAC
@@ -74,6 +74,7 @@ bss_done:
         ld      hl,(__argc)
         push    hl              ; argc
         call    _main
+        call    __cflush                ; flush any buffered console output
         call    __cpm_set_retcode
         jp      0000h
 
@@ -178,21 +179,156 @@ argv:
 __argbuf:
         ds      128
 
+COBSZ   equ     128
+
 ; __conout: output char in E to console with LF->CR/LF translation.
-; Preserves all registers except F.
+; Buffered: the character is appended to __cobuf and the buffer is flushed to
+; the BDOS lazily.  The flush policy is set by setvbuf()/setbuf():
+;   __cob_mode = 0 (_IOFBF)  flush only when the buffer fills, on fflush(),
+;                            before stdin input, or at program exit;
+;                1 (_IOLBF)  additionally flush at each newline (the default);
+;                2 (_IONBF)  flush after every character.
+; Preserves all registers except F (callers rely on this).
 __conout:
+        push    af
+        push    bc
+        push    de
+        push    hl
         ld      a,e
         cp      0ah             ; LF?
-        jr      nz,__conout_raw
-        push    de
-        ld      e,0dh           ; emit CR first
-        ld      c,2
-        call    5
-        pop     de              ; restore original E (=0Ah)
-__conout_raw:
-        ld      c,2
-        call    5
+        jr      nz,co_one
+        ld      a,0dh           ; LF -> CR first
+        call    __cob_put
+        ld      a,0ah
+co_one:
+        call    __cob_put       ; append the character
+        ld      a,(__cob_mode)
+        or      a               ; 0 = _IOFBF: no per-char flush
+        jr      z,co_ret
+        dec     a               ; 1 = _IOLBF
+        jr      z,co_line
+        call    __cflush        ; 2 = _IONBF: flush every character
+        jr      co_ret
+co_line:
+        ld      a,e
+        cp      0ah             ; flush the buffered line on newline
+        jr      nz,co_ret
+        call    __cflush
+co_ret:
+        pop     hl
+        pop     de
+        pop     bc
+        pop     af
         ret
+
+; __cob_put: append the character in A to the console buffer; flush if it is
+; now full.  Preserves BC/DE/HL (DE still holds the char for __conout);
+; clobbers A and flags.  The active buffer base is __cob_ptr and the fill
+; threshold (usable bytes before a forced flush) is __cob_cap; these point at
+; the internal __cobuf/COBSZ by default or at a caller buffer set via setvbuf.
+__cob_put:
+        push    de
+        push    hl
+        ld      hl,(__cobcnt)
+        ld      de,(__cob_ptr)
+        add     hl,de
+        ld      (hl),a          ; buffer[cobcnt] = A
+        ld      hl,(__cobcnt)
+        inc     hl
+        ld      (__cobcnt),hl
+        ld      de,(__cob_cap)
+        or      a
+        sbc     hl,de           ; cobcnt - capacity
+        jr      c,cp_done       ; still room in the buffer
+        call    __cflush        ; buffer full: drain it
+cp_done:
+        pop     hl
+        pop     de
+        ret
+
+; __cflush: drain the console buffer to the BDOS.  Maximal runs of non-'$'
+; characters go out with BDOS function 9 (print '$'-terminated string) and any
+; literal '$' goes out with function 2, so the buffered bytes are reproduced
+; exactly while still batching most output into single BDOS calls.  A guard
+; byte just past the buffer end lets a run that reaches the end borrow a '$'
+; terminator.  Preserves all registers except F.
+__cflush:
+        push    af
+        push    bc
+        push    de
+        push    hl
+        ld      bc,(__cobcnt)
+        ld      a,b
+        or      c
+        jr      z,cf_reset      ; nothing buffered
+        ld      hl,(__cob_ptr)
+cf_outer:
+        ld      a,b
+        or      c
+        jr      z,cf_reset      ; all bytes emitted
+        ld      a,(hl)
+        cp      '$'
+        jr      nz,cf_run
+        ; literal '$' -> BDOS function 2
+        push    bc
+        push    hl
+        ld      e,'$'
+        ld      c,2
+        call    5
+        pop     hl
+        pop     bc
+        inc     hl
+        dec     bc
+        jr      cf_outer
+cf_run:
+        ld      d,h
+        ld      e,l             ; DE = start of the non-'$' run
+cf_scan:
+        ld      a,(hl)
+        cp      '$'
+        jr      z,cf_emit
+        inc     hl
+        dec     bc
+        ld      a,b
+        or      c
+        jr      nz,cf_scan
+cf_emit:
+        ; Run is [DE, HL).  Temporarily terminate it with '$' at HL.
+        ld      a,(hl)
+        push    af              ; save the real '$' or the guard byte
+        ld      (hl),'$'
+        push    bc
+        push    hl
+        ld      c,9             ; BDOS print '$'-terminated string (DE = start)
+        call    5
+        pop     hl
+        pop     bc
+        pop     af
+        ld      (hl),a          ; restore the saved byte
+        jr      cf_outer
+cf_reset:
+        ld      hl,0
+        ld      (__cobcnt),hl
+        pop     hl
+        pop     de
+        pop     bc
+        pop     af
+        ret
+
+__cob_mode:
+        db      1               ; default _IOLBF (line-buffered console)
+__cobcnt:
+        dw      0
+; Active console buffer: base pointer + usable capacity (bytes appended before
+; a forced flush).  Default to the internal buffer; setvbuf/setbuf may repoint
+; these at a caller-supplied buffer (capacity = size-1, reserving one guard
+; byte for the '$' terminator borrowed by __cflush).
+__cob_ptr:
+        dw      __cobuf
+__cob_cap:
+        dw      COBSZ
+__cobuf:
+        ds      COBSZ+1         ; +1 guard slot for the '$' terminator
 
         public  __pchr
 __pchr:
@@ -300,8 +436,117 @@ clrerr_done:
         public  _setbuf
 _setbuf:
         ; void setbuf(FILE *fp, char *buf)
-        ; Unbuffered/stubbed: all current I/O goes through direct CP/M calls.
+        ; C89 7.9.5.5: equivalent to setvbuf(fp, buf, buf ? _IOFBF : _IONBF,
+        ; BUFSIZ).  When buf is non-NULL the caller's BUFSIZ-byte buffer is
+        ; adopted for console output; when NULL the stream becomes unbuffered
+        ; and the internal buffer is used.
+        push    ix
+        ld      ix,0
+        add     ix,sp
+        ld      a,(ix+5)                ; only stdout/stderr (fd 1/2) use this
+        or      a
+        jr      nz,sb_ret               ; real file stream: write-through no-op
+        ld      a,(ix+4)
+        cp      1
+        jr      z,sb_console
+        cp      2
+        jr      nz,sb_ret               ; stdin/invalid: no output buffer
+sb_console:
+        call    __cflush                ; drain anything already buffered
+        ld      l,(ix+6)
+        ld      h,(ix+7)                ; HL = buf
+        ld      a,h
+        or      l                       ; buf == NULL ?
+        jr      z,sb_none
+        ld      de,256                  ; BUFSIZ (stdio.h); literal for M80
+        call    __cob_setbuf            ; adopt caller buffer (size BUFSIZ)
+        xor     a                       ; _IOFBF
+        ld      (__cob_mode),a
+        jr      sb_ret
+sb_none:
+        call    __cob_default           ; revert to the internal buffer
+        ld      a,2                     ; _IONBF
+        ld      (__cob_mode),a
+sb_ret:
         ld      hl,0
+        pop     ix
+        ret
+
+        public  _setvbuf
+_setvbuf:
+        ; int setvbuf(FILE *fp, char *buf, int mode, size_t size)
+        ; mode: _IOFBF(0)/_IOLBF(1)/_IONBF(2).  Returns 0 on success, nonzero
+        ; for an invalid mode.  When buf is non-NULL and size >= 2 the caller's
+        ; buffer is adopted for console output (capacity = size-1, reserving
+        ; one guard byte); otherwise the internal buffer is used.
+        push    ix
+        ld      ix,0
+        add     ix,sp
+        ld      a,(ix+8)                ; mode (low byte; int is 16-bit)
+        cp      3
+        jr      nc,svb_bad              ; mode > 2: invalid
+        ld      a,(ix+5)                ; only stdout/stderr (fd 1/2) use this
+        or      a
+        jr      nz,svb_noop             ; real file stream: write-through no-op
+        ld      a,(ix+4)
+        cp      1
+        jr      z,svb_console
+        cp      2
+        jr      nz,svb_noop             ; stdin/invalid: no output buffer
+svb_console:
+        call    __cflush                ; drain anything already buffered
+        ld      a,(ix+8)                ; mode (low byte; int is 16-bit)
+        ld      (__cob_mode),a
+        ld      l,(ix+6)
+        ld      h,(ix+7)                ; HL = buf
+        ld      a,h
+        or      l                       ; buf == NULL ?
+        jr      z,svb_internal
+        ld      e,(ix+10)
+        ld      d,(ix+11)               ; DE = size
+        call    __cob_setbuf            ; adopt caller buffer if size >= 2
+        ld      hl,0                    ; success
+        pop     ix
+        ret
+svb_internal:
+        call    __cob_default
+        ld      hl,0                    ; success
+        pop     ix
+        ret
+svb_noop:
+        ld      hl,0                    ; success: file streams are write-through
+        pop     ix
+        ret
+svb_bad:
+        ld      hl,0ffffh               ; nonzero: invalid mode
+        pop     ix
+        ret
+
+; __cob_setbuf: adopt a caller buffer for console output.
+; IN:  HL = buffer base, DE = buffer size.
+; Sets __cob_ptr = HL and __cob_cap = size-1 (one byte reserved as the '$'
+; guard slot used by __cflush).  A size < 2 cannot host the guard byte, so it
+; falls back to the internal buffer.  Clobbers A/DE/HL.
+__cob_setbuf:
+        ld      a,d
+        or      a
+        jr      nz,csb_ok               ; size >= 256: plenty of room
+        ld      a,e
+        cp      2
+        jr      c,__cob_default         ; size 0 or 1: too small for a guard
+csb_ok:
+        ld      (__cob_ptr),hl
+        dec     de                      ; capacity = size - 1 (reserve guard)
+        ld      (__cob_cap),de
+        ret
+
+; __cob_default: revert console output to the internal __cobuf/COBSZ buffer.
+; Clobbers HL.
+__cob_default:
+        ld      hl,__cobuf
+        ld      (__cob_ptr),hl
+        ld      hl,COBSZ
+        ld      (__cob_cap),hl
         ret
 
         public  _strerror
@@ -434,6 +679,7 @@ _remove:
 
         public  __gchr
 __gchr:
+        call    __cflush        ; show any pending prompt before blocking
         ld      c,1
         call    5
         ld      h,0
@@ -454,11 +700,13 @@ __kbht:
 __gtch:
         ; int getch(void) - BDOS 6: direct console input without echo
         ; BDOS 6 with E=FFh returns 0 when no key ready; poll until non-zero
+        call    __cflush        ; show any pending prompt before blocking
+__gtch_poll:
         ld      c,6
         ld      e,0ffh
         call    5
         or      a
-        jr      z,__gtch
+        jr      z,__gtch_poll
         ld      l,a
         ld      h,0
         ret
@@ -3850,6 +4098,7 @@ _exit:
         ld      l,(ix+4)
         ld      h,(ix+5)
         pop     ix
+        call    __cflush                ; flush any buffered console output
         call    __cpm_set_retcode
         jp      0000h
 
@@ -3909,6 +4158,7 @@ __stchk:
         jr      c,stchk_over
         ret
 stchk_over:
+        call    __cflush        ; flush buffered output before the diagnostic
         ld      de,stchk_msg
         ld      c,9             ; BDOS print-string ('$'-terminated)
         call    5
@@ -4103,6 +4353,12 @@ __atl_d:        db      0
 
         public  _fflush
 _fflush:
+        ; int fflush(FILE *stream)
+        ; Console output is buffered in this RTL; drain it.  File streams are
+        ; written through directly (no user-visible buffer), so nothing further
+        ; needs flushing for them.  fflush(NULL)/fflush(stdout)/fflush(stderr)
+        ; all drain the console buffer.
+        call    __cflush
         ld      hl,0
         ret
 
@@ -4354,6 +4610,7 @@ _read:
         ld      a,(ix+8)
         or      (ix+9)
         jr      z,rdzero
+        call    __cflush        ; show any pending prompt before blocking
         ld      c,6
         ld      e,0ffh
         call    5
@@ -7121,6 +7378,7 @@ fgets_con:
         ld      l,(ix+4)
         ld      h,(ix+5)
         ld      (__fgets_ptr),hl
+        call    __cflush                ; show any pending prompt before input
 
 fgets_loop:
         ld      hl,(__fgets_rem)

--- a/docs/docs/en/05-stdio.md
+++ b/docs/docs/en/05-stdio.md
@@ -48,19 +48,8 @@ fprintf(stderr, "error %d\n", errno);
 
 The `v…` variants take a `va_list` (from
 [`stdarg.h`](09-utility-headers.md#stdargh-variadic-arguments)) so you can write
-your own `printf`-style wrappers that forward a format string:
-
-```c
-#include <stdarg.h>
-
-void logmsg(const char *fmt, ...)
-{
-    va_list ap;
-    va_start(ap, fmt);
-    vfprintf(stderr, fmt, ap);
-    va_end(ap);
-}
-```
+your own `printf`-style wrappers that forward a format string — see the worked
+[logging-wrapper example](12-examples.md#a-printf-style-logging-wrapper).
 
 ### printf conversions
 
@@ -109,40 +98,87 @@ precision. Use fixed widths in the format string.
 `putc` and `fputc` are separate C names that map to stream-character output;
 there is no `fgetc` alias in this runtime.
 
-## Character input
+## Console output buffering
+
+Console output (`printf`, `puts`, `putchar`, `fputs`/`fwrite`/`fprintf` to
+`stdout`/`stderr`) is **buffered**. Characters accumulate in a buffer and are
+sent to CP/M in batches, which is far faster than one BDOS call per character.
+The buffer is drained automatically:
+
+- when it fills,
+- when a newline is written (in the default line-buffered mode),
+- on `fflush()`,
+- before any blocking console **input** (`getchar`, `getch`, `scanf`, `fgets`),
+  so a prompt printed just before input is always visible first,
+- and at normal program exit (`main` return, `exit()`).
 
 | Function | Summary |
 | --- | --- |
-| `int getchar(void)` | Read one character from the console; blocks until a character is available. For non-blocking keyboard polling, check BDOS function 11, then read with BDOS function 6 (`E = 0xff`). |
-| `int getc(FILE *fp)` | Read one character from a stream. |
+| `int fflush(FILE *fp)` | Drain any buffered console output now. `fflush(NULL)`, `fflush(stdout)`, and `fflush(stderr)` all flush the console. Returns `0`. |
+| `int setvbuf(FILE *fp, char *buf, int mode, size_t size)` | Choose the buffering mode for `stdout`/`stderr`, optionally adopting your own buffer. Returns `0` on success, non-zero only for an invalid `mode`. |
+| `void setbuf(FILE *fp, char *buf)` | Shorthand: `setvbuf(fp, buf, buf ? _IOFBF : _IONBF, BUFSIZ)`. |
 
-`getchar` is the console input form. In the runtime it calls CP/M BDOS function
-1 (console input), so it waits for a character and returns that character as a
-non-negative `int`. `getc` reads from a stream through the `_read` path. The
-runtime does not provide `fgetc`. See
-[CP/M extensions](10-system-and-cpm.md#non-blocking-console-input) for a
-non-blocking polling convention.
+`setvbuf` must be called **before** any output on the stream. The `mode` is one
+of:
 
-For non-blocking console input on CP/M 2.2, use the BDOS calls directly:
+| Mode | Meaning |
+| --- | --- |
+| `_IOFBF` | Fully buffered — drain only when the buffer fills, on `fflush`, before input, or at exit. |
+| `_IOLBF` | Line buffered — additionally drain at each newline. This is the default. |
+| `_IONBF` | Unbuffered — drain after every character. |
 
-- `bdos(11, 0)` is console status. It returns `0` if no character is waiting and
-  nonzero if one is ready.
-- `bdos(6, 0xff)` is direct console input. With `E = 0xff`, it returns the next
-  character without echoing, or `0` if no character is ready.
+If you pass a non-`NULL` `buf` (with `size >= 2`), the runtime **adopts your
+buffer**: console output is accumulated there and a larger buffer means fewer
+BDOS calls. One byte of `size` is reserved internally, so the usable capacity is
+`size - 1`. A `NULL` `buf` (or `size < 2`) uses the runtime's small internal
+buffer instead.
+
+!!! warning "Buffer lifetime"
+    An adopted buffer must remain valid for as long as the stream uses it. Before
+    freeing it, detach it first — e.g. `setvbuf(stdout, NULL, _IOLBF, 0)` — so
+    the automatic exit-time flush does not touch freed memory.
+
+`setvbuf`/`setbuf` only configure the **console** (`stdout`/`stderr`). Called on
+a file stream they are accepted but have no effect (file writes are
+write-through). `stdout` and `stderr` share the one console buffer, so their
+output is interleaved in the exact order written.
 
 ```c
 #include <stdio.h>
 #include <stdlib.h>
 
-static int key_ready(void)
-{
-  return bdos(11, 0) != 0;
-}
+char *buf = malloc(4096);
+setvbuf(stdout, buf, _IOFBF, 4096);  /* batch up to ~4 KB before each flush */
 
-static int read_key_nonblocking(void)
-{
-  return bdos(6, 0xff);       /* returns 0 if no key is ready */
-}
+for (i = 0; i < 1000; i++)
+    printf("line %d\n", i);          /* accumulates; few BDOS calls */
+
+setvbuf(stdout, NULL, _IOLBF, 0);    /* detach before freeing */
+free(buf);
+```
+
+## Character input
+
+| Function | Summary |
+| --- | --- |
+| `int getchar(void)` | Read one character from the console; blocks until a character is available. For non-blocking keyboard polling use `kbhit()` / `getch()` (see below). |
+| `int getc(FILE *fp)` | Read one character from a stream. |
+| `int kbhit(void)` | Console status poll: returns nonzero if a key is waiting, `0` otherwise. Does **not** block and does **not** consume the character. |
+| `int getch(void)` | Read one key from the console without echo. Blocks (polls) until a key is available; guard it with `kbhit()` for non-blocking use. |
+
+`getchar` is the console input form. In the runtime it calls CP/M BDOS function
+1 (console input), so it waits for a character and returns that character as a
+non-negative `int`. `getc` reads from a stream through the `_read` path. The
+runtime does not provide `fgetc`. See
+[CP/M extensions](10-system-and-cpm.md#non-blocking-console-input) for more on
+the non-blocking convention.
+
+For non-blocking console input, use `kbhit()` to test whether a key is waiting,
+then `getch()` to read it. `kbhit()` never blocks; `getch()` only blocks if you
+call it when no key is ready, so the two are normally paired:
+
+```c
+#include <stdio.h>
 
 int main(void)
 {
@@ -150,12 +186,11 @@ int main(void)
 
   puts("Press Q to quit.");
   for (;;) {
-    if (key_ready()) {
-      ch = read_key_nonblocking();
+    if (kbhit()) {              /* non-blocking: a key is waiting */
+      ch = getch();             /* safe: will not block here */
       if (ch == 'q' || ch == 'Q')
         break;
-      if (ch)
-        putchar(ch);
+      putchar(ch);
     }
 
     /* do other periodic work here */
@@ -164,11 +199,11 @@ int main(void)
 }
 ```
 
-Because BDOS function 6 uses `0` as the "no character" sentinel, this convention
-is best for keyboard polling and command loops, not for input protocols where a
-NUL byte is meaningful. Avoid mixing direct console I/O with buffered console
-input in the same code path, because direct BDOS calls can bypass console
-buffers used by other input functions.
+Because `getch()` builds on BDOS function 6 (which uses `0` as its "no
+character" sentinel), this convention is best for keyboard polling and command
+loops, not for input protocols where a NUL byte is meaningful. `getch()` and
+`getchar()` flush any pending buffered console output before they block, so a
+prompt printed just before them is always visible first.
 
 ## File streams
 
@@ -176,7 +211,7 @@ buffers used by other input functions.
 | --- | --- |
 | `FILE *fopen(const char *path, const char *mode)` | Open a file. Modes: `"r"`, `"w"`, `"a"`, with optional `"+"` / `"b"`. |
 | `int fclose(FILE *fp)` | Flush and close a stream. |
-| `int fflush(FILE *fp)` | Flush buffered writes to disk. |
+| `int fflush(FILE *fp)` | Flush buffered output (see [Console output buffering](#console-output-buffering)). |
 | `char *fgets(char *buf, int n, FILE *fp)` | Read a line (up to `n-1` chars). |
 | `size_t fread(void *buf, size_t sz, size_t n, FILE *fp)` | Read `n` elements of `sz` bytes. |
 | `size_t fwrite(const void *buf, size_t sz, size_t n, FILE *fp)` | Write `n` elements of `sz` bytes. |
@@ -186,19 +221,13 @@ buffers used by other input functions.
 | `int feof(FILE *fp)` | Non-zero after end-of-file is reached. |
 | `int ferror(FILE *fp)` | Non-zero if an error flag is set. |
 | `void clearerr(FILE *fp)` | Clear the EOF and error flags. |
-| `void setbuf(FILE *fp, char *buf)` | Set a stream buffer. |
+| `void setbuf(FILE *fp, char *buf)` | Configure console buffering (see [above](#console-output-buffering)). |
+| `int setvbuf(FILE *fp, char *buf, int mode, size_t size)` | Configure console buffering (see [above](#console-output-buffering)). |
 | `int remove(const char *path)` | Delete a file. |
 | `void perror(const char *s)` | Print `s` plus the current error text. |
 
-```c
-FILE *fp = fopen("DATA.TXT", "r");
-if (fp) {
-    char line[128];
-    while (fgets(line, sizeof line, fp))
-        fputs(line, stdout);
-    fclose(fp);
-}
-```
+For a complete program, see the worked
+[file-reading example](12-examples.md#reading-a-text-file-line-by-line).
 
 ## scanf-family input
 
@@ -231,6 +260,9 @@ long big;
 sscanf("-12 hello 0x2a", "%d %s %i", &value, word, &value);
 sscanf("123456", "%ld", &big);
 ```
+
+For a complete, tested program, see the worked
+[`sscanf` parsing example](12-examples.md#parsing-input-with-sscanf).
 
 Not supported: floating input (`%f`, `%e`, `%g`), scansets (`%[...]`), `%n`, and
 `%p`.

--- a/docs/docs/en/10-system-and-cpm.md
+++ b/docs/docs/en/10-system-and-cpm.md
@@ -155,46 +155,48 @@ through the memory `dearg` points at, not in the return value.
 
 ### Non-blocking console input
 
-The standard input calls (`getchar`, `getc`, `fgets`, `scanf`) should be treated
-as blocking C-style input. For games, menus, terminal UIs, and other polling
-loops, use CP/M BDOS directly:
+The standard input calls (`getchar`, `getc`, `fgets`, `scanf`) are blocking
+C-style input. For games, menus, terminal UIs, and other polling loops, use the
+runtime's `kbhit()` and `getch()` (declared in `stdio.h`):
 
-- `bdos(11, 0)` checks console status and returns nonzero when a character is
-    waiting.
-- `bdos(6, 0xff)` performs direct console input and returns `0` when no
-    character is ready, otherwise the character value. It does not echo.
+- `int kbhit(void)` returns nonzero when a key is waiting and `0` otherwise. It
+  never blocks and does not consume the character.
+- `int getch(void)` reads one key without echo. It blocks until a key is ready,
+  so it is normally guarded by `kbhit()`.
 
 ```c
-#include <stdlib.h>
-
-int cpm_kbhit(void)
-{
-    return bdos(11, 0) != 0;
-}
-
-int cpm_getch_nonblock(void)
-{
-    return bdos(6, 0xff);       /* 0 means no character is ready */
-}
+#include <stdio.h>
 
 int main(void)
 {
     int ch;
 
-    if (cpm_kbhit()) {
-    ch = cpm_getch_nonblock();
-    if (ch)
-        handle_key(ch);
+    if (kbhit()) {          /* non-blocking test */
+        ch = getch();       /* safe: a key is already waiting */
+        if (ch)
+            handle_key(ch);
     }
     return 0;
 }
 ```
 
+Under the hood `kbhit()` is CP/M BDOS function 11 (console status) and `getch()`
+is BDOS function 6 (direct console input, `E = 0xff`). You can call those
+directly through `bdos()` if you need the raw behaviour, but the named functions
+are clearer and also flush pending buffered output before blocking:
+
+```c
+#include <stdlib.h>
+
+int raw_kbhit(void)        { return bdos(11, 0) != 0; }
+int raw_getch_nonblock(void) { return bdos(6, 0xff); }  /* 0 = no key ready */
+```
+
 BDOS function 6 uses `0` as the "no character" sentinel, so it is best for
 keyboard-style console input rather than protocols where NUL is meaningful.
-Avoid mixing direct console I/O with buffered console input in the same code
-path, because direct BDOS calls can bypass console buffers used by other input
-functions.
+Avoid mixing raw `bdos()` console I/O with the buffered console functions in the
+same code path, because direct BDOS calls bypass the console output buffer that
+`printf`/`puts` drain through.
 
 ### Direct port I/O
 

--- a/docs/docs/en/12-examples.md
+++ b/docs/docs/en/12-examples.md
@@ -12,33 +12,7 @@ comparator. The comparator returns negative / zero / positive — here the
 branchless `(x > y) - (x < y)` idiom.
 
 ```c
-#include <stdio.h>
-#include <stdlib.h>
-
-static int cmp_int(const void *a, const void *b)
-{
-    int x = *(const int *)a;
-    int y = *(const int *)b;
-    return (x > y) - (x < y);
-}
-
-int main(void)
-{
-    int v[8];
-    int key = 13;
-    const int *hit;
-
-    v[0] = 2; v[1] = 8; v[2] = 5; v[3] = 13;
-    v[4] = 1; v[5] = 21; v[6] = 3; v[7] = 34;
-
-    qsort(v, 8U, sizeof(int), cmp_int);     /* 1 2 3 5 8 13 21 34 */
-    hit = (const int *)bsearch(&key, v, 8U, sizeof(int), cmp_int);
-    if (hit)
-        printf("found %d at index %d\n", *hit, (int)(hit - v));
-    else
-        puts("not found");
-    return 0;
-}
+--8<-- "tests/texsort.c:example"
 ```
 
 Output: `found 13 at index 5`.
@@ -50,43 +24,7 @@ comparator reads the field it sorts on — here a string member via `strcmp` —
 `bsearch` reuses it to look a record up by name.
 
 ```c
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-struct item {
-    char name[8];
-    int  qty;
-};
-
-static int by_name(const void *a, const void *b)
-{
-    return strcmp(((const struct item *)a)->name,
-                  ((const struct item *)b)->name);
-}
-
-int main(void)
-{
-    struct item items[3];
-    struct item key;
-    const struct item *hit;
-    int i;
-
-    strcpy(items[0].name, "pears");  items[0].qty = 4;
-    strcpy(items[1].name, "apples"); items[1].qty = 9;
-    strcpy(items[2].name, "kiwis");  items[2].qty = 2;
-
-    qsort(items, 3U, sizeof(struct item), by_name);
-    for (i = 0; i < 3; i++)
-        printf("%-8s %d\n", items[i].name, items[i].qty);
-
-    strcpy(key.name, "kiwis");
-    hit = (const struct item *)bsearch(&key, items, 3U,
-                                       sizeof(struct item), by_name);
-    if (hit)
-        printf("%s: %d in stock\n", hit->name, hit->qty);
-    return 0;
-}
+--8<-- "tests/texstrct.c:example"
 ```
 
 Output:
@@ -104,41 +42,47 @@ Forwarding a `va_list` to `vfprintf` lets you build your own diagnostic helpers
 without re-parsing the arguments.
 
 ```c
-#include <stdio.h>
-#include <stdarg.h>
-
-static void logmsg(const char *fmt, ...)
-{
-    va_list ap;
-    va_start(ap, fmt);
-    vfprintf(stderr, fmt, ap);
-    va_end(ap);
-}
-
-int main(void)
-{
-    logmsg("ready: %d items, %lx flags\n", 3, 0xBEEFL);
-    return 0;
-}
+--8<-- "tests/texlog.c:example"
 ```
 
 ## Reading a text file line by line
 
 ```c
-#include <stdio.h>
-
-int main(void)
-{
-    FILE *fp = fopen("DATA.TXT", "r");
-    char  line[128];
-
-    if (!fp) {
-        perror("DATA.TXT");
-        return 1;
-    }
-    while (fgets(line, sizeof line, fp))
-        fputs(line, stdout);
-    fclose(fp);
-    return 0;
-}
+--8<-- "tests/texfile.c:example"
 ```
+
+## Parsing input with `sscanf`
+
+`sscanf` reads from a string using the same conversion subset as `scanf` and
+`fscanf` (integers and strings; no floating input). Each conversion stores
+through a pointer argument.
+
+```c
+--8<-- "tests/texscan.c:example"
+```
+
+Output:
+
+```text
+value=-12 word=hello hexval=42
+big=123456
+```
+
+## Buffered console output with a user-declared buffer
+
+`setvbuf` lets you hand the runtime your own buffer and fully buffer the
+console, so output accumulates instead of going to CP/M one character at a time.
+A larger buffer means fewer BDOS calls. Drain it with `fflush`, and detach it
+(`setvbuf(stdout, NULL, _IOLBF, 0)`) before the buffer's storage is reused — see
+[Console output buffering](05-stdio.md#console-output-buffering).
+
+```c
+--8<-- "tests/tbufex.c:example"
+```
+
+Output ends with `sum of squares 1..20 = 2870`. The `static` buffer keeps it off
+the small CP/M stack; a `malloc`'d buffer works too, but free it only *after*
+detaching it from the stream. This snippet is pulled verbatim from the
+`tests/tbufex.c` regression test, so the documented code is exactly what is
+built and run by the suite.
+

--- a/docs/docs/hooks/runtime_sizes.py
+++ b/docs/docs/hooks/runtime_sizes.py
@@ -40,6 +40,12 @@ DOC_GROUPS: List[Tuple[str, List[str]]] = [
         "_pffio", "_fprintf", "_printf", "_sprintf", "_vprintf", "_vsprintf",
         "_vfprintf", "_puts", "__fpc", "__fps", "__pchr",
     ]),
+    ("Console buffering control (stdio.h)", [
+        "_setvbuf", "_setbuf", "_fflush",
+    ]),
+    ("Console input (stdio.h)", [
+        "__gchr", "__gtch", "__kbht",
+    ]),
     ("Formatted input (scanf family)", ["_fscanf", "_scanf", "_sscanf"]),
     ("Low-level file I/O", [
         "_fread", "_fwrite", "_fgets", "_fopen", "_write", "_lseek", "_read",

--- a/docs/docs/mkdocs.yml
+++ b/docs/docs/mkdocs.yml
@@ -89,5 +89,11 @@ markdown_extensions:
       alternate_style: true
   - pymdownx.tasklist:
       custom_checkbox: true
+  - pymdownx.snippets:
+      # base_path is relative to docs_dir (en/); '../../' reaches the repo root
+      # so snippets can pull verbatim source from tests/ (single source of truth).
+      base_path:
+        - "../.."
+      check_paths: true
   - attr_list
   - md_in_html

--- a/scripts/perfcapture.ps1
+++ b/scripts/perfcapture.ps1
@@ -76,7 +76,7 @@ function Get-IgnoreApp {
 
 # Stage fixture input files
 function Stage-FixtureInputs {
-    $fixtures = @("E.PAS", "E.COB", "E.FOR", "E.ADA", "E.BAS", "E.F", "EU.C")
+    $fixtures = @("E.PAS", "E.COB", "E.FOR", "E.ADA", "E.BAS", "E.F", "eu.c")
     foreach ($f in $fixtures) {
         if (Test-Path "tests\$f") {
             Copy-Item -Path "tests\$f" -Destination "$BuildDir\$f" -Force -ErrorAction SilentlyContinue

--- a/scripts/runall.ps1
+++ b/scripts/runall.ps1
@@ -177,7 +177,7 @@ function Get-IgnoreApp {
 # these files from the current working directory, and apps are run from the
 # build dir (below), so the fixtures must live there too.
 function Stage-FixtureInputs {
-    $fixtures = @("E.PAS", "E.COB", "E.FOR", "E.ADA", "E.BAS", "E.F", "EU.C")
+    $fixtures = @("E.PAS", "E.COB", "E.FOR", "E.ADA", "E.BAS", "E.F", "eu.c", "DATA.TXT")
     foreach ($f in $fixtures) {
         $src = Join-Path "tests" $f
         if (Test-Path $src) {
@@ -290,7 +290,8 @@ function Invoke-AppTest {
             }
         }
         else {
-            $lines.Add("    (No baseline, output recorded)")
+            $lines.Add("    ERROR: no baseline at $BaselineDir/$AppName.txt (every app must have one)")
+            $appPassed = $false
         }
     }
 
@@ -383,7 +384,7 @@ $skipped = 0
 $failedApps = @()
 
 $modes = if ($Mode -eq "both") { @("peep", "nopeep") } else { @($Mode) }
-$fixtureList = @("E.PAS", "E.COB", "E.FOR", "E.ADA", "E.BAS", "E.F", "EU.C")
+$fixtureList = @("E.PAS", "E.COB", "E.FOR", "E.ADA", "E.BAS", "E.F", "eu.c", "DATA.TXT")
 
 # Build the list of work items up front (resolving per-app args/stack in the
 # parent), so parallel workers don't need the $appOverrides table.
@@ -419,7 +420,6 @@ function Show-AppResult {
     foreach ($line in $result.Lines) {
         $color = if ($line -match 'FAILED|MISMATCH|WARNING|ERROR') { 'Red' }
                  elseif ($line -match 'matches baseline') { 'Green' }
-                 elseif ($line -match 'No baseline') { 'Gray' }
                  else { 'Gray' }
         Write-Host $line -ForegroundColor $color
     }

--- a/stdio.h
+++ b/stdio.h
@@ -17,6 +17,11 @@
 
 #define BUFSIZ 256 /* C89 (7.9.2) minimum */
 
+/* setvbuf() buffering modes (C89 7.9.1). */
+#define _IOFBF 0 /* full buffering */
+#define _IOLBF 1 /* line buffering */
+#define _IONBF 2 /* no buffering   */
+
 /* Max streams open at once.  C89 (7.9.3) requires FOPEN_MAX >= 8 including the
  * three standard streams.  In this runtime stdin/stdout/stderr are console
  * pseudo-FILEs that do not use a real-file slot, and NFILES real files (fd 3..)
@@ -71,6 +76,7 @@ int    feof(FILE *stream);
 int    ferror(FILE *stream);
 void   clearerr(FILE *stream);
 void   setbuf(FILE *stream, char *buf);
+int    setvbuf(FILE *stream, char *buf, int mode, size_t size);
 
 /* Formatted-string helpers */
 int sprintf(char *s, const char *format, ...);

--- a/tests/DATA.TXT
+++ b/tests/DATA.TXT
@@ -1,0 +1,4 @@
+The quick brown fox
+jumps over the lazy dog.
+1234567890
+Goodbye.

--- a/tests/_test_overrides.json
+++ b/tests/_test_overrides.json
@@ -16,8 +16,8 @@
     { "name": "na", "ignore": true },
     { "name": "tc89fltb", "ignore": true },
     { "name": "spsmash", "ignore": true },
-    { "name": "EU", "ignore": true },
-    { "name": "SIEVEU", "ignore": true },
-    { "name": "TTTU", "ignore": true }
+    { "name": "eu", "ignore": true },
+    { "name": "sieveu", "ignore": true },
+    { "name": "tttu", "ignore": true }
   ]
 }

--- a/tests/baselines/tbufex.txt
+++ b/tests/baselines/tbufex.txt
@@ -1,0 +1,21 @@
+row  1: 0
+row  2: 1
+row  3: 5
+row  4: 14
+row  5: 30
+row  6: 55
+row  7: 91
+row  8: 140
+row  9: 204
+row 10: 285
+row 11: 385
+row 12: 506
+row 13: 650
+row 14: 819
+row 15: 1015
+row 16: 1240
+row 17: 1496
+row 18: 1785
+row 19: 2109
+row 20: 2470
+sum of squares 1..20 = 2870

--- a/tests/baselines/texfile.txt
+++ b/tests/baselines/texfile.txt
@@ -1,0 +1,4 @@
+The quick brown fox
+jumps over the lazy dog.
+1234567890
+Goodbye.

--- a/tests/baselines/texlog.txt
+++ b/tests/baselines/texlog.txt
@@ -1,0 +1,1 @@
+ready: 3 items, 0000beef flags

--- a/tests/baselines/texscan.txt
+++ b/tests/baselines/texscan.txt
@@ -1,0 +1,2 @@
+value=-12 word=hello hexval=42
+big=123456

--- a/tests/baselines/texsort.txt
+++ b/tests/baselines/texsort.txt
@@ -1,0 +1,1 @@
+found 13 at index 5

--- a/tests/baselines/texstrct.txt
+++ b/tests/baselines/texstrct.txt
@@ -1,0 +1,4 @@
+apples   9
+kiwis    2
+pears    4
+kiwis: 2 in stock

--- a/tests/baselines/tsvbuf2.txt
+++ b/tests/baselines/tsvbuf2.txt
@@ -1,0 +1,28 @@
+tsvbuf2 start
+4kbuf line A
+4kbuf line B
+4kbuf cost $5 and $10
+ok: 4K-IOFBF adopted (buffered 28 bytes)
+d1: leading $dollar
+d2: trailing dollar$
+d3: $only$dollars$
+d4: $$$$ four in a row
+d5: lone -> $
+$$$$$$$$
+mix: a$b$c$d$e$f
+small-buf line definitely longer than thirty-one bytes $x$
+boundary: $123456789012345678901234567890123456$890123456789012345678901234567890123$567890123456789012345678901234567890$234567890123456789012345678901234567$901234567890123456789012345678901234$67890123456789
+linebuf via fputs: cost is $7$
+linebuf via puts: $$ and done
+nobuf: $a$b$ X$Y
+setbuf-adopt: $a$
+ok: setbuf adopted (buffered 15 bytes)
+setbuf-null: $unbuffered$
+fprintf stdout: 3 dollars $100$
+fprintf stderr: warn $!$
+ok: invalid mode rejected
+file-noop A
+file-noop B
+ok: file-noop adopted (buffered 26 bytes)
+tsvbuf2 passed with great success
+tsvbuf2 done $tail-no-newline$

--- a/tests/eu.c
+++ b/tests/eu.c
@@ -1,0 +1,34 @@
+/* computes digits of e to 192 places */
+
+#define DIGITS_TO_FIND 200
+
+#include <stdio.h>
+
+extern int main() {
+  int N;
+  register int n;
+  int x;
+  int a[DIGITS_TO_FIND];
+
+  N = DIGITS_TO_FIND;
+  x = 0;
+
+  for (n = N - 1; n > 0; --n)
+    a[n] = 1;
+
+  a[1] = 2;
+  a[0] = 0;
+
+  while (N > 9) {
+    n = N--;
+    while (--n) {
+      a[n] = x % n;
+      x = 10 * a[n-1] + x / n;
+    }
+
+    printf("%u", x);
+  }
+
+  printf("\ndone\n");
+  return 0;
+}

--- a/tests/sieveu.c
+++ b/tests/sieveu.c
@@ -1,0 +1,34 @@
+/* sieve.c */
+
+/* Eratosthenes Sieve Prime Number Program in C from Byte Jan 1983
+   to compare the speed. */
+
+#include <stdio.h>
+
+#define TRUE 1
+#define FALSE 0
+#define SIZE 8190
+
+char flags[SIZE+1];
+
+int main()
+        {
+        int i,k;
+        int prime,count,iter;
+
+        for (iter = 1; iter <= 10; iter++) {    /* do program 10 times */
+                count = 0;                      /* initialize prime counter */
+                for (i = 0; i <= SIZE; i++)     /* set all flags TRUE */
+                        flags[i] = TRUE;
+                for (i = 0; i <= SIZE; i++) {
+                        if (flags[i]) {         /* found a prime */
+                                prime = i + i + 3;      /* twice index + 3 */
+                                for (k = i + prime; k <= SIZE; k += prime)
+                                        flags[k] = FALSE;       /* kill all multiples */
+                                count++;                /* primes found */
+                                }
+                        }
+                }
+        printf("%d primes.\n",count);           /*primes found in 10th pass */
+        return 0;
+        }

--- a/tests/tbufex.c
+++ b/tests/tbufex.c
@@ -1,0 +1,39 @@
+/* tbufex.c - worked example: buffered console output with a user-declared
+ * buffer.  Verifies the doc snippet compiles, runs, and batches output. */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* --8<-- [start:example] */
+int main(void)
+{
+    static char obuf[1024];   /* user-declared console buffer */
+    int i;
+    long total;
+
+    /* Adopt obuf and fully buffer: output accumulates instead of going to the
+     * BDOS one character at a time. */
+    if (setvbuf(stdout, obuf, _IOFBF, sizeof obuf) != 0) {
+        puts("setvbuf failed");
+        return 1;
+    }
+
+    total = 0;
+    for (i = 1; i <= 20; i = i + 1) {
+        printf("row %2d: %ld\n", i, total);
+        total = total + (long) i * i;
+    }
+
+    /* Nothing has reached the console yet (fully buffered, under 1 KB).
+     * Drain it explicitly. */
+    fflush(stdout);
+
+    printf("sum of squares 1..20 = %ld\n", total);
+
+    /* Detach the buffer before it goes out of scope / is reused, so the
+     * automatic flush at exit uses the internal buffer. */
+    setvbuf(stdout, (char *) 0, _IOLBF, 0);
+
+    return 0;
+}
+/* --8<-- [end:example] */

--- a/tests/texfile.c
+++ b/tests/texfile.c
@@ -1,0 +1,22 @@
+/* texfile.c - worked example: read a text file line by line.
+ * Reads the DATA.TXT fixture (tests/DATA.TXT, staged into the build dir).
+ * Pulled into docs/docs/en/12-examples.md via the snippet markers below. */
+
+#include <stdio.h>
+
+/* --8<-- [start:example] */
+int main(void)
+{
+    FILE *fp = fopen("DATA.TXT", "r");
+    char  line[128];
+
+    if (!fp) {
+        perror("DATA.TXT");
+        return 1;
+    }
+    while (fgets(line, sizeof line, fp))
+        fputs(line, stdout);
+    fclose(fp);
+    return 0;
+}
+/* --8<-- [end:example] */

--- a/tests/texlog.c
+++ b/tests/texlog.c
@@ -1,0 +1,21 @@
+/* texlog.c - worked example: a printf-style logging wrapper via vfprintf.
+ * Pulled into docs/docs/en/12-examples.md via the snippet markers below. */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+/* --8<-- [start:example] */
+static void logmsg(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+}
+
+int main(void)
+{
+    logmsg("ready: %d items, %lx flags\n", 3, 0xBEEFL);
+    return 0;
+}
+/* --8<-- [end:example] */

--- a/tests/texscan.c
+++ b/tests/texscan.c
@@ -1,0 +1,21 @@
+/* texscan.c - worked example: parse input with the scanf family (sscanf).
+ * Pulled into docs/docs/en/12-examples.md via the snippet markers below. */
+
+#include <stdio.h>
+
+/* --8<-- [start:example] */
+int main(void)
+{
+    int  value;
+    char word[16];
+    int  hexval;
+    long big;
+
+    sscanf("-12 hello 0x2a", "%d %s %i", &value, word, &hexval);
+    printf("value=%d word=%s hexval=%d\n", value, word, hexval);
+
+    sscanf("123456", "%ld", &big);
+    printf("big=%ld\n", big);
+    return 0;
+}
+/* --8<-- [end:example] */

--- a/tests/texsort.c
+++ b/tests/texsort.c
@@ -1,0 +1,32 @@
+/* texsort.c - worked example: sort + search an int array with qsort/bsearch.
+ * Pulled into docs/docs/en/12-examples.md via the snippet markers below. */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* --8<-- [start:example] */
+static int cmp_int(const void *a, const void *b)
+{
+    int x = *(const int *)a;
+    int y = *(const int *)b;
+    return (x > y) - (x < y);
+}
+
+int main(void)
+{
+    int v[8];
+    int key = 13;
+    const int *hit;
+
+    v[0] = 2; v[1] = 8; v[2] = 5; v[3] = 13;
+    v[4] = 1; v[5] = 21; v[6] = 3; v[7] = 34;
+
+    qsort(v, 8U, sizeof(int), cmp_int);     /* 1 2 3 5 8 13 21 34 */
+    hit = (const int *)bsearch(&key, v, 8U, sizeof(int), cmp_int);
+    if (hit)
+        printf("found %d at index %d\n", *hit, (int)(hit - v));
+    else
+        puts("not found");
+    return 0;
+}
+/* --8<-- [end:example] */

--- a/tests/texstrct.c
+++ b/tests/texstrct.c
@@ -1,0 +1,42 @@
+/* texstrct.c - worked example: sort an array of structs by a key field.
+ * Pulled into docs/docs/en/12-examples.md via the snippet markers below. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* --8<-- [start:example] */
+struct item {
+    char name[8];
+    int  qty;
+};
+
+static int by_name(const void *a, const void *b)
+{
+    return strcmp(((const struct item *)a)->name,
+                  ((const struct item *)b)->name);
+}
+
+int main(void)
+{
+    struct item items[3];
+    struct item key;
+    const struct item *hit;
+    int i;
+
+    strcpy(items[0].name, "pears");  items[0].qty = 4;
+    strcpy(items[1].name, "apples"); items[1].qty = 9;
+    strcpy(items[2].name, "kiwis");  items[2].qty = 2;
+
+    qsort(items, 3U, sizeof(struct item), by_name);
+    for (i = 0; i < 3; i++)
+        printf("%-8s %d\n", items[i].name, items[i].qty);
+
+    strcpy(key.name, "kiwis");
+    hit = (const struct item *)bsearch(&key, items, 3U,
+                                       sizeof(struct item), by_name);
+    if (hit)
+        printf("%s: %d in stock\n", hit->name, hit->qty);
+    return 0;
+}
+/* --8<-- [end:example] */

--- a/tests/tsvbuf2.c
+++ b/tests/tsvbuf2.c
@@ -1,0 +1,177 @@
+/* tsvbuf2.c - exercise console buffering with CALLER-SUPPLIED buffers.
+ *
+ * This RTL ADOPTS the buffer you pass to setvbuf()/setbuf(): console output is
+ * accumulated in YOUR array and drained (with BDOS-fn9 '$'-splitting) only when
+ * it fills, on fflush(), before stdin input, or at program exit.  The tests
+ * below prove the buffer is really used by inspecting its bytes after buffered
+ * writes (the runtime stores '\n' as CR,LF), and stress the '$'-split flush
+ * with leading/trailing/embedded/consecutive dollars and writes that overflow
+ * the buffer.  Output is identical regardless of buffering mode. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int g_fail = 0;
+
+static char *make_buf(size_t n)
+{
+    char *b = (char *) malloc(n);
+    if (b == 0) {
+        printf("FAIL: malloc(%u) returned NULL\n", (unsigned) n);
+        exit(1);
+    }
+    memset(b, 0, n);
+    return b;
+}
+
+/* Confirm the caller's buffer holds the given bytes at offset 0, proving the
+ * RTL is buffering console output into it. */
+static void expect_prefix(const char *buf, const char *want, const char *tag)
+{
+    int n = (int) strlen(want);
+    int i;
+    for (i = 0; i < n; i = i + 1) {
+        if (buf[i] != want[i]) {
+            g_fail = g_fail + 1;
+            printf("FAIL %s: buf[%d]=0x%02x want 0x%02x\n",
+                   tag, i, (unsigned char) buf[i], (unsigned char) want[i]);
+            return;
+        }
+    }
+    printf("ok: %s adopted (buffered %d bytes)\n", tag, n);
+}
+
+int main(void)
+{
+    char *big;          /* the 4 KB buffer */
+    char *line;
+    int i;
+
+    printf("tsvbuf2 start\n");
+
+    /* ---- 1. allocate a 4 KB buffer and hand it to setvbuf ---- */
+    big = make_buf(4096);
+    if (setvbuf(stdout, big, _IOFBF, 4096) != 0)
+        printf("FAIL: setvbuf 4K _IOFBF rejected\n");
+
+    /* Fully buffered: newlines do NOT flush, so several lines accumulate in the
+     * 4 KB buffer.  Their total is far below 4 KB, so nothing drains yet. */
+    printf("4kbuf line A\n");
+    printf("4kbuf line B\n");
+    printf("4kbuf cost $5 and $10\n");
+
+    /* The buffer must now contain those lines, with '\n' stored as CR,LF. */
+    expect_prefix(big, "4kbuf line A\r\n4kbuf line B\r\n", "4K-IOFBF");
+
+    fflush(stdout);     /* drain all three lines at once */
+
+    /* ---- 2. '$' torture, all delivered while fully buffered in big[] ---- */
+    printf("d1: leading $dollar\n");
+    printf("d2: trailing dollar$\n");
+    printf("d3: $only$dollars$\n");
+    printf("d4: $$$$ four in a row\n");
+    printf("d5: lone -> $\n");
+    printf("$$$$$$$$\n");                  /* a whole line of dollars */
+    printf("mix: a$b$c$d$e$f\n");
+    fflush(stdout);
+
+    /* ---- 3. a write that overflows a SMALL adopted buffer, forcing an
+     *         internal flush partway through the line ---- */
+    {
+        char *small = make_buf(32);
+        setvbuf(stdout, small, _IOFBF, 32);   /* capacity 31 before auto-flush */
+        printf("small-buf line definitely longer than thirty-one bytes $x$\n");
+        fflush(stdout);
+        free(small);
+    }
+
+    /* ---- 4. a 200-char line with dollars, overflowing back into big[] ---- */
+    setvbuf(stdout, big, _IOFBF, 4096);
+    line = make_buf(256);
+    for (i = 0; i < 200; i = i + 1) {
+        line[i] = (char) ('0' + (i % 10));
+        if (i % 37 == 0) line[i] = '$';
+    }
+    line[200] = '\n';
+    line[201] = '\0';
+    printf("boundary: %s", line);
+    fflush(stdout);
+    free(line);
+
+    /* ---- 5. line buffering with the SAME 4 KB buffer ---- */
+    setvbuf(stdout, big, _IOLBF, 4096);
+    fputs("linebuf via fputs: cost is $7$\n", stdout);
+    puts("linebuf via puts: $$ and done");
+
+    /* ---- 6. unbuffered (NULL buffer reverts to the internal one) ---- */
+    setvbuf(stdout, (char *) 0, _IONBF, 0);
+    printf("nobuf: $a$b$ ");
+    putchar('X');
+    putchar('$');
+    putchar('Y');
+    putchar('\n');
+
+    /* ---- 7. setbuf adopts a buffer (_IOFBF); setbuf(NULL) is unbuffered ---- */
+    {
+        char *sbuf = make_buf(BUFSIZ);
+        setbuf(stdout, sbuf);
+        printf("setbuf-adopt: $a$\n");
+        expect_prefix(sbuf, "setbuf-adopt: $", "setbuf");
+        fflush(stdout);
+        free(sbuf);
+        setbuf(stdout, (char *) 0);
+        printf("setbuf-null: $unbuffered$\n");
+    }
+
+    /* ---- 8. fprintf to stdout and stderr (both are the console) ---- */
+    fprintf(stdout, "fprintf stdout: %d dollars $%d$\n", 3, 100);
+    fprintf(stderr, "fprintf stderr: warn $!$\n");
+
+    /* ---- 9. invalid mode rejected ---- */
+    if (setvbuf(stdout, (char *) 0, 7, 0) == 0)
+        printf("FAIL: invalid mode 7 accepted\n");
+    else
+        printf("ok: invalid mode rejected\n");
+
+    /* ---- 10. setvbuf on a real file must not reconfigure the console ---- */
+    {
+        FILE *fp;
+        char *fbuf;
+
+        memset(big, 0, 4096);
+        setvbuf(stdout, big, _IOFBF, 4096);
+        printf("file-noop A\n");
+
+        fp = fopen("SVBUF2.TMP", "w");
+        if (fp == 0) {
+            printf("FAIL: fopen SVBUF2.TMP\n");
+        } else {
+            fbuf = make_buf(64);
+            if (setvbuf(fp, fbuf, _IONBF, 64) != 0)
+                printf("FAIL: file setvbuf rejected\n");
+            setbuf(fp, fbuf);
+            fprintf(fp, "file output $ok$\n");
+            fclose(fp);
+            free(fbuf);
+        }
+
+        printf("file-noop B\n");
+        expect_prefix(big, "file-noop A\r\nfile-noop B\r\n", "file-noop");
+        fflush(stdout);
+        remove("SVBUF2.TMP");
+    }
+
+    /* Revert to the internal buffer BEFORE freeing big, so the exit-flush does
+     * not touch freed memory, then leave a no-newline tail to prove exit-flush. */
+    setvbuf(stdout, (char *) 0, _IOLBF, 0);
+    free(big);
+
+    if (g_fail == 0)
+        printf("tsvbuf2 passed with great success\n");
+    else
+        printf("tsvbuf2 FAILED (%d)\n", g_fail);
+
+    printf("tsvbuf2 done $tail-no-newline$");
+    return 0;
+}

--- a/tests/tttu.c
+++ b/tests/tttu.c
@@ -1,0 +1,308 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define ABPrune true
+#define WinLosePrune true
+#define SCORE_WIN 6
+#define SCORE_TIE 5
+#define SCORE_LOSE  4
+#define SCORE_MAX 9
+#define SCORE_MIN 2
+#define DefaultIterations 1
+
+#define PieceX 1
+#define PieceO 2
+#define PieceBlank 0
+
+int g_Iterations = DefaultIterations;
+
+typedef uint8_t ttt_t;
+
+ttt_t g_board[ 9 ];
+
+#if true
+
+ttt_t pos0func( void )
+{
+    ttt_t x = g_board[0];
+
+    if ( ( x == g_board[1] && x == g_board[2] ) ||
+         ( x == g_board[3] && x == g_board[6] ) ||
+         ( x == g_board[4] && x == g_board[8] ) )
+        return x;
+    return PieceBlank;
+}
+
+ttt_t pos1func( void )
+{
+    ttt_t x = g_board[1];
+
+    if ( ( x == g_board[0] && x == g_board[2] ) ||
+         ( x == g_board[4] && x == g_board[7] ) )
+        return x;
+    return PieceBlank;
+}
+
+ttt_t pos2func( void )
+{
+    ttt_t x = g_board[2];
+
+    if ( ( x == g_board[0] && x == g_board[1] ) ||
+         ( x == g_board[5] && x == g_board[8] ) ||
+         ( x == g_board[4] && x == g_board[6] ) )
+        return x;
+    return PieceBlank;
+}
+
+ttt_t pos3func( void )
+{
+    ttt_t x = g_board[3];
+
+    if ( ( x == g_board[4] && x == g_board[5] ) ||
+         ( x == g_board[0] && x == g_board[6] ) )
+        return x;
+    return PieceBlank;
+}
+
+ttt_t pos4func( void )
+{
+    ttt_t x = g_board[4];
+
+    if ( ( x == g_board[0] && x == g_board[8] ) ||
+         ( x == g_board[2] && x == g_board[6] ) ||
+         ( x == g_board[1] && x == g_board[7] ) ||
+         ( x == g_board[3] && x == g_board[5] ) )
+        return x;
+    return PieceBlank;
+}
+
+ttt_t pos5func( void )
+{
+    ttt_t x = g_board[5];
+
+    if ( ( x == g_board[3] && x == g_board[4] ) ||
+         ( x == g_board[2] && x == g_board[8] ) )
+        return x;
+    return PieceBlank;
+}
+
+ttt_t pos6func( void )
+{
+    ttt_t x = g_board[6];
+
+    if ( ( x == g_board[7] && x == g_board[8] ) ||
+         ( x == g_board[0] && x == g_board[3] ) ||
+         ( x == g_board[4] && x == g_board[2] ) )
+        return x;
+    return PieceBlank;
+}
+
+ttt_t pos7func( void )
+{
+    ttt_t x = g_board[7];
+
+    if ( ( x == g_board[6] && x == g_board[8] ) ||
+         ( x == g_board[1] && x == g_board[4] ) )
+        return x;
+    return PieceBlank;
+}
+
+ttt_t pos8func( void )
+{
+    ttt_t x = g_board[8];
+
+    if ( ( x == g_board[6] && x == g_board[7] ) ||
+         ( x == g_board[2] && x == g_board[5] ) ||
+         ( x == g_board[0] && x == g_board[4] ) )
+        return x;
+    return PieceBlank;
+}
+
+typedef ttt_t (*pfunc_t)( void );
+
+pfunc_t winner_functions[9] =
+{
+    pos0func,
+    pos1func,
+    pos2func,
+    pos3func,
+    pos4func,
+    pos5func,
+    pos6func,
+    pos7func,
+    pos8func,
+};
+
+#else
+
+ttt_t LookForWinner()
+{
+    ttt_t p = g_board[0];
+    if ( PieceBlank != p )
+    {
+        if ( p == g_board[1] && p == g_board[2] )
+            return p;
+
+        if ( p == g_board[3] && p == g_board[6] )
+            return p;
+    }
+
+    p = g_board[3];
+    if ( PieceBlank != p && p == g_board[4] && p == g_board[5] )
+        return p;
+
+    p = g_board[6];
+    if ( PieceBlank != p && p == g_board[7] && p == g_board[8] )
+        return p;
+
+    p = g_board[1];
+    if ( PieceBlank != p && p == g_board[4] && p == g_board[7] )
+        return p;
+
+    p = g_board[2];
+    if ( PieceBlank != p && p == g_board[5] && p == g_board[8] )
+        return p;
+
+    p = g_board[4];
+    if ( PieceBlank != p )
+    {
+        if ( ( p == g_board[0] ) && ( p == g_board[8] ) )
+            return p;
+
+        if ( ( p == g_board[2] ) && ( p == g_board[6] ) )
+            return p;
+    }
+
+    return PieceBlank;
+} /*LookForWinner*/
+
+#endif
+
+uint32_t g_Moves = 0;
+
+ttt_t MinMax( ttt_t alpha, ttt_t beta, ttt_t depth, ttt_t move )
+{
+    ttt_t value, pieceMove, p, score;
+
+    //printf("d=%d m=%d a=%d b=%d\n", depth, move, alpha, beta);
+
+    g_Moves++;
+
+    if ( depth >= 4 )
+    {
+        #if true
+            p = winner_functions[ move ]();
+        #else
+            p = LookForWinner();
+        #endif       
+
+        if ( PieceBlank != p )
+        {
+            if ( PieceX == p )
+                return SCORE_WIN;
+
+            return SCORE_LOSE;
+        }
+
+        if ( 8 == depth )
+            return SCORE_TIE;
+    }
+
+    if ( depth & 1 )
+    {
+        value = SCORE_MIN;
+        pieceMove = PieceX;
+    }
+    else
+    {
+        value = SCORE_MAX;
+        pieceMove = PieceO;
+    }
+
+    for ( p = 0; p < 9; p++ )
+    {
+        if ( PieceBlank == g_board[ p ] )
+        {
+            g_board[p] = pieceMove;
+            score = MinMax( alpha, beta, depth + 1, p );
+            g_board[p] = PieceBlank;
+
+            if ( depth & 1 )
+            {
+                if ( WinLosePrune && SCORE_WIN == score )
+                    return SCORE_WIN;
+
+                if ( score > value )
+                {
+                    value = score;
+
+                    if ( ABPrune )
+                    {
+                        if ( value >= beta )
+                            return value;
+                        if ( value > alpha )
+                            alpha = value;
+                    }
+                }
+            }
+            else
+            {
+                if ( WinLosePrune && SCORE_LOSE == score )
+                    return SCORE_LOSE;
+
+                if ( score < value )
+                {
+                    value = score;
+
+                    if ( ABPrune )
+                    {
+                        if ( value <= alpha )
+                            return value;
+                        if ( value < beta )
+                            beta = value;
+                    }
+                }
+            }
+        }
+    }
+
+    return value;
+}  /*MinMax*/
+
+int FindSolution( ttt_t position )
+{
+    size_t i;
+    for ( i = 0; i < 9; i++ )
+        g_board[ i ] = PieceBlank;
+    g_board[ position ] = PieceX;
+    MinMax( SCORE_MIN, SCORE_MAX, 0, position );
+    
+    return 0;
+} /*FindSolution*/
+
+void ttt( void )
+{
+    FindSolution( 0 );
+    FindSolution( 1 );
+    FindSolution( 4 );
+} //ttt
+
+extern int main( int argc, char * argv[] )
+{
+    int times;
+
+    if ( 2 == argc )
+        g_Iterations = atoi( argv[1] );
+
+    for ( times = 0; times < g_Iterations; times++ )
+        ttt();
+
+    printf( "%lu moves\n", g_Moves );
+    printf( "%d iterations\n", g_Iterations );
+    fflush(stdout);
+    return 0;
+} //main
+
+


### PR DESCRIPTION
Replace the per-character BDOS console writes with a buffered output path in DCCRTL.MAC. Characters are appended to __cobuf and drained to the BDOS lazily by __cflush, which emits maximal non-'$' runs.

Buffering policy is selectable via setvbuf()/setbuf():
  _IOFBF  flush only when the buffer fills or on fflush()/exit
  _IOLBF  additionally flush at each newline (default)
  _IONBF  flush after every character

Add the new setvbuf() prototype and _IOFBF/_IOLBF/_IONBF mode macros to stdio.h. fflush() and program exit drain any pending console output to bring inline with c89 specs.

Tests:
  tsvbuf2  setvbuf modes and buffer handling
  tbufex   buffer exercise / flush boundaries
  texlog, texscan, texsort, texfile, texstrct, eu, sieveu, tttu
           buffered-output variants of existing programs
Add matching baselines and DATA.TXT; refresh stdio/system docs.