### PR TITLE
perf: register-ABI 16x16 long multiply + pow2 mulu peephole

### DIFF
--- a/DCCRTL.MAC
+++ b/DCCRTL.MAC
@@ -6363,104 +6363,78 @@ lmul_bs:
         pop     ix
         ret
 
-; __m16u: unsigned 16x16 -> 32 multiply.
-;   The caller pushes both operands in the 32-bit convention (push de;push hl
-;   each), but these are sign/zero-extended 16-bit values, so only the LOW
-;   words carry information.  This helper reads just those low words
-;   (LHS_L at ix+8, RHS_L at ix+4) and ignores the high zero-extension words,
-;   producing the same DE:HL result the full 32x32 __lmul would for two
-;   zero-extended operands -- at a fraction of the cost (one 16-iteration
-;   register loop, no cross products).  Caller still cleans 8 bytes.
-;   NB: name kept to <=6 significant chars and distinct from __lmul/__m16s,
-;   because L80 only treats the first 6 characters of a public as significant.
-        public  __m16u
-__m16u:
-        push    ix
-        ld      ix,0
-        add     ix,sp
-        ld      c,(ix+8)                ; BC = LHS low word (multiplicand)
-        ld      b,(ix+9)
-        ld      e,(ix+4)                ; DE = RHS low word (multiplier/low acc)
-        ld      d,(ix+5)
+; __m1u: unsigned 16x16 -> 32 multiply, register ABI.
+;   Entry: BC = LHS low word, HL = RHS low word.  Exit: DE:HL = product.
+;   Used by dcc when both long operands were freshly widened from 16-bit.
+        public  __m1u
+__m1u:
+        ex      de,hl                   ; DE = multiplier/low accumulator
         ld      hl,0                    ; HL = high accumulator
         ld      a,16
-lmulu_b:
-        bit     0,e                     ; multiplier LSB
-        jr      z,lmulu_bn
-        add     hl,bc                   ; HL += multiplicand; CF = carry out
-        jr      lmulu_bs
-lmulu_bn:
-        or      a                       ; CF = 0 for a clean shift
-lmulu_bs:
-        rr      h                       ; shift CF:HL:DE right by one (33-bit)
+lm1u_b:
+        bit     0,e
+        jr      z,lm1u_bn
+        add     hl,bc
+        jr      lm1u_bs
+lm1u_bn:
+        or      a
+lm1u_bs:
+        rr      h
         rr      l
         rr      d
         rr      e
         dec     a
-        jr      nz,lmulu_b
-        ex      de,hl                   ; DE = high, HL = low
-        ld      sp,ix
-        pop     ix
+        jr      nz,lm1u_b
+        ex      de,hl
         ret
 
-; __m16s: signed 16x16 -> 32 multiply.
-;   Like __m16u, but the two low words are signed.  Compute the result sign
-;   from the operand signs, multiply the magnitudes with the same unsigned
-;   16-iteration core, then negate the 32-bit product if the signs differ.
-;   Matches (mod 2^32) what __lmul produces for two SIGN-extended operands.
-        public  __m16s
-__m16s:
-        push    ix
-        ld      ix,0
-        add     ix,sp
-        ld      l,(ix+8)                ; HL = LHS low word
-        ld      h,(ix+9)
-        ld      e,(ix+4)                ; DE = RHS low word
-        ld      d,(ix+5)
-        ld      a,h
-        xor     d
-        ld      (lmuls_sg),a            ; bit7 = sign of product
-        bit     7,h                     ; HL = |LHS|
-        jr      z,lmuls_ap
+; __m1s: signed 16x16 -> 32 multiply, register ABI.
+;   Entry: BC = LHS low word, HL = RHS low word.  Exit: DE:HL = product.
+        public  __m1s
+__m1s:
+        ld      a,b
+        xor     h
+        ld      (lm1s_sg),a             ; bit7 = sign of product
+        bit     7,b
+        jr      z,lm1s_ap
+        xor     a
+        sub     c
+        ld      c,a
+        sbc     a,a
+        sub     b
+        ld      b,a
+lm1s_ap:
+        bit     7,h
+        jr      z,lm1s_bp
         xor     a
         sub     l
         ld      l,a
         sbc     a,a
         sub     h
         ld      h,a
-lmuls_ap:
-        bit     7,d                     ; DE = |RHS|
-        jr      z,lmuls_bp
-        xor     a
-        sub     e
-        ld      e,a
-        sbc     a,a
-        sub     d
-        ld      d,a
-lmuls_bp:
-        ld      b,h                     ; BC = |LHS| (multiplicand)
-        ld      c,l
+lm1s_bp:
+        ex      de,hl                   ; DE = |RHS| multiplier/low accumulator
         ld      hl,0                    ; HL = high accumulator
         ld      a,16
-lmuls_b:
-        bit     0,e                     ; multiplier LSB
-        jr      z,lmuls_bn
+lm1s_b:
+        bit     0,e
+        jr      z,lm1s_bn
         add     hl,bc
-        jr      lmuls_bs
-lmuls_bn:
+        jr      lm1s_bs
+lm1s_bn:
         or      a
-lmuls_bs:
-        rr      h                       ; shift CF:HL:DE right by one
+lm1s_bs:
+        rr      h
         rr      l
         rr      d
         rr      e
         dec     a
-        jr      nz,lmuls_b
+        jr      nz,lm1s_b
         ex      de,hl                   ; HL = low, DE = high
-        ld      a,(lmuls_sg)
+        ld      a,(lm1s_sg)
         bit     7,a
-        jr      z,lmuls_done
-        ld      a,l                     ; negate 32-bit DE:HL (HL=low, DE=high)
+        ret     z
+        ld      a,l
         cpl
         ld      l,a
         ld      a,h
@@ -6475,13 +6449,10 @@ lmuls_bs:
         inc     hl
         ld      a,h
         or      l
-        jr      nz,lmuls_done
+        ret     nz
         inc     de
-lmuls_done:
-        ld      sp,ix
-        pop     ix
         ret
-lmuls_sg:       db      0
+lm1s_sg:        db      0
 
 ; __ldivu: unsigned 32-bit divide.  Returns DE:HL = LHS / RHS.
         public  __ldu

--- a/src/apps/attn/ATTNC89.C
+++ b/src/apps/attn/ATTNC89.C
@@ -60,6 +60,10 @@
 
 #define ERROR (-1)
 
+#define FM_TRAIN 1
+#define FM_VALID 2
+#define FM_INFER 3
+
 /* Trained weights are saved here so inference can reload them. */
 #define WFILE "ATTN.WTS"
 
@@ -185,16 +189,14 @@ static int  fxdiv(int a, int b);
 static int  asr(int v, int n);
 static void addcl(int *dst, int v);
 static int  subcl(int a, int b);
-static int  vmax(int *vec, int n, int *pidx);
-static int  vdot(int *x, int *y, int n);
-static void vcpy(int *src, int *dst, int n);
-static void vclr(int *p, int n);
-static void vsadd(int sc, int *src, int *dst, int n);
-static void sftmx(int *vec, int n);
-static void mvmul(int *mat, int *vin, int *vout, int rows, int cols);
-static void mvadd(int *mat, int *vin, int *vout, int rows, int cols);
-static void vtmul(int *mat, int *vin, int *vout, int rows, int cols);
-static void outer(int *mat, int *vx, int *vy, int rows, int cols);
+static int  vmax(int *vec, unsigned char n, int *pidx);
+static int  vdot(int *x, int *y, unsigned char n);
+static void vsadd(int sc, int *src, int *dst, unsigned char n);
+static void sftmx(int *vec, unsigned char n);
+static void mvmul(int *mat, int *vin, int *vout, unsigned char rows, unsigned char cols);
+static void mvadd(int *mat, int *vin, int *vout, unsigned char rows, unsigned char cols);
+static void vtmul(int *mat, int *vin, int *vout, unsigned char rows, unsigned char cols);
+static void outer(int *mat, int *vx, int *vy, unsigned char rows, unsigned char cols);
 static void embed(void);
 static void attn(void);
 static void proj(void);
@@ -212,6 +214,8 @@ static void mktarg(void);
 static void gensm(void);
 static void trseq(void);
 static int  ckseq(void);
+static int  doseq(int mode);
+static int  seqfile(char *fname, int mode);
 static int  filrun(char *fname, int trn);
 static void count(void);
 static int  closs(void);
@@ -220,6 +224,8 @@ static void report(void);
 static void test(void);
 static int  infseq(void);
 static int  runfil(char *fname);
+static int  wio(int fd, long *w, int n, int wr);
+static int  wfile(int fd, int wr);
 static int  savew(void);
 static int  loadw(void);
 static unsigned elapsed(void);
@@ -291,9 +297,10 @@ static int subcl(int a, int b)
 /* Vector primitives                                            */
 /* ============================================================ */
 
-static int vmax(int *vec, int n, int *pidx)
+static int vmax(int *vec, unsigned char n, int *pidx)
 {
-    int mx, mi, i;
+    int mx;
+    unsigned char mi, i;
 
     mx = vec[0];
     mi = 0;
@@ -306,10 +313,10 @@ static int vmax(int *vec, int n, int *pidx)
     return mx;
 }
 
-static int vdot(int *x, int *y, int n)
+static int vdot(int *x, int *y, unsigned char n)
 {
     long acc;
-    int i;
+    unsigned char i;
 
     acc = 0;
     for (i = 0; i < n; i++)
@@ -317,35 +324,20 @@ static int vdot(int *x, int *y, int n)
     return lq8(acc);
 }
 
-static void vcpy(int *src, int *dst, int n)
-{
-    int i;
-
-    for (i = 0; i < n; i++)
-        dst[i] = src[i];
-}
-
-static void vclr(int *p, int n)
-{
-    int i;
-
-    for (i = 0; i < n; i++)
-        p[i] = 0;
-}
-
 /* dst[k] += (scalar * src[k]) >> 8, saturating */
-static void vsadd(int sc, int *src, int *dst, int n)
+static void vsadd(int sc, int *src, int *dst, unsigned char n)
 {
-    int k;
+    unsigned char k;
 
     for (k = 0; k < n; k++)
         addcl(&dst[k], mq8(sc, src[k]));
 }
 
 /* softmax in place (Q8), LUT-based */
-static void sftmx(int *vec, int n)
+static void sftmx(int *vec, unsigned char n)
 {
-    int i, mx, d, idx, sum, dummy;
+    int mx, d, idx, sum, dummy;
+    unsigned char i;
 
     mx = vmax(vec, n, &dummy);
     sum = 0;
@@ -368,10 +360,11 @@ static void sftmx(int *vec, int n)
 /* ============================================================ */
 
 /* vout[i] = sum_j mat[i][j] * vin[j]  (Q16 accum, >>8, clamp) */
-static void mvmul(int *mat, int *vin, int *vout, int rows, int cols)
+static void mvmul(int *mat, int *vin, int *vout, unsigned char rows, unsigned char cols)
 {
     long acc;
-    int i, j, mi;
+    int mi;
+    unsigned char i, j;
 
     mi = 0;
     for (i = 0; i < rows; i++) {
@@ -384,10 +377,11 @@ static void mvmul(int *mat, int *vin, int *vout, int rows, int cols)
 }
 
 /* vout[i] += sum_j mat[i][j] * vin[j]  (saturating add) */
-static void mvadd(int *mat, int *vin, int *vout, int rows, int cols)
+static void mvadd(int *mat, int *vin, int *vout, unsigned char rows, unsigned char cols)
 {
     long acc;
-    int i, j, mi;
+    int mi;
+    unsigned char i, j;
 
     mi = 0;
     for (i = 0; i < rows; i++) {
@@ -400,12 +394,12 @@ static void mvadd(int *mat, int *vin, int *vout, int rows, int cols)
 }
 
 /* vout[j] = sum_i (mat[i][j] * vin[i]) >> 8   (per-product Q8) */
-static void vtmul(int *mat, int *vin, int *vout, int rows, int cols)
+static void vtmul(int *mat, int *vin, int *vout, unsigned char rows, unsigned char cols)
 {
-    int i, j, sc, mi;
+    unsigned char i, j;
+    int sc, mi;
 
-    for (j = 0; j < cols; j++)
-        vout[j] = 0;
+    memset(vout, 0, cols * (int)sizeof(int));
     mi = 0;
     for (i = 0; i < rows; i++) {
         sc = vin[i];
@@ -416,9 +410,10 @@ static void vtmul(int *mat, int *vin, int *vout, int rows, int cols)
 }
 
 /* mat[i][j] += (vx[i] * vy[j]) >> 8   (saturating) */
-static void outer(int *mat, int *vx, int *vy, int rows, int cols)
+static void outer(int *mat, int *vx, int *vy, unsigned char rows, unsigned char cols)
 {
-    int i, j, sc, mi;
+    int sc, mi;
+    unsigned char i, j;
 
     mi = 0;
     for (i = 0; i < rows; i++) {
@@ -436,7 +431,8 @@ static void outer(int *mat, int *vx, int *vy, int rows, int cols)
 /* X[i] = tok_emb[tokens[i]] + pos_emb[i] */
 static void embed(void)
 {
-    int i, j, tok, oi;
+    int tok, oi;
+    unsigned char i, j;
 
     oi = 0;
     for (i = 0; i < S; i++) {
@@ -450,7 +446,7 @@ static void embed(void)
 /* self-attention forward pass */
 static void attn(void)
 {
-    int i, j;
+    unsigned char i, j;
 
     /* Step 1-3: Q = X.Wq, K = X.Wk, V = X.Wv */
     for (i = 0; i < S; i++) {
@@ -477,7 +473,7 @@ static void attn(void)
 /* logits[i] = Wout^T . Y[i] */
 static void proj(void)
 {
-    int i;
+    unsigned char i;
 
     for (i = 0; i < S; i++)
         vtmul(qwot, &yy[i * D], &logits[i * V], D, V);
@@ -565,12 +561,12 @@ static void updat(void)
 
 static void zerog(void)
 {
-    vclr(gtke, V * D);
-    vclr(gpse, S * D);
-    vclr(gwq, D * D);
-    vclr(gwk, D * D);
-    vclr(gwv, D * D);
-    vclr(gwot, D * V);
+    memset(gtke, 0, V * D * (int)sizeof(int));
+    memset(gpse, 0, S * D * (int)sizeof(int));
+    memset(gwq, 0, D * D * (int)sizeof(int));
+    memset(gwk, 0, D * D * (int)sizeof(int));
+    memset(gwv, 0, D * D * (int)sizeof(int));
+    memset(gwot, 0, D * V * (int)sizeof(int));
 }
 
 /* ============================================================ */
@@ -582,7 +578,7 @@ static void bkwrd(void)
     int i, j, k, o, tok, dad, t;
 
     /* Step 1: dLogits, dWout, dY */
-    vclr(dy, S * D);
+    memset(dy, 0, S * D * (int)sizeof(int));
     for (i = 0; i < S; i++) {
         for (k = 0; k < V; k++)
             dl[k] = logits[i * V + k];
@@ -595,7 +591,7 @@ static void bkwrd(void)
     }
 
     /* Step 2: dA, dV */
-    vclr(dvv, S * D);
+    memset(dvv, 0, S * D * (int)sizeof(int));
     for (i = 0; i < S; i++)
         for (j = 0; j < S; j++) {
             da[i * S + j] = vdot(&work[VB + j * D], &dy[i * D], D);
@@ -622,7 +618,7 @@ static void bkwrd(void)
     }
 
     /* Step 5: backward projections + dX */
-    vcpy(dy, dxx, S * D);
+    memcpy(dxx, dy, S * D * (int)sizeof(int));
     for (i = 0; i < S; i++) {
         o = i * D;
         mvadd(qwq, &dqq[o], &dxx[o], D, D);
@@ -692,8 +688,19 @@ static int ckseq(void)
     return ok;
 }
 
-/* read fixed samples from fname. trn=1 trains; trn=0 validates quietly. */
-static int filrun(char *fname, int trn)
+static int doseq(int mode)
+{
+    if (mode == FM_INFER)
+        return infseq();
+    mktarg();
+    if (mode == FM_TRAIN) {
+        trseq();
+        return 1;
+    }
+    return ckseq();
+}
+
+static int seqfile(char *fname, int mode)
 {
     int ch, i, n;
     FILE *fp;
@@ -704,10 +711,6 @@ static int filrun(char *fname, int trn)
 
     n = 0;
     i = 0;
-    if (!trn) {
-        vhits = 0;
-        cvt16();
-    }
     while ((ch = getc(fp)) != EOF && ch != 26) {
         if (ch >= '0' && ch <= '9') {
             if (i < S)
@@ -715,26 +718,39 @@ static int filrun(char *fname, int trn)
             i = i + 1;
         } else if (ch == '\n') {
             if (i >= S) {
-                mktarg();
-                if (trn)
-                    trseq();
-                else
-                    vhits = vhits + ckseq();
                 n = n + 1;
-            }
+                if (mode == FM_VALID)
+                    vhits = vhits + doseq(mode);
+                else if (mode == FM_INFER)
+                    fhits = fhits + doseq(mode);
+                else
+                    doseq(mode);
+            } else if (mode == FM_INFER && i > 0)
+                printf(" (skipped line: %d digits, need %d)\n", i, S);
             i = 0;
         }
     }
     if (i >= S) {
-        mktarg();
-        if (trn)
-            trseq();
-        else
-            vhits = vhits + ckseq();
         n = n + 1;
+        if (mode == FM_VALID)
+            vhits = vhits + doseq(mode);
+        else if (mode == FM_INFER)
+            fhits = fhits + doseq(mode);
+        else
+            doseq(mode);
     }
     fclose(fp);
     return n;
+}
+
+/* read fixed samples from fname. trn=1 trains; trn=0 validates quietly. */
+static int filrun(char *fname, int trn)
+{
+    if (!trn) {
+        vhits = 0;
+        cvt16();
+    }
+    return seqfile(fname, trn ? FM_TRAIN : FM_VALID);
 }
 
 /* count correct argmax predictions */
@@ -802,9 +818,9 @@ static void test(void)
     int n, i, idx, allok, ok;
 
     ok = 0;
+    cvt16();
     for (n = 0; n < 10; n++) {
         gensm();
-        cvt16();
         forwrd();
         for (i = 0; i < S; i++) {
             vmax(&logits[i * V], V, &idx);
@@ -863,38 +879,8 @@ static int infseq(void)
  * Returns the count processed, or ERROR if the file cannot be opened. */
 static int runfil(char *fname)
 {
-    int ch, i, n;
-    FILE *fp;
-
-    fp = fopen(fname, "r");
-    if (fp == NULL)
-        return ERROR;
-
-    n = 0;
-    i = 0;
     fhits = 0;
-    while ((ch = getc(fp)) != EOF && ch != 26) {
-        if (ch >= '0' && ch <= '9') {
-            if (i < S)
-                tokens[i] = ch - '0';
-            i = i + 1;
-        } else if (ch == '\n') {
-            if (i >= S) {
-                fhits = fhits + infseq();
-                n = n + 1;
-            } else if (i > 0)
-                printf(" (skipped line: %d digits, need %d)\n", i, S);
-            i = 0;
-        }
-        /* other chars are in-line separators and are ignored */
-    }
-    /* handle a final line with no trailing newline */
-    if (i >= S) {
-        fhits = fhits + infseq();
-        n = n + 1;
-    }
-    fclose(fp);
-    return n;
+    return seqfile(fname, FM_INFER);
 }
 
 /* ============================================================ */
@@ -903,6 +889,26 @@ static int runfil(char *fname)
 
 /* save the six Q16 weight arrays to WFILE; 0 ok, ERROR on fail.
  * dcc stores `long` little-endian, so the file is little-endian. */
+static int wio(int fd, long *w, int n, int wr)
+{
+    int bytes;
+
+    bytes = n * (int)sizeof(long);
+    if (wr)
+        return write(fd, w, bytes) == bytes;
+    return read(fd, w, bytes) == bytes;
+}
+
+static int wfile(int fd, int wr)
+{
+    return wio(fd, wtke, V * D, wr)
+        && wio(fd, wpse, S * D, wr)
+        && wio(fd, wwq,  D * D, wr)
+        && wio(fd, wwk,  D * D, wr)
+        && wio(fd, wwv,  D * D, wr)
+        && wio(fd, wwot, D * V, wr);
+}
+
 static int savew(void)
 {
     int fd, ok;
@@ -910,12 +916,7 @@ static int savew(void)
     fd = open(WFILE, O_WRONLY | O_CREAT | O_TRUNC, 0);
     if (fd < 0)
         return ERROR;
-    ok = write(fd, wtke, sizeof(wtke)) == (int)sizeof(wtke)
-      && write(fd, wpse, sizeof(wpse)) == (int)sizeof(wpse)
-      && write(fd, wwq,  sizeof(wwq))  == (int)sizeof(wwq)
-      && write(fd, wwk,  sizeof(wwk))  == (int)sizeof(wwk)
-      && write(fd, wwv,  sizeof(wwv))  == (int)sizeof(wwv)
-      && write(fd, wwot, sizeof(wwot)) == (int)sizeof(wwot);
+    ok = wfile(fd, 1);
     close(fd);
     return ok ? 0 : ERROR;
 }
@@ -928,12 +929,7 @@ static int loadw(void)
     fd = open(WFILE, O_RDONLY, 0);
     if (fd < 0)
         return ERROR;
-    ok = read(fd, wtke, sizeof(wtke)) == (int)sizeof(wtke)
-      && read(fd, wpse, sizeof(wpse)) == (int)sizeof(wpse)
-      && read(fd, wwq,  sizeof(wwq))  == (int)sizeof(wwq)
-      && read(fd, wwk,  sizeof(wwk))  == (int)sizeof(wwk)
-      && read(fd, wwv,  sizeof(wwv))  == (int)sizeof(wwv)
-      && read(fd, wwot, sizeof(wwot)) == (int)sizeof(wwot);
+    ok = wfile(fd, 0);
     close(fd);
     return ok ? 0 : ERROR;
 }

--- a/src/dcc/dcc_ops.c
+++ b/src/dcc/dcc_ops.c
@@ -706,10 +706,10 @@ void emit_and_hl_const(unsigned int mask);
 static const char *long_mul_widen_helper(int lhs_w, int rhs_w)
 {
     /* 5-char names: L80 only treats the first 6 characters of a public symbol
-     * as significant, so __lmuls/__lmulu would alias __lmul.  __m16s/__m16u
+     * as significant, so __lmuls/__lmulu would alias __lmul.  __m1s/__m1u
      * stay distinct. */
-    if (lhs_w == 1 && rhs_w == 1) return "__m16s";
-    if (lhs_w == 2 && rhs_w == 2) return "__m16u";
+    if (lhs_w == 1 && rhs_w == 1) return "__m1s";
+    if (lhs_w == 2 && rhs_w == 2) return "__m1u";
     return 0;
 }
 
@@ -982,14 +982,11 @@ void gen_mul(void)
 
                 mulhelp = (op == '*') ? long_mul_widen_helper(lhs_w, rhs_w) : 0;
                 if (mulhelp) {
-                    /* Same 8-byte stack convention as gen_binop32's l32call,
-                     * but the 16x16 helper reads only the two pushed low
-                     * words. */
-                    emit("\tpush de\n\tpush hl\n");
+                    /* LHS is already stacked as high,low and RHS is in DE:HL.
+                     * The widened-16 multiply only needs the low words, so use
+                     * a register ABI helper: BC=LHS low, HL=RHS low -> DE:HL. */
+                    emit("\tpop bc\n\tpop af\n");
                     emit_runtime_call(mulhelp);
-                    emit("\tld b,d\n\tld c,e\n\tex de,hl\n");
-                    emit("\tld hl,8\n\tadd hl,sp\n\tld sp,hl\n");
-                    emit("\tex de,hl\n\tld d,b\n\tld e,c\n");
                 } else {
                     gen_binop32(op, common_type);
                 }

--- a/src/dccpeep/dccpeep.c
+++ b/src/dccpeep/dccpeep.c
@@ -2473,6 +2473,7 @@ static int pass_mulu_const(void)
         long de_val;
         int has_extrn;
         int n_delete;
+        int shift_count;
         char tmp[MAX_LINE];
         char *endp;
 
@@ -2506,6 +2507,27 @@ static int pass_mulu_const(void)
                     }
                 }
             }
+        }
+
+        if (de_val == 0 || de_val == 1 ||
+            (de_val > 0 && de_val <= 32768 && (de_val & (de_val - 1)) == 0)) {
+            delete_n(i, n_delete);
+
+            if (de_val == 0) {
+                insert_line_tagged(i, "ld hl,0", "mulu0");
+            } else {
+                shift_count = 0;
+                while (de_val > 1) {
+                    de_val >>= 1;
+                    shift_count++;
+                }
+                while (shift_count-- > 0)
+                    insert_line_tagged(i, "add hl,hl", "mulu_pow2");
+            }
+
+            changed = 1;
+            if (i > 0) i--;
+            continue;
         }
 
         /* Inline expansion for specific multiplier constants.


### PR DESCRIPTION
@davidly perf for learnt from attn and rolled into the runtime and compiler

Speeds up the widened-16 (long)int * int hotspot on Z80 and trims the runtime. Validated: full fast regression 189/0/7; ATTNC89 accuracy 14/14.

dcc (codegen):
- gen_mul: when both long operands are freshly widened from 16-bit, hand the low words to the multiply helper via registers (pop bc = LHS low, pop af discards the extension high word; RHS low already in HL) instead of the 8-byte stack setup/teardown. long_mul_widen_helper now returns the emitted names (__m1s/__m1u) directly.

DCCRTL.MAC (runtime):
- Add __m1s/__m1u: signed/unsigned 16x16 -> 32 multiply with a register ABI (BC=LHS low, HL=RHS low -> DE:HL), no IX frame. Same shift-add core as the old __m16s/__m16u.
- Remove the now-dead stack-ABI __m16s/__m16u routines.

dccpeep (peephole):
- pass_mulu_const: fold `ld de,N; call __mulu` for N==0 (ld hl,0), N==1 (identity), and powers of two <= 32768 (log2(N) x `add hl,hl`), valid for __mulu's 16-bit modulo result.

attn (workload):
- ATTNC89.C: type fixed small loop counters/dimensions (counts <= 16) as unsigned char in the vector/matrix helpers.