### PR TITLE
Anonymous aggregate members

### DIFF
--- a/.github/skills/dcc-cpm-z80/SKILL.md
+++ b/.github/skills/dcc-cpm-z80/SKILL.md
@@ -122,10 +122,12 @@ parameter loads, and returns. Include `stdbool.h` for the portable spellings
 `bool`, `true`, and `false`. dcc also accepts practical front-end compatibility
 used by common C99-era code: forward enum declarations are parsed as `int`-sized
 enum types, including inside function prototypes and function-pointer
-declarators such as `int (*member)(enum E value)`. C11 anonymous struct/union
-members are accepted, including aggregate initialization through the anonymous
-member. GNU `__attribute__((...))` annotations are skipped when they appear in
-supported declaration positions.
+declarators such as `int (*member)(enum E value)`. C11 anonymous struct and
+union members are accepted; members of anonymous aggregates are promoted for
+ordinary member access, including nested forms, and aggregate initialization
+through anonymous struct/union members is supported. GNU
+`__attribute__((...))` annotations are skipped when they appear in supported
+declaration positions.
 
 Not implemented yet, but plausible front-end scope: C99 designated initializers,
 C99 array designators, C99 compound literals, C99 variadic macros, GNU statement

--- a/docs/docs/en/01-c-conformance.md
+++ b/docs/docs/en/01-c-conformance.md
@@ -102,8 +102,10 @@ for (int i = 0; i < 3; i++)
   `true`, and `false`.
 - Forward enum declarations are accepted as `int`-sized enum types, including
   inside prototypes and function-pointer declarators.
-- C11 anonymous struct/union members are accepted, including aggregate
-  initialization through the anonymous member.
+- C11 anonymous struct and union members are accepted. Members of anonymous
+  aggregates are promoted for ordinary member access, including nested forms,
+  and aggregate initialization through anonymous struct/union members is
+  supported.
 - GNU `__attribute__((...))` annotations are skipped in supported declaration
   positions.
 - `static inline` functions are supported for small helper functions. dcc can

--- a/docs/docs/en/index.md
+++ b/docs/docs/en/index.md
@@ -74,6 +74,12 @@ optimizer pass.
 
 ## Engineering Notes
 
-dcc changes are built often, run under the emulator, and compared against
-baselines. The main constraints are small memory, old tools, fixed file formats,
-and reproducible tests.
+The dcc C Compiler was engineered agentically, with plenty of human supervision,
+patience, and love. It is unit tested against baselines grounded in modern desktop
+C compilers and a platform-appropriate subset of the community-driven
+[c-testsuite](https://github.com/c-testsuite/c-testsuite).
+
+## Contributions and Feedback Welcome
+
+This is an Open Source C compiler, community contributions welcome and/or report issues via the GitHub Issues for this project.
+

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -288,6 +288,8 @@ struct FieldDef {
     int dim_count;
     int dims[4];
     int parent_struct_id; /* which struct/union owns this field */
+    int is_anonymous;   /* unnamed C11 struct/union member; owns layout/init slot */
+    int is_promoted;    /* synthetic lookup alias through an anonymous member */
     int bit_width;      /* >0 for C89 int bitfield */
     int bit_shift;      /* bit offset within containing 16-bit storage unit */
     unsigned int bit_mask;

--- a/src/dcc/dcc_decl.c
+++ b/src/dcc/dcc_decl.c
@@ -514,7 +514,7 @@ int next_parent_field_index(int sid, int start)
 {
     int k;
     for (k = start; k < nfield_defs; ++k)
-        if (field_defs[k].parent_struct_id == sid)
+        if (field_defs[k].parent_struct_id == sid && !field_defs[k].is_promoted)
             return k;
     return -1;
 }
@@ -549,7 +549,7 @@ void emit_init_auto_struct_type(struct Sym *s, int baseoff, int type)
         struct FieldDef *first;
         first = NULL;
         for (i = 0; i < nfield_defs; ++i) {
-            if (field_defs[i].parent_struct_id == sid) {
+            if (field_defs[i].parent_struct_id == sid && !field_defs[i].is_promoted) {
                 first = &field_defs[i];
                 break;
             }
@@ -605,7 +605,7 @@ void emit_init_auto_struct_type(struct Sym *s, int baseoff, int type)
             expect('=');
         } else {
             fd = &field_defs[i];
-            if (fd->parent_struct_id != sid)
+            if (fd->parent_struct_id != sid || fd->is_promoted)
                 continue;
         }
 
@@ -626,7 +626,7 @@ void emit_init_auto_struct_type(struct Sym *s, int baseoff, int type)
             while (k >= 0 && k < nfield_defs && tok.kind != TOK_EOF && tok.kind != '}') {
                 struct FieldDef *bfd;
                 bfd = &field_defs[k];
-                if (bfd->parent_struct_id == sid) {
+                if (bfd->parent_struct_id == sid && !bfd->is_promoted) {
                     if (bfd->bit_width <= 0 || bfd->offset != unit_off)
                         break;
                     unit |= bitfield_init_part(bfd, parse_struct_init_const_value());

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -2008,7 +2008,7 @@ static void parse_global_init_struct_at(struct Sym *s, int type, int baseoff)
         struct FieldDef *first;
         first = NULL;
         for (i = 0; i < nfield_defs; ++i) {
-            if (field_defs[i].parent_struct_id == sid) {
+            if (field_defs[i].parent_struct_id == sid && !field_defs[i].is_promoted) {
                 first = &field_defs[i];
                 break;
             }
@@ -2059,7 +2059,7 @@ static void parse_global_init_struct_at(struct Sym *s, int type, int baseoff)
             expect('=');
         } else {
             fd = &field_defs[i];
-            if (fd->parent_struct_id != sid)
+            if (fd->parent_struct_id != sid || fd->is_promoted)
                 continue;
         }
 
@@ -2077,7 +2077,7 @@ static void parse_global_init_struct_at(struct Sym *s, int type, int baseoff)
             while (k >= 0 && k < nfield_defs && tok.kind != TOK_EOF && tok.kind != '}') {
                 struct FieldDef *bfd;
                 bfd = &field_defs[k];
-                if (bfd->parent_struct_id == sid) {
+                if (bfd->parent_struct_id == sid && !bfd->is_promoted) {
                     if (bfd->bit_width <= 0 || bfd->offset != unit_off)
                         break;
                     unit |= bitfield_init_part(bfd, parse_struct_init_const_value());

--- a/src/dcc/dcc_types.c
+++ b/src/dcc/dcc_types.c
@@ -135,7 +135,7 @@ int type_scalar_atom_count(int type)
         int d;
 
         fd = &field_defs[i];
-        if (fd->parent_struct_id != sid)
+        if (fd->parent_struct_id != sid || fd->is_promoted)
             continue;
 
         fcount = 1;
@@ -338,6 +338,37 @@ struct FieldDef *find_field_def(int struct_id, const char *field_name)
     return NULL;
 }
 
+static void promote_anonymous_aggregate_fields(int parent_struct_id, struct FieldDef *anon_fd)
+{
+    int child_sid;
+    int i;
+    int limit;
+
+    if (anon_fd == NULL || !(anon_fd->type & TYPE_STRUCT) || type_ptr_depth(anon_fd->type) != 0)
+        return;
+
+    child_sid = type_struct_id(anon_fd->type);
+    if (child_sid <= 0 || child_sid > nstruct_defs)
+        return;
+
+    limit = nfield_defs;
+    for (i = 0; i < limit; ++i) {
+        if (field_defs[i].parent_struct_id != child_sid || field_defs[i].is_anonymous)
+            continue;
+        if (field_defs[i].name[0] == 0)
+            continue;
+        if (nfield_defs >= MAX_FIELDS)
+            fatal("too many struct fields");
+
+        field_defs[nfield_defs] = field_defs[i];
+        field_defs[nfield_defs].parent_struct_id = parent_struct_id;
+        field_defs[nfield_defs].offset += anon_fd->offset;
+        field_defs[nfield_defs].is_anonymous = 0;
+        field_defs[nfield_defs].is_promoted = 1;
+        nfield_defs++;
+    }
+}
+
 void parse_struct_definition(int struct_id)
 {
     struct StructDef *sd;
@@ -362,19 +393,27 @@ void parse_struct_definition(int struct_id)
 
         for (;;) {
             int is_funcptr_field;
+            int is_anonymous_field;
+            int field_index;
             while (accept('*')) { skip_type_qualifiers(); ftype = type_add_ptr(ftype); }
 
             is_funcptr_field = 0;
+            is_anonymous_field = 0;
             if (parse_funcptr_declarator(&ftype, fname, sizeof(fname))) {
                 is_funcptr_field = 1;
             } else {
                 if (tok.kind != TOK_ID) {
-                    error_here("field name expected");
-                    break;
+                    if (tok.kind == ';' && (ftype & TYPE_STRUCT) && type_ptr_depth(ftype) == 0) {
+                        fname[0] = 0;
+                        is_anonymous_field = 1;
+                    } else {
+                        error_here("field name expected");
+                        break;
+                    }
+                } else {
+                    dcc_copy_str(fname, sizeof(fname), tok.text);
+                    next_token();
                 }
-
-                dcc_copy_str(fname, sizeof(fname), tok.text);
-                next_token();
             }
 
             if (tok.kind == ':') {
@@ -466,6 +505,8 @@ void parse_struct_definition(int struct_id)
             }
 
             field_defs[nfield_defs].size = bytes;
+            field_defs[nfield_defs].is_anonymous = is_anonymous_field;
+            field_index = nfield_defs;
             nfield_defs++;
 
             sd->field_count++;
@@ -475,6 +516,9 @@ void parse_struct_definition(int struct_id)
             } else {
                 sd->size += bytes;
             }
+
+            if (is_anonymous_field)
+                promote_anonymous_aggregate_fields(struct_id, &field_defs[field_index]);
 
             if (!accept(',')) break;
         }

--- a/tests/_extended_test_overrides.json
+++ b/tests/_extended_test_overrides.json
@@ -4,8 +4,6 @@
     "Ignored tests below are either not-yet-implemented C99/C11/GNU front-end compatibility candidates or true CP/M 2.2/Z80 target-model/runtime mismatches. Target-model reasons are called out explicitly."
   ],
   "tests": [
-    { "name": "00046", "ignore": true, "reason": "Uses C11 anonymous struct/union members; dcc does not implement anonymous aggregate member lookup yet." },
-    { "name": "00050", "ignore": true, "reason": "Uses C11 anonymous union members and aggregate initialization through anonymous members; dcc does not implement this yet." },
     { "name": "00081", "ignore": true, "reason": "Uses long long; dcc has no 64-bit integer type." },
     { "name": "00082", "ignore": true, "reason": "Uses unsigned long long; dcc has no 64-bit integer type." },
     { "name": "00104", "ignore": true, "reason": "Uses int64_t and 64-bit integer constants; dcc has no 64-bit integer type." },

--- a/tests/baselines/tanonagg.txt
+++ b/tests/baselines/tanonagg.txt
@@ -1,0 +1,1 @@
+anonymous aggregate tests passed

--- a/tests/tanonagg.c
+++ b/tests/tanonagg.c
@@ -1,0 +1,95 @@
+/* tanonagg.c - C11 anonymous struct/union member lookup and initialization. */
+#include <stdio.h>
+
+struct NestedAnon {
+    int a;
+    union {
+        int b1;
+        int b2;
+    };
+    struct {
+        union {
+            struct {
+                int c;
+            };
+        };
+    };
+    struct {
+        int d;
+    };
+};
+
+struct Pair {
+    int x;
+    int y;
+};
+
+struct InitAnon {
+    int a;
+    int b;
+    union {
+        int c;
+        int d;
+    };
+    struct Pair pair;
+};
+
+static int failures;
+static struct NestedAnon global_nested = { 1, 2, 3, 4 };
+static struct InitAnon global_init = { 10, 20, 30, { 40, 50 } };
+
+static void check_int(const char *name, int got, int want)
+{
+    if (got != want) {
+        printf("FAIL %s got=%d want=%d\n", name, got, want);
+        failures++;
+    }
+}
+
+static void check_global_initializers(void)
+{
+    check_int("global_nested.a", global_nested.a, 1);
+    check_int("global_nested.b1", global_nested.b1, 2);
+    check_int("global_nested.b2", global_nested.b2, 2);
+    check_int("global_nested.c", global_nested.c, 3);
+    check_int("global_nested.d", global_nested.d, 4);
+    check_int("global_init.a", global_init.a, 10);
+    check_int("global_init.b", global_init.b, 20);
+    check_int("global_init.c", global_init.c, 30);
+    check_int("global_init.d", global_init.d, 30);
+    check_int("global_init.pair.x", global_init.pair.x, 40);
+    check_int("global_init.pair.y", global_init.pair.y, 50);
+}
+
+static void check_local_initializers(void)
+{
+    struct NestedAnon nested;
+    struct InitAnon init = { 11, 12, 13, { 14, 15 } };
+
+    nested.a = 5;
+    nested.b2 = 6;
+    nested.c = 7;
+    nested.d = 8;
+
+    check_int("nested.a", nested.a, 5);
+    check_int("nested.b1", nested.b1, 6);
+    check_int("nested.b2", nested.b2, 6);
+    check_int("nested.c", nested.c, 7);
+    check_int("nested.d", nested.d, 8);
+    check_int("init.a", init.a, 11);
+    check_int("init.b", init.b, 12);
+    check_int("init.c", init.c, 13);
+    check_int("init.d", init.d, 13);
+    check_int("init.pair.x", init.pair.x, 14);
+    check_int("init.pair.y", init.pair.y, 15);
+}
+
+int main(void)
+{
+    check_global_initializers();
+    check_local_initializers();
+
+    if (failures == 0)
+        printf("anonymous aggregate tests passed\n");
+    return failures != 0;
+}


### PR DESCRIPTION
@davidly 

Implement C11 anonymous aggregate members

Add support for C11 anonymous struct and union members in the dcc front end.
Unnamed aggregate fields are now accepted during struct/union parsing, retained
as real layout/initializer slots, and expanded into promoted member aliases for
ordinary member lookup. Positional aggregate initialization skips those promoted
aliases so anonymous aggregates still consume the correct initializer slot.

Also add regression coverage for anonymous aggregate member access and
initialization, remove the extended-suite ignores for 00046 and 00050, and update
the C conformance documentation to describe the supported behavior.

Validation:
- pwsh ./scripts/build-dcc.ps1
- ./dcc tests/extended-tests/tests/single-exec/00046.c
- ./dcc tests/extended-tests/tests/single-exec/00050.c
- gcc -std=c11 tests/tanonagg.c -o /tmp/tanonagg && /tmp/tanonagg
- pwsh ./scripts/ma.ps1 tanonagg fast
- ntvcm build/TANONAGG.COM
- pwsh ./scripts/validate-unit-test.ps1 -App tanonagg
- pwsh ./scripts/runall.ps1 -Extended
- pwsh ./scripts/runall.ps1 -mode=full -extended