### PR TITLE
docs update notably the conformance section and the consistent use of…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "cmake.sourceDirectory": "/home/dave/GitHub/dcc/src/dcc"
+    "cmake.sourceDirectory": "/Users/dave/GitHub/dcc/src/dcc"
 }

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -1,7 +1,7 @@
-# dcc MkDocs site
+# DCC C Compiler MkDocs site
 
 This folder contains the MkDocs configuration and English documentation source
-for the dcc documentation site.
+for the DCC C Compiler documentation site.
 
 ## Layout
 

--- a/docs/docs/en/00-agent-skills.md
+++ b/docs/docs/en/00-agent-skills.md
@@ -1,20 +1,19 @@
 # Agentic skills
 
-The dcc repo ships a project-scoped **agentic skill** in
+The DCC C Compiler repo ships a project-scoped **agentic skill** in
 `.github/skills/dcc-cpm-z80`. A skill is a folder containing a `SKILL.md` (plus
-optional `references/`) that packages domain knowledge. This one covers C89
-plus target-appropriate C99/C11 code for dcc, CP/M 2.2, Z80, ntvcm, and the dcc
-runtime library.
+optional `references/`) that packages domain knowledge. This one covers the
+language, runtime, and toolchain rules for the DCC C Compiler.
 
 An agent that supports skills reads `SKILL.md` on demand when your task matches
-the skill's description, so it gets dcc-specific guidance without you pasting it
+the skill's description, so it gets guidance for the DCC C Compiler without you pasting it
 into every prompt.
 
 ## Invoking the skill in VS Code
 
 With GitHub Copilot in VS Code (agent mode), the skill is picked up when you
-open the dcc repo. The agent loads it when your request falls within the skill's
-scope, such as dcc, CP/M, Z80, ntvcm, or DCCRTL. You can also request it
+open the DCC C Compiler repo. The agent loads it when your request falls within the skill's
+scope, such as source for the DCC C Compiler, DCCRTL, or ntvcm. You can also request it
 explicitly:
 
 > use the dcc-cpm-z80 skill to build and test foo.c
@@ -28,12 +27,12 @@ a session:
     copilot
 
 Then ask something within the skill's scope, for example: "build and run sieve.c
-for CP/M with dcc".
+with the DCC C Compiler".
 
 ## Making the skill available system-wide
 
-The copy in the dcc repo only applies while you work inside that repo. To use
-the skill from other projects, copy it to a personal skills root. The dcc tools
+The copy in the DCC C Compiler repo only applies while you work inside that repo. To use
+the skill from other projects, copy it to a personal skills root. The DCC C Compiler tools
 and `DCCRTL.MAC` must still be on your `PATH`; see
 [Setting up the toolchain](00-setup-toolchain.md).
 

--- a/docs/docs/en/00-setup-toolchain.md
+++ b/docs/docs/en/00-setup-toolchain.md
@@ -1,26 +1,23 @@
 # The toolchain
 
-To build and run CP/M apps with dcc you need two things: the dcc compiler tools
-(`dcc`, `dccpeep`, `dccrtlstrip`, plus `DCCRTL.MAC`, `m80.com`, and `l80.com`)
-and the [ntvcm](https://github.com/davidly/ntvcm) CP/M 2.2 emulator to run the
-results. Both are self-contained projects that build on Windows, Linux, and
-macOS.
+To compile, assemble, link, and run CP/M apps with the DCC C Compiler toolchain, you need two things: the DCC C Compiler tools
+(`dcc`, `dccmake`, `dccpeep`, `dccrtlstrip`, plus `DCCRTL.MAC`, `m80.com`, and `l80.com`) and the [ntvcm](https://github.com/davidly/ntvcm) CP/M 2.2 emulator to run CP/M binaries, including `m80.com`, `l80.com`, and the resulting programs.
 
 You build these tools once. After that, use them from any CP/M app project.
 
 Setup flow:
 
 - Install the host prerequisites for Windows, macOS, or Linux.
-- Clone the `dcc` and `ntvcm` repositories.
-- Build the dcc host tools with `pwsh ./scripts/build-dcc.ps1`.
+- Clone the DCC C Compiler (`dcc`) and `ntvcm` repositories.
+- Build the DCC C Compiler host tools with `pwsh ./scripts/build-dcc.ps1`.
 - Build the ntvcm emulator.
-- Add the dcc and ntvcm directories to your `PATH`.
+- Add the DCC C Compiler and ntvcm directories to your `PATH`.
 - Verify the setup with a sample CP/M program.
 
 ## Install prerequisites
 
 Install the native compiler tools for your host platform before cloning and
-building dcc or ntvcm.
+building DCC C Compiler or ntvcm.
 
 === "Windows"
 
@@ -139,7 +136,7 @@ building dcc or ntvcm.
 
         You can also use the Visual Studio Installer and select **Desktop
         development with C++**, then add the **MSVC ARM64/ARM64EC build tools**
-        component. The dcc Windows build scripts use the native ARM64 MSVC
+        component. The DCC C Compiler Windows build scripts use the native ARM64 MSVC
         environment (`vcvarsarm64.bat`) when they run on Windows ARM64.
 
     2. Verify that the ARM64 MSVC tools were installed:
@@ -162,13 +159,13 @@ building dcc or ntvcm.
 
 ## Clone the repositories
 
-    # Clone the dcc compiler
+    # Clone DCC C Compiler
     git clone https://github.com/davidly/dcc.git
 
     # Clone the ntvcm z80 emulator
     git clone https://github.com/davidly/ntvcm.git
 
-## Build dcc
+## Build DCC C Compiler
 
 The cross-platform PowerShell build script is in the `scripts` directory. It
 builds `dcc`, `dccpeep`, and `dccrtlstrip`, using MSVC on Windows, clang on
@@ -253,27 +250,28 @@ Build scripts live in the `scripts` directory:
 
 Run the single-app shell helper directly on Linux/macOS, or run the PowerShell
 scripts from your operating-system terminal or the VS Code terminal by changing
-to the dcc checkout, starting `pwsh`, and running `./scripts/ma.ps1` or
+to the DCC C Compiler checkout, starting `pwsh`, and running `./scripts/ma.ps1` or
 `./scripts/runall.ps1`.
 
 They resolve each tool the same way: they use an environment variable if you set
 one, otherwise they look for the tool on your `PATH`. The relevant tools are:
 
 - `dcc` — compiler
+- `dccmake` — build pipeline helper
 - `dccpeep` — peephole optimizer
 - `dccrtlstrip` — runtime stripper
 - `ntvcm` — CP/M emulator
 - `m80` / `l80` — assembler and linker
 
-Recommended setup, especially when building apps in a project *outside* the dcc
+Recommended setup, especially when building apps in a project *outside* the DCC C Compiler
 repo, is to add the directories containing the built `dcc` and `ntvcm`
-binaries to your `PATH`. The dcc directory also provides `dccpeep`,
+binaries to your `PATH`. The DCC C Compiler directory also provides `dccpeep`,
 `dccrtlstrip`, `m80.com`, `l80.com`, and `DCCRTL.MAC`, so no per-tool variables
 are needed.
 
 === "Windows"
 
-    1. Add the dcc and ntvcm directories to `PATH` for the current PowerShell
+    1. Add the DCC C Compiler and ntvcm directories to `PATH` for the current PowerShell
        session:
 
         ```powershell
@@ -293,7 +291,7 @@ are needed.
        `dccpeep`, `dccrtlstrip`, and `ntvcm` automatically.
 
        To pin specific binaries instead (for example, when juggling multiple
-       dcc builds), set the environment variables to explicit paths and only
+    DCC C Compiler builds), set the environment variables to explicit paths and only
        put ntvcm on `PATH`:
 
         ```powershell
@@ -305,7 +303,7 @@ are needed.
 
 === "macOS"
 
-    1. Add the dcc and ntvcm directories to `PATH` for the current shell
+    1. Add the DCC C Compiler and ntvcm directories to `PATH` for the current shell
        session:
 
         ```bash
@@ -326,7 +324,7 @@ are needed.
        automatically.
 
        To pin specific binaries instead (for example, when juggling multiple
-       dcc builds), set the environment variables to explicit paths and only
+    DCC C Compiler builds), set the environment variables to explicit paths and only
        put ntvcm on `PATH`:
 
         ```bash
@@ -338,7 +336,7 @@ are needed.
 
 === "Ubuntu"
 
-    1. Add the dcc and ntvcm directories to `PATH` for the current shell
+    1. Add the DCC C Compiler and ntvcm directories to `PATH` for the current shell
        session:
 
         ```bash
@@ -359,7 +357,7 @@ are needed.
        automatically.
 
        To pin specific binaries instead (for example, when juggling multiple
-       dcc builds), set the environment variables to explicit paths and only
+    DCC C Compiler builds), set the environment variables to explicit paths and only
        put ntvcm on `PATH`:
 
         ```bash
@@ -371,7 +369,7 @@ are needed.
 
 === "Ubuntu ARM64"
 
-    1. Add the dcc and ntvcm directories to `PATH` for the current shell
+    1. Add the DCC C Compiler and ntvcm directories to `PATH` for the current shell
        session:
 
         ```bash
@@ -392,7 +390,7 @@ are needed.
        automatically.
 
        To pin specific binaries instead (for example, when juggling multiple
-       dcc builds), set the environment variables to explicit paths and only
+    DCC C Compiler builds), set the environment variables to explicit paths and only
        put ntvcm on `PATH`:
 
         ```bash
@@ -404,7 +402,7 @@ are needed.
 
 === "Windows ARM64"
 
-    1. Add the dcc and ntvcm directories to `PATH` for the current PowerShell
+    1. Add the DCC C Compiler and ntvcm directories to `PATH` for the current PowerShell
        session:
 
         ```powershell
@@ -424,7 +422,7 @@ are needed.
        `dccpeep`, `dccrtlstrip`, and `ntvcm` automatically.
 
        To pin specific binaries instead (for example, when juggling multiple
-       dcc builds), set the environment variables to explicit paths and only
+    DCC C Compiler builds), set the environment variables to explicit paths and only
        put ntvcm on `PATH`:
 
         ```powershell
@@ -436,9 +434,9 @@ are needed.
 
 ## Verify the setup
 
-With the tools on your `PATH`, build and run one of the dcc repo's sample tests
+With the tools on your `PATH`, build and run one of the DCC C Compiler repo's sample tests
 to confirm everything is wired up. From your operating-system terminal or the VS
-Code terminal, change to the dcc checkout, start PowerShell, build
+Code terminal, change to the DCC C Compiler checkout, start PowerShell, build
 `tests/tstr.c`, then run the generated `.COM` file under ntvcm:
 
     cd /path/to/dcc
@@ -446,7 +444,7 @@ Code terminal, change to the dcc checkout, start PowerShell, build
     ./scripts/ma.ps1 tstr -Mode fast       # compiles tests/tstr.c -> TSTR.COM
     ntvcm TSTR.COM                         # runs it under the emulator
 
-The dcc repo's `tests/` programs are suitable samples for scratch projects, but
-day-to-day work does not need to happen inside the dcc repo. The tools build
+The DCC C Compiler repo's `tests/` programs are suitable samples for scratch projects, but
+day-to-day work does not need to happen inside the DCC C Compiler repo. The tools build
 CP/M apps from wherever your sources live. Once that works, move on to
 [Building and linking](02-build-and-link.md) for the day-to-day workflow.

--- a/docs/docs/en/01-c-conformance.md
+++ b/docs/docs/en/01-c-conformance.md
@@ -1,220 +1,142 @@
-# C conformance and target exceptions
+# C language conformance
 
-dcc is a CP/M 2.2 / Z80 cross-compiler with a C89 language core, a first-class
-`_Bool` scalar type, and selected target-appropriate C99/C11 front-end
-compatibility. It aims for strong C89 source compatibility within the CP/M/Z80
-target contract, not hosted desktop C conformance.
+The DCC C Compiler is a C compiler for CP/M 2.2 on the Z80. This page describes language
+support for that target, not for a hosted desktop system. Its base language is
+C89, with selected C99 and C11 features added where they fit CP/M and the Z80.
 
-Read this page by exception:
+Read the tables additively: start with the C89 support, then add the supported
+C99 features, then add the supported C11 features.
 
-- The baseline is ordinary C89, subject to the target-model and runtime limits
-  below.
-- Later C99/C11/GNU features are supported only when listed in
-  [Supported post-C89 front-end features](#supported-post-c89-front-end-features).
-- Anything listed in [Unsupported or target-inapplicable features](#unsupported-or-target-inapplicable-features)
-  should be treated as unavailable even if a hosted desktop compiler accepts it.
+## Target model
 
-## Target contract
+These limits apply at every language level.
 
-The target contract applies to every source level. These are not temporary parser
-gaps; they follow from CP/M 2.2, the Z80 data model, or the DCCRTL runtime.
-
-| Area | dcc behavior |
+| Feature | DCC C Compiler behavior |
 | --- | --- |
-| Integer and pointer model | `int`, `short`, pointers, `size_t`, and `ptrdiff_t` are 16-bit. `long` is 32-bit. |
-| Boolean model | `_Bool` is a first-class 8-bit scalar type. Nonzero values normalize to `1` when stored, cast, initialized, loaded as parameters, or returned as `_Bool`. |
-| Floating point | `float` is the only floating type. Unsuffixed floating constants are treated as single-precision `float`. |
-| `double` / `long double` | Not supported as distinct types. Use `float`. |
-| `long long` / 64-bit integers | Not supported. Use 32-bit `long` / `unsigned long`. |
-| Host ABI assumptions | Do not assume ILP32/LP64/LLP64 macros, host-sized `int`, or host-width expression results. |
-| Byte-stream stdio | CP/M text files use Ctrl-Z EOF semantics, and DCCRTL stdio is a subset of hosted C stdio. |
-| Wide-character Unicode runtime | `wchar_t` is a 16-bit integer typedef, but Unicode/wide-character library behavior is not implemented. |
-| POSIX / hosted services | No pthreads, C11 threads, POSIX process APIs, signals, locale, or time library support in the CP/M runtime. |
+| `char` | 8 bits, signed |
+| `short`, `int` | 16 bits |
+| pointers | 16 bits |
+| `long` | 32 bits |
+| `float` | 32 bits |
+| `_Bool` | 8 bits, normalized to `0` or `1` |
+| `double`, `long double` | not distinct types; use `float` |
+| `long long` | not supported |
+| hosted environment | outside the CP/M 2.2 target model |
+| processes, threads, signals, locales | outside the CP/M 2.2 target model |
 
-## Recognized keywords
+## Practical implications of the target model
 
-dcc recognizes the C89 keyword set except for `double`. It also recognizes
-`_Bool` as a first-class scalar type and a small number of later keywords as
-compatibility syntax.
+These follow directly from the table above and are often the source of
+portability surprises when code is moved from a hosted desktop compiler.
 
-| Category | Keywords |
+| Practical rule | What it means |
 | --- | --- |
-| Types | `char`, `short`, `int`, `long`, `signed`, `unsigned`, `float`, `void`, `_Bool` |
-| Storage class | `auto`, `extern`, `register`, `static`, `typedef` |
-| Type qualifiers | `const`, `volatile` |
-| Aggregates / enums | `struct`, `union`, `enum` |
-| Control flow | `if`, `else`, `switch`, `case`, `default`, `for`, `while`, `do`, `break`, `continue`, `goto`, `return` |
-| Operators | `sizeof` |
-| Accepted compatibility keywords | `inline` |
+| `int` is 16-bit | Use `long` (and `%ld`) for values beyond +/-32767. Code that assumes host-sized `int` or 64-bit arithmetic is outside the target model. |
+| `float` is the only floating type | Unsuffixed floating constants are treated as `float`; there is no wider `double` fallback. |
+| `float` precision is ~24 bits | Integers above about +/-16,777,216 are not all exactly representable as `float`; converting large `long` values rounds to nearest representable single precision value. |
+| `%` is integer-only | Use `fmodf` for floating-point remainder; `float % float` is a compile error. |
 
-### Keyword exceptions
+## C89 support
 
-| Keyword | Status |
+| Language feature | Status |
 | --- | --- |
-| `double` / `long double` | Not supported. dcc has 32-bit `float` as its only floating type. |
-| `long long` | Not supported. dcc has no 64-bit integer type. |
-| `restrict` | Not implemented. |
-| `_Complex` | Not implemented. |
-| `_Atomic`, `_Generic`, `_Thread_local` | Not implemented. |
+| Basic scalar types: `char`, `short`, `int`, `long`, `float`, `void` | Supported, with the target sizes above |
+| Signed and unsigned integer types | Supported |
+| Pointers, arrays, pointer arithmetic | Supported |
+| `struct`, `union`, `enum` | Supported |
+| Integer bit-fields | Supported, packed into 16-bit units |
+| Function declarations and prototypes | Supported |
+| Old-style function declarations and definitions | Supported |
+| `typedef` | Supported |
+| Storage classes: `auto`, `extern`, `register`, `static` | Supported; `auto` is a no-op and `register` is only a hint |
+| Type qualifiers: `const`, `volatile` | Accepted for source compatibility; no CP/M/Z80 memory-model semantics are provided |
+| Expressions and usual arithmetic conversions | Supported within the target type model |
+| `if`, `switch`, loops, `break`, `continue`, `goto`, `return` | Supported |
+| `sizeof` | Supported |
+| Preprocessor macros and conditional inclusion | Supported |
+| `__FILE__`, `__LINE__`, `__DATE__`, `__TIME__`, `__STDC__` | Supported |
+| String literals and adjacent string literal concatenation | Supported |
+| Global and automatic initializers | Supported |
 
-## Accepted-but-inert qualifiers
+## Missing from C89
 
-A few keywords are parsed so source compiles, but they do not change code
-generation:
+| Language or environment feature | Status |
+| --- | --- |
+| Distinct `double` and `long double` arithmetic | Not supported |
+| Full hosted C library behavior | Outside the CP/M 2.2 target model |
+| Locale-sensitive execution environment | Outside the CP/M 2.2 target model |
+| Standard signal environment | Outside the CP/M 2.2 target model |
+| Wide-character library behavior | Outside the CP/M 2.2 target model |
+| Read-only storage for `const` objects | Outside the CP/M 2.2 memory model |
+| Strict `volatile` memory/device access semantics | Outside the CP/M 2.2 memory model |
+| Forced register allocation from `register` | Not implemented |
 
-- `const` - honored only for constant folding of const-initialized variables. It
-  does not place data in read-only memory.
-- `volatile` - accepted but otherwise ignored.
-- `register` - accepted as a hint only; it does not force register allocation.
-- `auto` - accepted; since it is already the default storage for locals, it is a
-  no-op.
+## C99 additions
 
-`inline` is accepted as a function specifier. The supported optimization form is
-`static inline`; plain externally linked `inline` is parsed but emitted as a
-normal externally linked function.
+| C99 feature | Status |
+| --- | --- |
+| `_Bool` | Supported as a real scalar type |
+| `stdbool.h` aliases: `bool`, `true`, `false` | Supported |
+| `//` comments | Supported |
+| Declarations in `for` loop initializers | Supported |
+| Mixed declarations and statements in nested blocks | Supported |
+| Unnamed parameters in prototypes | Supported |
+| Array parameters adjusted to pointers | Supported |
+| Function-typed parameters adjusted to pointers | Supported |
+| Variadic macros and `__VA_ARGS__` | Supported |
+| Empty variadic macro arguments | Supported |
+| Designated initializers for struct and array members | Supported |
+| File-scope compound literals in constant initializers | Supported |
+| Address-taking block-scope compound literals | Supported |
+| `inline` keyword | Accepted; plain external `inline` is emitted as an ordinary function |
+| `static inline` simple helper functions | Supported for a useful subset |
+| Trailing comma in enum lists | Accepted as syntax compatibility |
 
-## Supported post-C89 front-end features
+## Missing from C99
 
-These features are supported because they are useful for modern C source and fit
-the Z80/CP/M target model.
+| C99 feature | Status |
+| --- | --- |
+| `long long` and 64-bit integer types | Not supported |
+| Variable-length arrays | Not supported |
+| `restrict` | Not supported |
+| `_Complex` and complex arithmetic | Not supported |
+| Full C99 compound literal value semantics | Partly supported only |
+| Flexible array member initialization | Not supported |
+| C99 external `inline` linkage rules | Not implemented |
+| Full C99 floating-point environment | Outside the CP/M 2.2 target model |
+| Full C99 hosted library | Outside the CP/M 2.2 target model |
 
-### C99 comments and declarations
+## C11 additions
 
-- `//` line comments are accepted everywhere C89 block comments are accepted,
-  including trailing comments on preprocessor directives.
-- `for`-loop init declarations are supported with C99 loop scope.
-- Block-local declarations may appear inside nested `{ ... }` blocks and shadow
-  outer locals for that block.
+| C11 feature | Status |
+| --- | --- |
+| Anonymous `struct` members | Supported |
+| Anonymous `union` members | Supported |
+| Initialization through anonymous aggregate members | Supported |
 
-```c
-int i = 99;
-for (int i = 0; i < 3; i++)
-    use(i);                 /* 0, 1, 2 */
-/* outer i is still 99 here */
-```
+## Missing from C11
 
-### C99/C11 declaration compatibility
+| C11 feature | Status |
+| --- | --- |
+| `_Generic` | Not supported |
+| `_Atomic` | Outside the CP/M 2.2 target model |
+| `_Thread_local` | Outside the CP/M 2.2 target model |
+| C11 threads | Outside the CP/M 2.2 target model |
+| C11 atomics library | Outside the CP/M 2.2 target model |
+| C11 bounds-checking interfaces | Outside the CP/M 2.2 target model |
+| Hosted C11 library additions | Outside the CP/M 2.2 target model |
 
-- `_Bool` is a first-class 1-byte scalar type in dcc's type system, not a macro
-  or library simulation. Assignments, casts, initializers, parameter loads, and
-  return values normalize nonzero values to `1`; include
-  [`stdbool.h`](standard-lib/11-stdbool.md) for the portable aliases `bool`,
-  `true`, and `false`.
-- Forward enum declarations are accepted as `int`-sized enum types, including
-  inside prototypes and function-pointer declarators.
-- C11 anonymous struct and union members are accepted. Members of anonymous
-  aggregates are promoted for ordinary member access, including nested forms,
-  and aggregate initialization through anonymous struct/union members is
-  supported.
-- GNU `__attribute__((...))` annotations are skipped in supported declaration
-  positions.
-- `static inline` functions are supported for small helper functions. dcc can
-  inline simple return-expression bodies, early-return `if` chains lowered to
-  conditional expressions, simple struct/pointer member accessors,
-  statement-context `void` helpers made of one or more expression statements
-  such as `*dst = value`, and scalar
-  `int`/pointer/`long`/`float` expression helpers. `void` helpers inline only
-  when called as a statement; their assignment/store expressions may contain
-  ordinary helper calls, for example `*dst = clamp((long)*dst + v)`. When all
-  call sites inline and the function address is not taken,
-  dcc removes the private out-of-line static function body; if a call cannot be
-  inlined safely, or if the function address is used, it keeps and calls the
-  private static fallback body. Hidden caller-frame temporaries preserve single
-  evaluation for multi-use 16-bit parameters such as `max(i++, j++)`.
-  Multi-use `long`/`float` parameters with side-effecting arguments, inline
-  bodies with local declarations, and unsupported statement bodies fall back to
-  the out-of-line body. Plain `inline`
-  without `static` is accepted for source compatibility but does not yet receive
-  C99 external-inline linkage semantics or call-site inlining.
+## Extensions accepted for compatibility
 
-  ```c
-  static inline int max_int(int a, int b)
-  {
-    return a > b ? a : b;
-  }
+| Extension | Status |
+| --- | --- |
+| `__attribute__((...))` in common declaration positions | Ignored |
 
-  static inline int clamp8(int x)
-  {
-    if (x < 0)
-      return 0;
-    if (x > 255)
-      return 255;
-    return x;
-  }
+## Extensions not supported
 
-  static inline void add_int(int *dst, int v)
-  {
-    *dst = clamp8(*dst + v);
-    dst[1] = clamp8(dst[1] - v);
-  }
-
-  value = max_int(i++, limit);    /* i++ is evaluated once */
-  byte = clamp8(sample + bias);   /* helper body can be removed if all calls inline */
-  add_int(&total, delta);         /* statement-context helper */
-  ```
-
-### C99 aggregate initializers and compound literals
-
-- Struct/union field designators such as `.field = value` are supported in
-  global and automatic aggregate initializers.
-- Array designators such as `[index] = value` are supported, including nested
-  array designators in multidimensional aggregate initializers. GNU range
-  designators such as `[0 ... 3] = value` are not supported.
-- File-scope compound literals used in global constant initializers are
-  supported, including address-taking forms such as `&(struct S){ 1, 2 }`.
-- Address-taking automatic/block-scope compound literals such as
-  `&(struct S){ 1, 2 }` are supported by creating hidden automatic storage for
-  the enclosing function.
-
-### C99 variadic macros
-
-Function-like macros may declare a trailing `...` parameter, and `__VA_ARGS__`
-expands to the matching trailing arguments (with their separating commas) in the
-replacement list.
-
-- All top-level commas after the named parameters are captured as a single
-  `__VA_ARGS__` argument, so the variadic tail keeps its internal commas.
-- `#__VA_ARGS__` stringizes the variadic tail, following the usual `#`
-  stringize rules.
-- Empty variadic invocations are supported: when no trailing arguments are
-  supplied, `__VA_ARGS__` expands to nothing (for example `#define Z(...) 0`
-  called as `Z()`, or `#define Z1(A, ...) A` called as `Z1(1)`).
-
-```c
-#define CALL(F, ...) F(__VA_ARGS__)
-#define ARGS(...)    __VA_ARGS__
-#define STR(...)     #__VA_ARGS__
-
-CALL(two, 3, 4);     /* two(3, 4) */
-foo(ARGS(5));        /* foo(5) */
-puts(STR(1, 2, 3));  /* "1, 2, 3" */
-```
-
-## Unsupported or target-inapplicable features
-
-The table below separates target-model limits from front-end compatibility gaps.
-Target-model limits are part of dcc's CP/M/Z80 contract. Front-end gaps may
-become supportable later, but code should not depend on them today.
-
-| Source level | Feature | Status |
-| --- | --- | --- |
-| C89 | `double` / `long double` | Target-inapplicable. dcc has single-precision `float` as its only floating type. |
-| C89 hosted library | Hosted stdio, locale, signal, time, process, and wide-character runtime behavior | Runtime-inapplicable or absent in DCCRTL. |
-| C99 | `long long` and 64-bit integer typedefs/operations | Target-inapplicable. The Z80 model uses 16-bit `int`/pointers and 32-bit `long`. |
-| C99 | Variable-length arrays | Not implemented. Use `malloc` and an explicit pointer when runtime-sized storage is required. |
-| C99 | `restrict` | Not implemented. |
-| C99 | `_Complex` | Not implemented. |
-| C99 | Block-scope compound literal value/copy forms | Not implemented. Address-taking forms are supported as described above. |
-| C99 | Flexible-array member initialization | Not implemented. |
-| C11 | `_Generic` | Not implemented; some imported tests also require unsupported `long long`. |
-| C11 | `_Atomic`, `_Thread_local`, C11 threads | Not implemented or runtime-inapplicable. |
-| GNU/TCC extensions | Range designators | Not implemented; includes `[first ... last] = value`. |
-| GNU/TCC extensions | Empty structs | Not implemented; empty `struct {}` is an extension. |
-| GNU extensions | Statement expressions and branch prediction builtins | Not implemented; includes `({ ... })` and `__builtin_expect`. |
-
-## Identifier significance
-
-dcc exceeds C89's identifier-significance minimum of 31 characters for internal
-identifiers. Externals are still constrained by the M80/L80 toolchain's symbol
-handling, so keep exported names reasonably distinct near the front of the
-identifier.
+| Extension | Status |
+| --- | --- |
+| GNU range designators, such as `[0 ... 3]` | Not supported |
+| Empty structures | Not supported |
+| Statement expressions, such as `({ ... })` | Not supported |
+| `__builtin_expect` | Not supported |

--- a/docs/docs/en/02-build-and-link.md
+++ b/docs/docs/en/02-build-and-link.md
@@ -2,8 +2,8 @@
 
 This page covers the path from a `.c` file to a runnable CP/M `.COM` program and
 the compiler options that most affect the result. You typically do this in your
-**own project directory** — dcc and ntvcm are general-purpose tools for building
-CP/M / Z80 C apps anywhere, not just inside the dcc repo. As long as the tools
+**own project directory** — DCC C Compiler and ntvcm are general-purpose tools for building
+CP/M / Z80 C apps anywhere, not just inside the DCC C Compiler repo. As long as the tools
 are on your `PATH` (see [Setting up the toolchain](00-setup-toolchain.md)), the
 commands below work from any folder that holds your `.c` sources.
 
@@ -282,8 +282,8 @@ script resolves each tool from your `PATH` or from the `DCC`, `DCCPEEP`, and
     `scripts/ma.ps1` stages `m80.com` and `l80.com` before invoking `ntvcm`.
     For a manual build, keep those `.COM` files and `DCCRTL.MAC` in the working
     directory where you run the pipeline, or adjust the paths to match your
-    layout. Replace `/path/to/dcc` (or `C:\path\to\dcc`) with the dcc repo path
-    that contains the standard headers; if you run from the dcc repo root, the
+    layout. Replace `/path/to/dcc` (or `C:\path\to\dcc`) with the DCC C Compiler repo path
+    that contains the standard headers; if you run from the DCC C Compiler repo root, the
     explicit `-I` is usually unnecessary.
 
     M80 expects CP/M-style CRLF text files; LF-only files can be misread. The Unix
@@ -329,7 +329,7 @@ Common options:
   the bottom of the stack, so growing the stack shrinks the heap and vice versa.
   By default there are no runtime checks that stop the stack from smashing the
   heap.
-- **`-fstack-check`** — opt in to a lightweight stack-overflow guard. dcc emits
+- **`-fstack-check`** — opt in to a lightweight stack-overflow guard. the DCC C Compiler emits
   a short `call __stchk` in each function prologue (after the frame is set up)
   that compares the live stack pointer against the heap ceiling. If the stack
   has grown into the heap, the program prints `?stack overflow` and exits with

--- a/docs/docs/en/03-types-and-conventions.md
+++ b/docs/docs/en/03-types-and-conventions.md
@@ -1,6 +1,6 @@
 # Types and conventions
 
-dcc uses a compact 16-bit model. Knowing the exact widths up front avoids most
+The DCC C Compiler uses a compact 16-bit model. Knowing the exact widths up front avoids most
 overflow and precision surprises.
 
 ## Type sizes
@@ -79,7 +79,7 @@ reference.
 
 ## Floating limits (`float.h`)
 
-[`float.h`](standard-lib/03-float.md) describes dcc's single-precision reality:
+[`float.h`](standard-lib/03-float.md) describes DCC C Compiler's single-precision reality:
 
 | Macro | Value |
 | --- | ---: |
@@ -92,7 +92,7 @@ reference.
 | `FLT_MIN_EXP` / `FLT_MAX_EXP` | -125 / 128 |
 | `FLT_MIN_10_EXP` / `FLT_MAX_10_EXP` | -37 / 38 |
 
-dcc has no `double` or `long double`. The `DBL_*` and `LDBL_*` macros are
+The DCC C Compiler has no `double` or `long double`. The `DBL_*` and `LDBL_*` macros are
 defined as aliases of the `FLT_*` values so source that references those names
 still compiles, but they intentionally reflect the single-precision target:
 
@@ -104,7 +104,7 @@ still compiles, but they intentionally reflect the single-precision target:
 ## Zero-initialized data
 
 In a normal final application build, uninitialized globals and uninitialized
-function-scope `static` objects are backed by dcc's synthetic BSS range. The
+function-scope `static` objects are backed by the DCC C Compiler's synthetic BSS range. The
 compiler emits the range as `__bssb .. __bsse`, and the runtime `start`
 entrypoint zeroes that range before calling `main`. So an uninitialized global
 array is guaranteed to be all zeros, as C89 requires:

--- a/docs/docs/en/04-operators.md
+++ b/docs/docs/en/04-operators.md
@@ -1,6 +1,6 @@
 # Operators
 
-dcc supports the full C89 operator set. The only things to watch are the
+The DCC C Compiler supports the full C89 operator set. The only things to watch are the
 behaviours that follow from the 16-bit `int` / 32-bit `long` model.
 
 ## The full set

--- a/docs/docs/en/11-limitations.md
+++ b/docs/docs/en/11-limitations.md
@@ -5,25 +5,12 @@ and the single source-of-truth runtime.
 
 ## Language and type limits
 
-- **The compiler is C89 plus target-appropriate C99/C11 front-end support, not
-  hosted desktop C.** See [C conformance and target exceptions](01-c-conformance.md)
-  for the supported post-C89 features and the not-yet-implemented front-end
-  compatibility candidates.
-- **No `double` or `long double`.** Only 32-bit `float` exists; all math is
-  single precision. Unsuffixed floating constants are treated as `float`, not as
-  a wider host `double`.
-- **No `long long` or 64-bit integer type.** The largest integer type is 32-bit
-  `long` / `unsigned long`.
-- **`float` precision is ~24 bits.** Integers past about ±16,777,216 are not
-  all representable, so converting a large `long` to
-  `float` — or comparing a `long` against a `float` — rounds to the nearest
-  single. Keep values as integers when you need full 32-bit precision. See
-  [Floating point math](standard-lib/08-math.md).
-- **`%` is integer-only.** Use `fmodf` for a floating-point remainder;
-  `float % float` is a compile error.
-- **`int` is 16-bit.** Use `long` (and `%ld`) when you need more than ±32767.
-  Tests or programs that assume host-sized `int`, ILP32/LP64/LLP64 ABI macros,
-  or 64-bit arithmetic are outside the Z80 target model.
+- **Language support is defined on the conformance page.** See
+  [C conformance and target exceptions](01-c-conformance.md) for the additive
+  C89/C99/C11 feature matrix, target model, and practical numeric implications.
+- **Treat hosted-desktop assumptions as out of scope for this target.** Code
+  written for ILP32/LP64/LLP64 host ABIs, full hosted C libraries, or 64-bit
+  arithmetic should be treated as a porting task.
 
 ## Library limits
 
@@ -35,7 +22,7 @@ and the single source-of-truth runtime.
   field widths.
 - **`%f` needs `-ffloatio`.** Without that flag, float formatting isn't linked.
 - **Wide-character Unicode library behavior is not implemented.** `wchar_t` is a
-  16-bit integer typedef, but dcc does not provide a hosted wide-character
+  16-bit integer typedef, but the DCC C Compiler does not provide a hosted wide-character
   Unicode runtime.
 
 ## Runtime and environment limits
@@ -60,7 +47,7 @@ definition, the link step fails with an unresolved external.
 
 | Function | Notes |
 | --- | --- |
-| `atof` | Implemented and declared as `float atof(const char *)`. C89 `atof` returns `double`, which dcc does not have; this extension returns `float` (IEEE 754 single precision). |
+| `atof` | Implemented and declared as `float atof(const char *)`. C89 `atof` returns `double`, which the DCC C Compiler does not have; this extension returns `float` (IEEE 754 single precision). |
 
 If you need to supply your own implementation of an unimplemented function,
 either `#include` its `.c` from your main file, or compile it separately with

--- a/docs/docs/en/appendix/00-architecture.md
+++ b/docs/docs/en/appendix/00-architecture.md
@@ -1,6 +1,6 @@
 # Appendix: compiler architecture
 
-This appendix describes the dcc toolchain: the compiler `dcc`, the peephole
+This appendix describes the DCC C Compiler toolchain: the compiler `dcc`, the peephole
 optimizer `dccpeep`, the runtime size reducer `dccrtlstrip`, and the Microsoft
 `M80` / `L80` assembler and linker.
 
@@ -41,13 +41,13 @@ flowchart LR
 | Link | `L80` | `.REL` files | `.COM` | Resolve symbols into a CP/M executable |
 
 The `dccpeep` stage is optional (`./scripts/ma.ps1 name -Mode nopeep` skips it
-when run from PowerShell in the dcc checkout). `dccrtlstrip` runs against the
+when run from PowerShell in the DCC C Compiler checkout). `dccrtlstrip` runs against the
 *final* application assembly so it
 sees the real set of runtime symbols the program calls.
 
 ## Compiler Shape
 
-dcc's compiler implementation is AST-driven for function bodies: statements and
+DCC C Compiler's implementation is AST-driven for function bodies: statements and
 expressions are parsed into typed AST nodes, and the AST walker emits the Z80
 assembly. Code generation is a **single AST path** — every expression and
 statement, including local-declaration initializers, is lowered through the AST
@@ -67,7 +67,7 @@ flowchart LR
 
 The phases are:
 
-| Classic phase | Conventional design | dcc's approach |
+| Classic phase | Conventional design | DCC C Compiler approach |
 | --- | --- | --- |
 | Lexical analysis | Separate tokenizer | `next_token` lexer in `dcc_preproc.c` (integrated with the preprocessor) |
 | Parsing | Build an AST | Recursive-descent parse into a function-local AST |
@@ -85,7 +85,7 @@ typed operand is always in hand before any code is emitted.
 
 ## Compiler Features
 
-dcc is intentionally small, but the compiler front end still provides a
+The DCC C Compiler is intentionally small, but the compiler front end still provides a
 user-facing feature set around diagnostics, C89/C99 compatibility extensions,
 target-model checks, and size-oriented dead-code elimination in the generated
 program.
@@ -117,7 +117,7 @@ was detected, while the message text names the exact source-level issue.
 
 ### Dead code detection and elimination
 
-dcc does not run a whole-program control-flow analysis pass, and it does not
+The DCC C Compiler does not run a whole-program control-flow analysis pass, and it does not
 warn about arbitrary unreachable user statements. Instead, dead-code handling is
 pragmatic and size-focused at the points where the toolchain has reliable local
 knowledge:
@@ -141,7 +141,7 @@ This split keeps the compiler simple while still attacking the biggest sources
 of wasted code: unused expression values, local assembly redundancies, unused
 inline bodies, and unreferenced runtime support.
 
-## Inside dcc: module architecture
+## Inside DCC C Compiler: module architecture
 
 The compiler is one binary built from focused modules that all share a single
 umbrella header, `dcc.h`. The parser, AST builder, AST emitter, and low-level
@@ -211,7 +211,7 @@ other — the arrows show the usual direction, not a hard layering rule.
 
 ## Inside dccpeep: a fixpoint peephole optimizer
 
-`dccpeep` is dcc's **machine-dependent optimizer**. It reads the emitted `.MAC`
+`dccpeep` is DCC C Compiler's **machine-dependent optimizer**. It reads the emitted `.MAC`
 as an array of text lines and applies dozens of small *peephole* rewrites —
 each one matches a short local instruction pattern and replaces it with a
 cheaper equivalent (for example folding a redundant store/reload, threading a
@@ -341,7 +341,7 @@ the runtime and rebuilding the docs is all that is needed to refresh them.
 
 ## Architecture summary
 
-- dcc is an **AST-driven** C89 compiler for function bodies, with direct
+- the DCC C Compiler is an **AST-driven** C89 compiler for function bodies, with direct
   lowering from typed AST nodes to Z80/M80 assembly.
 - Typed AST expression nodes drive mixed-width (16/32-bit, pointer, float)
   codegen decisions from the tree being emitted.
@@ -353,5 +353,5 @@ the runtime and rebuilding the docs is all that is needed to refresh them.
   `self`/`marginal` size cost and `dccrtlstrip` can link only the blocks a
   program references.
 - The back half of the pipeline reuses the proven off-the-shelf Microsoft
-  **`M80`/`L80`** assembler and linker, so dcc never has to implement object
+  **`M80`/`L80`** assembler and linker, so DCC C Compiler never has to implement object
   formats or relocation itself.

--- a/docs/docs/en/appendix/01-dccrtlstrip.md
+++ b/docs/docs/en/appendix/01-dccrtlstrip.md
@@ -1,7 +1,7 @@
 # Appendix: runtime optimization
 
 `DCCRTL.MAC` is a single ~19,000-line runtime, but most programs use only a
-fraction of it. The normal dcc build flow runs `dccrtlstrip` before the final
+fraction of it. The normal DCC C Compiler build flow runs `dccrtlstrip` before the final
 L80 link to remove unreferenced routines. This appendix explains how it decides
 what to keep and what each library feature costs in code size once its
 transitive dependencies are linked.
@@ -9,7 +9,7 @@ transitive dependencies are linked.
 ## How `dccrtlstrip` decides what to keep
 
 Most library names in the standard headers are ordinary C identifiers. During
-code generation, dcc maps well-known library calls to short internal assembler
+code generation, DCC C Compiler maps well-known library calls to short internal assembler
 labels (for example `memcpy` becomes `__mcpy`, `strlen` becomes `__slen`). Do
 not write those short names yourself; include the header and call the C
 function. These internal names are what `dccrtlstrip` sees when it scans the

--- a/docs/docs/en/appendix/03-utilities.md
+++ b/docs/docs/en/appendix/03-utilities.md
@@ -1,8 +1,8 @@
 # Utilities
 
-Developer scripts for building and testing dcc programs.
+Developer scripts for building and testing DCC C Compiler programs.
 
-Run these scripts from the dcc checkout or from an installed package. Linux and
+Run these scripts from the DCC C Compiler checkout or from an installed package. Linux and
 macOS packages include a native shell build driver, so normal package users do
 not need PowerShell to build a single app.
 
@@ -69,7 +69,7 @@ dcc-ma cobint --mode fast --build-dir mybuild
 - `DCC_LONGIO` — Set to `1` to pass `-flongio` and keep long integer `printf` runtime support
 - `DCC_ARGS` — Extra whitespace-separated `dcc` options such as `-DNAME=1 -UOLD`
 - `NTVCM_ARGS` — Extra whitespace-separated `ntvcm` options such as `-p -s:4000000`
-- `DCC_HOME` — dcc package/install root; used to find `include/`, `lib/`, and CP/M tools
+- `DCC_HOME` — DCC C Compiler package/install root; used to find `include/`, `lib/`, and CP/M tools
 - `DCC_INCLUDE` — extra include directories, separated by the host path separator
 - `DCC_LIB` — extra runtime/tool asset roots, separated by the host path separator
 - `DCC_RUNTIME` — explicit path to `DCCRTL.MAC`
@@ -82,7 +82,7 @@ Run `dcc-ma -Help` on Windows or `dcc-ma --help` on Linux/macOS for the full opt
 
 Builds and runs the test suite against per-app baselines in `tests/baselines/`.
 It uses `dccmake` for builds and `tests/_test_overrides.json` for test-specific
-runtime arguments, stack sizes, and optional dcc build flags.
+runtime arguments, stack sizes, and optional DCC C Compiler build flags.
 
 Runs in parallel by default:
 
@@ -173,7 +173,7 @@ Compiles each `tests/*.c` program with a native host C compiler, runs the host
 executable, and compares stdout with `tests/baselines/<app>.txt`. This is a
 read-only baseline check: it never rewrites baseline files. It is useful for
 checking that the unit-test sources and expected output still make sense on a
-normal C implementation before comparing them with dcc's CP/M/Z80 output.
+normal C implementation before comparing them with the DCC C Compiler output.
 
 Host compiler selection follows `scripts/build-dcc.ps1`:
 
@@ -223,7 +223,7 @@ compiler can build and link 32-bit executables. The script probes this
 automatically: if the probe succeeds, Linux GCC host validations run with
 `-m32`; if it fails, the script keeps using the normal compiler mode.
 
-This matters because dcc has 16-bit pointers and 32-bit `long`, so a 32-bit host
+This matters because the DCC C Compiler has 16-bit pointers and 32-bit `long`, so a 32-bit host
 build can run a few host-only tests that are skipped on a normal 64-bit Linux
 compiler. Install the normal C build tools plus the 32-bit development libraries
 for your distribution, then rerun the validator.
@@ -275,7 +275,7 @@ one test, keyed by `name`:
 | `args` | string | no | `""` | Command-line arguments passed to the program when run. Multi-token strings are split on whitespace (e.g. `"a bb ccc"`) |
 | `stdin` | string | no | `""` | Text piped to the program's standard input during execution (for keyboard/input-driven tests) |
 | `stack_size` | integer | no | `512` | C stack reserve in bytes, passed to `dcc` as `-stack`. Used by recursive apps that need more headroom |
-| `dcc_args` | string | no | `""` | Extra dcc-style build arguments passed through `dccmake` (for example `-DNAME=1 -UOLD`) |
+| `dcc_args` | string | no | `""` | Extra DCC C Compiler build arguments passed through `dccmake` (for example `-DNAME=1 -UOLD`) |
 | `dcc_floatio` | boolean | no | environment/default | When set, controls `dccmake` `dcc-floatio` and dcc `-ffloatio` for this app |
 | `dcc_longio` | boolean | no | environment/default | When set, controls `dccmake` `dcc-flongio` and dcc `-flongio` for this app |
 | `ignore` | boolean | no | `false` | When `true`, the test is skipped entirely (not built or run) |
@@ -361,7 +361,7 @@ controls which CSV columns are populated: `-Mode full` fills both `peep_*` and
 
 ## Stack Size Measurement (`stacksize.sh` / `stacksize.bat`)
 
-Finds the minimum C stack reserve an app needs under dcc's lightweight
+Finds the minimum C stack reserve an app needs under DCC C Compiler's lightweight
 stack-overflow guard (`-fstack-check`). See the
 [Building and linking](../02-build-and-link.md#measuring-the-stack-an-app-needs)
 section for full documentation, or run `scripts/stacksize.sh --help`.

--- a/docs/docs/en/appendix/04-package-testing.md
+++ b/docs/docs/en/appendix/04-package-testing.md
@@ -1,6 +1,6 @@
 # Package Testing with Linux and Windows VMs
 
-This guide describes how to test the dcc release packages from an x64 host
+This guide describes how to test the DCC C Compiler release packages from an x64 host
 running an Ubuntu-based distribution. Use native x64 VMs for the x64 packages
 and emulated ARM64 VMs for the ARM64 packages.
 
@@ -130,7 +130,7 @@ under `/var/lib/libvirt/images` instead of `$HOME` to avoid permission failures.
 ## Resetting Guests with Snapshots
 
 Install each guest operating system once, apply guest OS updates and basic tools,
-then take a clean snapshot before installing any dcc package. Revert to that
+then take a clean snapshot before installing any DCC C Compiler package. Revert to that
 clean state before each package test so install, upgrade, and uninstall checks
 are repeatable.
 
@@ -139,7 +139,7 @@ shut the guest down and create a snapshot:
 
 ```sh
 virsh shutdown dcc-x64
-virsh snapshot-create-as dcc-x64 clean-install "Clean OS install before dcc package testing" --atomic
+virsh snapshot-create-as dcc-x64 clean-install "Clean OS install before DCC C Compiler package testing" --atomic
 virsh snapshot-list dcc-x64
 ```
 
@@ -147,7 +147,7 @@ For the Windows x64 guest, use the Windows domain name:
 
 ```sh
 virsh shutdown dcc-windows-x64
-virsh snapshot-create-as dcc-windows-x64 clean-install "Clean OS install before dcc package testing" --atomic
+virsh snapshot-create-as dcc-windows-x64 clean-install "Clean OS install before DCC C Compiler package testing" --atomic
 virsh snapshot-list dcc-windows-x64
 ```
 
@@ -208,7 +208,7 @@ qemu-img create -f qcow2 -F qcow2 -b windows-arm64-base.qcow2 windows-arm64.qcow
 ```
 
 For Apple Silicon package tests in Parallels, use Parallels snapshots. Take a
-snapshot after the clean macOS guest setup and before installing the dcc package,
+snapshot after the clean macOS guest setup and before installing the DCC C Compiler package,
 then revert that snapshot before each package test run.
 
 ## x64 Guest VM
@@ -560,7 +560,7 @@ cat > hello.c <<'EOF'
 #include <stdio.h>
 
 int main(void) {
-    printf("hello from dcc package\n");
+    printf("hello from DCC C Compiler package\n");
     return 0;
 }
 EOF
@@ -581,7 +581,7 @@ ntvcm build/HELLO.COM
 Expected output:
 
 ```text
-hello from dcc package
+hello from DCC C Compiler package
 ```
 
 Also verify the package files are where the installer expects them:
@@ -631,7 +631,7 @@ Set-Location "$HOME\dcc-smoke"
 #include <stdio.h>
 
 int main(void) {
-  printf("hello from dcc package\n");
+  printf("hello from DCC C Compiler package\n");
   return 0;
 }
 '@ | Set-Content -LiteralPath .\hello.c -Encoding ascii
@@ -652,7 +652,7 @@ ntvcm .\build\HELLO.COM
 Expected output:
 
 ```text
-hello from dcc package
+hello from DCC C Compiler package
 ```
 
 Also verify the package files are where the installer expects them:

--- a/docs/docs/en/images/dcc-retro-banner.svg
+++ b/docs/docs/en/images/dcc-retro-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 520" role="img" aria-labelledby="title desc">
-  <title id="title">dcc retro CP/M Z80 compiler banner</title>
-  <desc id="desc">A retro terminal-inspired banner showing dcc compiling C89 and C99-style source into CP/M 2.2 Z80 applications.</desc>
+  <title id="title">DCC C Compiler retro CP/M Z80 compiler banner</title>
+  <desc id="desc">A retro terminal-inspired banner showing DCC C Compiler compiling C89 and C99-style source into CP/M 2.2 Z80 applications.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#101820"/>
@@ -69,11 +69,11 @@
   </g>
 
   <g transform="translate(690 74)">
-    <text x="0" y="48" class="sans" font-size="58" font-weight="800" fill="#f2f7f4">dcc</text>
-    <text x="118" y="48" class="sans" font-size="30" font-weight="700" fill="#ffc857">C89 + practical C99 conveniences</text>
-    <text x="0" y="94" class="sans muted" font-size="24">Cross-compile modern-feeling C for CP/M 2.2 on the Z80.</text>
+    <text x="0" y="48" class="sans" font-size="54" font-weight="800" fill="#f2f7f4">DCC C Compiler</text>
+    <text x="0" y="92" class="sans" font-size="30" font-weight="700" fill="#ffc857">C89 + practical C99 conveniences</text>
+    <text x="0" y="132" class="sans muted" font-size="24">Cross-compile modern-feeling C for CP/M 2.2 on the Z80.</text>
 
-    <g transform="translate(0 138)">
+    <g transform="translate(0 162)">
       <rect x="0" y="0" width="185" height="92" rx="12" fill="url(#paper)" stroke="#fff6d6" stroke-width="2"/>
       <text x="24" y="34" class="mono dark" font-size="24">hello.c</text>
       <text x="24" y="64" class="mono dark" font-size="18">C source</text>

--- a/docs/docs/en/index.md
+++ b/docs/docs/en/index.md
@@ -1,21 +1,17 @@
 # Introduction
 
-**dcc** is an open source C compiler for **CP/M 2.2 on the Z80**. It has a C89
+**DCC C Compiler** is an open source C compiler for **CP/M 2.2 on the Z80**. It has a C89
 core plus target-appropriate C99/C11 front-end compatibility. For every source
-file it accepts, dcc translates the `.c` file to M80 assembly; M80 assembles the
+file it accepts, the DCC C Compiler translates the `.c` file to M80 assembly; M80 assembles the
 result, and L80 links it into a CP/M `.COM` program.
 
-dcc runs on Windows, macOS, and Linux, but the programs it builds run under
+The DCC C Compiler runs on Windows, macOS, and Linux, but the programs it builds run under
 CP/M. The [ntvcm](https://github.com/davidly/ntvcm) emulator and other popular
-CP/M Z80 emulators run those programs.
+CP/M Z80 emulators run those programs, as well real Z80 CPM 2.2 and 3.0 systems.
 
-The repository contains tests and build scripts, but dcc is not tied to the
-repository. Once the tools are on your `PATH`, you can build CP/M programs from
-any project directory.
+![DCC C Compiler banner](images/dcc-retro-banner.svg)
 
-![dcc compiler banner](images/dcc-retro-banner.svg)
-
-This manual describes the language accepted by dcc, the runtime library, and the
+This manual describes the language accepted by the DCC C Compiler, the runtime library, and the
 build path from C source to `.COM` file.
 
 - Start with [Setting up the toolchain](00-setup-toolchain.md).
@@ -35,7 +31,7 @@ build path from C source to `.COM` file.
 - Read [Limitations](11-limitations.md) before depending on hosted-C behavior.
 - Try the [worked examples](12-examples.md) when you want complete programs.
 - Use [Agentic skills](00-agent-skills.md) if you want an AI assistant to load the
-  dcc-specific rules while working in another project.
+  DCC C Compiler rules while working in another project.
 
 ## Runtime
 
@@ -59,7 +55,7 @@ the final `.COM` file. The build steps are shown in
 
 ## Performance Snapshot
 
-The chart compares `.COM` programs produced by dcc with CP/M-era and modern
+The chart compares `.COM` programs produced by the DCC C Compiler with CP/M-era and modern
 CP/M-targeting compilers. Times come from `ntvcm -p` cycle counts converted to
 the emulator's `approx ms at 4Mhz` value for Z80-mode runs. Sizes are CP/M file
 sizes rounded to 128-byte records. Lower is better for `ms` and `bytes`.
@@ -68,13 +64,13 @@ sizes rounded to 128-byte records. Lower is better for `ms` and `bytes`.
 
 The benchmark names are the test programs: strings and memory (`tstring`),
 sieve, digits of `e`, allocation (`tm`), tic-tac-toe (`ttt`), hexadecimal pi
-digits (`pihex`), and matrix multiply (`mm`). Rows labelled `xcomp` are dcc
+digits (`pihex`), and matrix multiply (`mm`). Rows labelled `xcomp` are DCC C Compiler
 output before `dccpeep`; rows labelled `dccpeep optimized` are after the
 optimizer pass.
 
 ## Engineering Notes
 
-The dcc C Compiler was engineered agentically, with plenty of human supervision,
+DCC C Compiler was engineered agentically, with plenty of human supervision,
 patience, and love. It is unit tested against baselines grounded in modern desktop
 C compilers and a platform-appropriate subset of the community-driven
 [c-testsuite](https://github.com/c-testsuite/c-testsuite).
@@ -82,4 +78,3 @@ C compilers and a platform-appropriate subset of the community-driven
 ## Contributions and Feedback Welcome
 
 This is an Open Source C compiler, community contributions welcome and/or report issues via the GitHub Issues for this project.
-

--- a/docs/docs/en/standard-lib/02-errno.md
+++ b/docs/docs/en/standard-lib/02-errno.md
@@ -9,11 +9,11 @@ error codes.
 
 ## Runtime model
 
-The dcc runtime is single-threaded, so `errno` is one global `int`. Runtime calls
+The DCC C Compiler runtime is single-threaded, so `errno` is one global `int`. Runtime calls
 set it when they fail; successful calls are not required to clear it. Test the
 function result first, then inspect `errno` only on failure.
 
-C89 requires `EDOM` and `ERANGE`. dcc also defines conventional small-system and
+C89 requires `EDOM` and `ERANGE`. DCC C Compiler also defines conventional small-system and
 POSIX-style file errors used by the CP/M file and directory support.
 
 ## Error checks

--- a/docs/docs/en/standard-lib/03-float.md
+++ b/docs/docs/en/standard-lib/03-float.md
@@ -9,7 +9,7 @@ macros.
 
 ## Runtime model
 
-dcc has only one floating type: 32-bit IEEE-style `float`. There is no distinct
+The DCC C Compiler has only one floating type: 32-bit IEEE-style `float`. There is no distinct
 `double` or `long double` representation. The `DBL_*` and `LDBL_*` macros are
 therefore aliases of the `FLT_*` values so portable source can compile, but they
 intentionally describe the same single-precision target.

--- a/docs/docs/en/standard-lib/04-limits.md
+++ b/docs/docs/en/standard-lib/04-limits.md
@@ -1,6 +1,6 @@
 # Integer limits (`limits.h`)
 
-Include [`limits.h`](04-limits.md) for the integer type ranges used by the dcc
+Include [`limits.h`](04-limits.md) for the integer type ranges used by the DCC C Compiler
 target model.
 
 ## Macros
@@ -9,13 +9,13 @@ target model.
 
 ## Runtime model
 
-dcc uses 8-bit `char`, 16-bit `short` and `int`, and 32-bit `long`. Plain `char`
+The DCC C Compiler uses 8-bit `char`, 16-bit `short` and `int`, and 32-bit `long`. Plain `char`
 is signed, so `CHAR_MIN` and `CHAR_MAX` match `SCHAR_MIN` and `SCHAR_MAX`.
 
 The header also provides `UINT32_MAX` for compatibility with code that uses the
 32-bit unsigned limit name alongside `stdint.h`.
 
-dcc has no locale or multibyte-character support, so locale-related C89 limits
+The DCC C Compiler has no locale or multibyte-character support, so locale-related C89 limits
 such as `MB_LEN_MAX` are not defined.
 
 ## Range choices

--- a/docs/docs/en/standard-lib/05-stdio.md
+++ b/docs/docs/en/standard-lib/05-stdio.md
@@ -159,7 +159,7 @@ For a complete, tested program, see the worked
 [`sscanf` parsing example](../12-examples.md#parsing-input-with-sscanf).
 
 Not supported: floating input (`%f`, `%e`, `%g`), scansets (`%[...]`), `%n`, and
-`%p`. No `dcc` compiler option enables floating-point `scanf` input.
+`%p`. No DCC C Compiler option enables floating-point `scanf` input.
 
 ## Character and string I/O
 

--- a/docs/docs/en/standard-lib/06-stdlib.md
+++ b/docs/docs/en/standard-lib/06-stdlib.md
@@ -14,7 +14,7 @@ control, and pseudo-random numbers.
 
 ## Runtime model
 
-The standard functions in this header are runtime-backed. dcc also declares a
+The standard functions in this header are runtime-backed. DCC C Compiler also declares a
 small set of CP/M and Z80 extensions here (`bdos`, `inp`, and `outp`); those are
 documented with the CP/M services rather than treated as portable C APIs.
 
@@ -66,8 +66,8 @@ long  v = strtol("  -0x1Ag", &end, 0);            /* v = -26, *end = 'g'  */
 unsigned long u = strtoul("4294967295", NULL, 10); /* ULONG_MAX */
 ```
 
-`atof` is available as a dcc extension: it is declared as `float atof(const char *nptr)`
-and returns IEEE 754 single precision. C89 `atof` normally returns `double`, which dcc
+`atof` is available as a DCC C Compiler extension: it is declared as `float atof(const char *nptr)`
+and returns IEEE 754 single precision. C89 `atof` normally returns `double`, which DCC C Compiler
 does not have.
 
 ## Integer arithmetic helpers

--- a/docs/docs/en/standard-lib/08-math.md
+++ b/docs/docs/en/standard-lib/08-math.md
@@ -1,6 +1,6 @@
 # Floating point math (`math.h`)
 
-Include [`math.h`](08-math.md). dcc has only 32-bit `float` (no `double`), so
+Include [`math.h`](08-math.md). the DCC C Compiler has only 32-bit `float` (no `double`), so
 the math entry points are the single-precision `...f` variants. The unsuffixed
 C89 names are provided as macro aliases for convenience.
 
@@ -17,7 +17,7 @@ corresponding single-precision `...f` runtime function.
 
 ## Runtime model
 
-dcc treats `float` as the only floating type. C89 normally declares the
+DCC C Compiler treats `float` as the only floating type. C89 normally declares the
 unsuffixed math names (`sqrt`, `sin`, `pow`, and so on) as `double` functions,
 but this runtime has no `double`, so [`math.h`](08-math.md) maps those names to
 the single-precision `...f` functions with macros.

--- a/docs/docs/en/standard-lib/09-setjmp.md
+++ b/docs/docs/en/standard-lib/09-setjmp.md
@@ -14,7 +14,7 @@ later with a non-local jump.
 ## Runtime model
 
 `jmp_buf` is an 8-byte buffer holding the saved return address, stack pointer,
-IX frame pointer, and padding. dcc declares `setjmp` as an ordinary function;
+IX frame pointer, and padding. DCC C Compiler declares `setjmp` as an ordinary function;
 the runtime entry still reads the caller frame so the call behaves like the C89
 non-local jump primitive.
 

--- a/docs/docs/en/standard-lib/10-stdarg.md
+++ b/docs/docs/en/standard-lib/10-stdarg.md
@@ -12,7 +12,7 @@ parameter list.
 `va_list` is a `char *` cursor walking the caller's stack frame. Start it with
 `va_start`, fetch each argument with `va_arg`, and finish with `va_end`.
 
-dcc uses 16-bit `int` and pointer arguments, 32-bit `long` and `float`
+The DCC C Compiler uses 16-bit `int` and pointer arguments, 32-bit `long` and `float`
 arguments, and no `double`. Pass the exact promoted type to `va_arg`: use `int`
 for narrow integer types after default promotions, `long` for long values, and
 `float` for floating values on this target.

--- a/docs/docs/en/standard-lib/11-stdbool.md
+++ b/docs/docs/en/standard-lib/11-stdbool.md
@@ -9,7 +9,7 @@ portable C programs.
 
 ## Runtime model
 
-dcc recognizes the native C99 `_Bool` keyword as a first-class 1-byte scalar
+DCC C Compiler recognizes the native C99 `_Bool` keyword as a first-class 1-byte scalar
 type. This header only provides the portable names: `bool` is `_Bool`, `true` is
 `1`, and `false` is `0`.
 

--- a/docs/docs/en/standard-lib/12-stddef.md
+++ b/docs/docs/en/standard-lib/12-stddef.md
@@ -9,7 +9,7 @@ headers and portable data-structure code.
 
 ## Runtime model
 
-dcc is a 16-bit target: `size_t`, `ptrdiff_t`, and object pointers are all
+The DCC C Compiler is a 16-bit target: `size_t`, `ptrdiff_t`, and object pointers are all
 16-bit. `wchar_t` is an unsigned 16-bit type and matches the representation used
 for wide string literals.
 

--- a/docs/docs/en/standard-lib/13-stdint.md
+++ b/docs/docs/en/standard-lib/13-stdint.md
@@ -1,7 +1,7 @@
 # Fixed-width integers (`stdint.h`)
 
 Include [`stdint.h`](13-stdint.md) for fixed-width integer typedefs that match
-the dcc target model.
+The DCC C Compiler target model.
 
 ## Types
 
@@ -9,7 +9,7 @@ the dcc target model.
 
 ## Runtime model
 
-dcc is a 16-bit target with 8-bit `char`, 16-bit `int`, and 32-bit `long`.
+The DCC C Compiler is a 16-bit target with 8-bit `char`, 16-bit `int`, and 32-bit `long`.
 `stdint.h` names those exact storage widths without adding new runtime support.
 
 `wchar_t` is also defined here if no earlier header has defined it. The type is
@@ -32,6 +32,6 @@ struct rec {
 
 Use the ordinary C types when you only need the natural target word size.
 
-For formatted output, use the underlying dcc type. For example, `uint32_t` is an
+For formatted output, use the underlying DCC C Compiler type. For example, `uint32_t` is an
 `unsigned long`, so print it with `%lu` or `%lx` and compile with `-fl` /
 `-flongio`.

--- a/docs/docs/en/standard-lib/14-string.md
+++ b/docs/docs/en/standard-lib/14-string.md
@@ -9,7 +9,7 @@ Include [`string.h`](14-string.md) for byte-string and raw memory operations.
 ## Runtime model
 
 The string and memory functions operate on byte strings and raw byte buffers.
-`strcoll` is equivalent to `strcmp`; dcc has no locale model.
+`strcoll` is equivalent to `strcmp`; the DCC C Compiler has no locale model.
 
 ## String and memory operations
 

--- a/docs/docs/mkdocs.yml
+++ b/docs/docs/mkdocs.yml
@@ -1,12 +1,12 @@
-site_name: dcc C89/C99/C11 Reference
+site_name: DCC C Compiler Reference
 site_author: David Lee
 site_description: >-
-  MkDocs documentation for the dcc compiler, runtime, and dccrtlstrip size analysis.
+  MkDocs documentation for DCC C Compiler, its runtime, and dccrtlstrip size analysis.
 
 docs_dir: en
 site_dir: ../site
 
-repo_name: dcc
+repo_name: DCC C Compiler
 repo_url: https://github.com/davidly/dcc
 
 copyright: >-
@@ -55,7 +55,7 @@ plugins:
         - locale: en
           name: English
           default: true
-          site_name: dcc C89/C99/C11 Reference
+          site_name: DCC C Compiler Reference
 
 hooks:
   - hooks/copy_assets.py


### PR DESCRIPTION
… DCC C Compiler as a recursive acronym naming convention