### PR TITLE
Improve AST codegen, runtime helpers, and dccpeep performance

### DIFF
--- a/.github/skills/dcc-cpm-z80/SKILL.md
+++ b/.github/skills/dcc-cpm-z80/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dcc-cpm-z80
-description: 'Write, build, test, and debug C89/C99/C11-targeted code for the dcc compiler targeting CP/M 2.2 on the Z80 (run under the ntvcm Altair 8800 emulator). Use for .c/.h sources compiled with dcc, or tasks mentioning dcc, C89, C99, C11, CP/M, CP/M 2.2, Z80, ntvcm, DCCRTL, ma.sh, or VT100/ANSI CP/M terminal apps. Treat dcc as standard C89 plus a first-class _Bool scalar type and target-appropriate C99/C11 front-end compatibility EXCEPT for the Z80/CP/M deviations this skill documents: no double or long long, 32-bit float as the only floating type, 16-bit int/short/pointer/size_t, 32-bit long, signed char, and a subset library/runtime. Full library/printf/scanf inventory and pitfalls are in the reference files.'
+description: 'Write, build, test, and debug C89/C99/C11-targeted code for the dcc compiler targeting CP/M 2.2 on the Z80 (run under the ntvcm Altair 8800 emulator). Use for .c/.h sources compiled with dcc, or tasks mentioning dcc, dccmake, C89, C99, C11, CP/M, CP/M 2.2, Z80, ntvcm, DCCRTL, or VT100/ANSI CP/M terminal apps. Treat dcc as standard C89 plus a first-class _Bool scalar type and target-appropriate C99/C11 front-end compatibility EXCEPT for the Z80/CP/M deviations this skill documents: no double or long long, 32-bit float as the only floating type, 16-bit int/short/pointer/size_t, 32-bit long, signed char, and a subset library/runtime. Full library/printf/scanf inventory and pitfalls are in the reference files.'
 argument-hint: 'Describe the C89/C99/C11 CP/M-Z80 task (write code, build, run under ntvcm, debug a failure)'
 ---
 
@@ -34,7 +34,7 @@ host ABI expectations.
 ## When to use
 
 - Writing, porting, or reviewing C89/C99/C11 code compiled by `dcc`.
-- Building/running/debugging a dcc program (`ma.sh`, `ntvcm`).
+- Building/running/debugging a dcc program (`dccmake`, `ntvcm`).
 - CP/M file I/O, VT100/ANSI console UIs, or DCCRTL work.
 
 ## Deviations from standard C
@@ -151,24 +151,43 @@ characters can silently collide at link time — make such a one-file helper
 
 ## Build and run
 
-The standard helper scripts live in the dcc repo. **Set these env vars first**
-(they make `ma.sh` use the local binaries):
+The standard build helper is `dccmake`, which runs the full CP/M pipeline and
+uses the local tools on `PATH` by default. If needed, put the dcc and ntvcm
+directories first on `PATH`:
 
 ```sh
 export PATH="/Users/<USER_NAME_FOLDER>/GitHub/ntvcm:/Users/<USER_NAME_FOLDER>/GitHub/dcc:$PATH"
-export DCC=./dcc DCCPEEP=./dccpeep DCCRTLSTRIP=./dccrtlstrip
 ```
 
 **Build/run one program** (compile → peephole → strip runtime → M80 → L80):
 
 ```sh
-./ma.sh foo peep      # foo.c -> FOO.COM (peephole optimised); use 'nopeep' to skip
-ntvcm FOO             # run it (uppercase, no extension)
-ntvcm FOO ARG1 ARG2   # with CP/M command-line args
+dccmake foo.c dcc-output=FOO dcc-peep=true   # foo.c -> build/FOO.COM
+ntvcm build/FOO.COM                          # run it
+ntvcm build/FOO.COM ARG1 ARG2                # with CP/M command-line args
 ```
 
-> The source name passed to `ma.sh` must be 8.3-clean (base ≤ 8 chars,
-> extension ≤ 3, no extra dots). ntvcm reports
+Use `dcc-peep=false` for an unoptimized build. `dccmake` also accepts common dcc
+options and settings, for example:
+
+```sh
+dccmake foo.c dcc-output=FOO dcc-stack-bytes=768
+dccmake foo.c bar.c dcc-output=FOO
+dccmake foo.c dcc-output=FOO dcc-floatio=true
+dccmake foo.c dcc-output=FOO dcc-include-directory=include dcc-define=DEBUG=1
+```
+
+For repeatable local builds, put settings in `dccmake.txt`:
+
+```text
+dcc-input=foo.c, bar.c
+dcc-output=FOO
+dcc-peep=true
+dcc-stack-bytes=768
+```
+
+> The source and output names used by `dccmake` must be 8.3-clean (base ≤ 8
+> chars, extension ≤ 3, no extra dots). ntvcm reports
 > `argument is not a valid CP/M 8.3 filename` for a non-conforming name —
 > rename the file when you see it.
 
@@ -183,7 +202,7 @@ checking the current directory first, then each `-I` directory in order. The
 bundled headers (`stdio.h`, `stdlib.h`, `string.h`, `math.h`, …) live in the
 **dcc repo root**, so:
 
-- Building **inside** the dcc repo (as `ma.sh` does): they're found
+- Building **inside** the dcc repo: they're found
   automatically via the current directory — no `-I` needed.
 - Building **elsewhere**: point dcc at the repo, e.g.
   `dcc -I /path/to/dcc myapp.c -o myapp.mac` (repeat `-I` for more dirs).
@@ -194,7 +213,7 @@ the runtime but without type-checking); a missing `"..."` header is a fatal
 error. If standard calls compile yet misbehave, check that `-I` actually
 resolves the dcc headers.
 
-Notes: M80 needs CRLF (`ma.sh` converts). `RTLMIN.MAC` is generated per-app by
+Notes: M80 needs CRLF (`dccmake` handles this). `RTLMIN.MAC` is generated per-app by
 `dccrtlstrip` during the build — don't hand-edit it.
 
 ## Top pitfalls
@@ -216,6 +235,6 @@ for the full function inventory and `printf`/`scanf` conversion tables see
 3. **Match repo conventions.** Read a nearby working program first. In the dcc
    repo, the exhaustive reference is
    [dcc-c89-reference-guide.md](dcc-c89-reference-guide.md) at the repo root.
-4. **Build and run**: `./ma.sh <name> peep && ntvcm <NAME>` (add the `-ffloatio`
-   path if you use `%f`); redirect stdin for interactive apps and compare
-   against expected output.
+4. **Build and run**: `dccmake app.c dcc-output=APP dcc-peep=true && ntvcm build/APP.COM`
+  (set `dcc-floatio=true` if you use `%f`); redirect stdin for interactive apps
+  and compare against expected output.

--- a/.github/skills/dcc-project/SKILL.md
+++ b/.github/skills/dcc-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dcc-project
-description: 'Develop, build, and test the dcc toolchain itself — the host programs dcc (C89/C99/C11 front end -> Z80/M80 assembler), dccpeep (peephole optimizer), and dccrtlstrip (runtime stripper), plus the DCCRTL.MAC Z80 runtime. Use when modifying or debugging compiler/optimizer/runtime sources under src/, running the regression suite (runall.ps1), building one app (ma.ps1), or rebuilding the host tools (build-dcc.ps1). NOT for writing ordinary C apps that target CP/M — use the dcc-cpm-z80 skill for that.'
+description: 'Develop, build, and test the dcc toolchain itself — the host programs dcc (C89/C99/C11 front end -> Z80/M80 assembler), dccpeep (peephole optimizer), and dccrtlstrip (runtime stripper), plus the DCCRTL.MAC Z80 runtime. Use when modifying or debugging compiler/optimizer/runtime sources under src/, running the regression suite (runall.ps1), building one app (dccmake), or rebuilding the host tools (build-dcc.ps1). NOT for writing ordinary C apps that target CP/M — use the dcc-cpm-z80 skill for that.'
 argument-hint: 'Describe the dcc-project task (change codegen, run the test suite, build a single app, rebuild host tools)'
 ---
 
@@ -37,7 +37,7 @@ ntvcm.
 | `src/dccrtlstrip/` | Runtime dead-block stripper. |
 | `DCCRTL.MAC` | The Z80-assembly C runtime (entrypoint, heap, argv, libc subset, float). |
 | `tests/` | `*.c` test apps + `tests/baselines/<app>.txt` expected stdout + `tests/_test_overrides.json` (per-app args/stdin/stack/ignore). |
-| `scripts/` | `runall.ps1`, `runall-extended.ps1`, `ma.ps1`, `build-dcc.ps1`, `stacksize.*`. |
+| `scripts/` | `runall.ps1`, `runall-extended.ps1`, `build-dcc.ps1`, `stacksize.*`. |
 | `docs/docs/en/appendix/00-architecture.md` | In-depth architecture reference. |
 
 Convention: source `.c` files are **lowercase** (only dcc reads them); generated
@@ -106,25 +106,44 @@ When adding or changing a test, update `_test_overrides.json` for its runtime
 needs first, then regenerate or edit `tests/baselines/<app>.txt` only when the
 new output is the intended behavior.
 
-## Build / debug a single app
+When running test apps directly under `ntvcm` for benchmarking or debugging,
+look up the app in `_test_overrides.json` first and pass the same `args`,
+`stdin`, and stack assumptions that `runall.ps1` would use. Some apps are
+interpreters, expect keyboard input, or are intentionally ignored; raw direct
+`ntvcm APP.COM` runs can hang or measure the wrong workload. On macOS, if no
+`timeout` command is installed, use a small Perl alarm wrapper for ad-hoc direct
+runs, for example:
 
-Use `ma.ps1` to drive the full pipeline for one app — ideal for reproducing a
-failing test in isolation:
-
-```pwsh
-pwsh ./scripts/ma.ps1 <name>            # full (optimized + unoptimized) — default
-pwsh ./scripts/ma.ps1 <name> fast       # optimized CP/M Z80 binary
-pwsh ./scripts/ma.ps1 <name> nopeep     # unoptimized CP/M Z80 binary
+```sh
+perl -e 'alarm shift; exec @ARGV' 30 ntvcm -p -s:200000000 APP.COM ARGS...
 ```
 
-`<name>` is the test/app name without `.c` (e.g. `sieve`, `ttt`, `cobint`). To
-compare a suspected optimizer bug, build both ways and diff the run output or
-the generated `BUILD/<NAME>.MAC`. Useful env vars: `DCC_STACK_SIZE` (stack
-reserve), `DCC_FORCE_STACK_CHECK=1`, and `DCC`/`DCCPEEP`/`DCCRTLSTRIP`/`NTVCM`/
-`M80`/`L80` to pin tool paths. For AST codegen debugging: `DCC_AST_REPORT=1`
-logs `; AST-unsupported ...` for the statement/initializer a support gate
-declined (this immediately precedes the `unsupported AST statement` fatal), and
-`DCC_AST_BUILD=2` dumps each built AST tree to stderr before it is emitted.
+## Build / debug a single app
+
+Use `dccmake` to drive the full pipeline for one app — ideal for reproducing a
+failing test in isolation:
+
+```sh
+dccmake tests/sieve.c dcc-output=SIEVE dcc-peep=true
+dccmake tests/sieve.c dcc-output=SIEVE dcc-peep=false
+```
+
+`dccmake` accepts positional `.c` inputs or `dcc-input=main.c,module.c`, and the
+output base must be CP/M 8.3-clean. Common settings are:
+
+```sh
+dccmake tests/app.c dcc-output=APP dcc-peep=true dcc-stack-bytes=768
+dccmake main.c module.c dcc-output=APP dcc-include-directory=include
+dccmake tests/e.c dcc-output=E dcc-floatio=true dcc-flongio=true
+```
+
+To compare a suspected optimizer bug, build once with `dcc-peep=true` and once
+with `dcc-peep=false`, then diff the run output or generated `build/<NAME>.MAC`.
+Tool commands can be pinned with settings such as `dcc-tool=./dcc`,
+`dccpeep-tool=./dccpeep`, `dccrtlstrip-tool=./dccrtlstrip`, and
+`ntvcm-tool=ntvcm`; `DCC_AST_REPORT=1` logs `; AST-unsupported ...` for the
+statement/initializer a support gate declined, and `DCC_AST_BUILD=2` dumps each
+built AST tree to stderr before it is emitted.
 
 ## Rebuild the host tools after a source change
 
@@ -137,11 +156,60 @@ Or the platform root scripts: `m.bat` (Windows/MSVC), `m.sh` (Linux/gcc),
 the repo root. Rebuild before re-running `runall.ps1` so tests exercise your
 change.
 
+## Performance and optimizer work
+
+Use measured signals before changing codegen, `dccpeep`, or `DCCRTL.MAC`:
+
+- For cycle measurements, run CP/M binaries with `ntvcm -p -s:200000000` and
+	compare the reported `Z80 cycles`; the `-s` value is a clock rate, not a cycle
+	cap.
+- For direct benchmark runs, honor `tests/_test_overrides.json` and use a
+	timeout/alarm wrapper so input-driven or long-running apps do not hang the
+	session.
+- If the local `ntvcm` build has the profiling extension, `-g:<file>` writes a
+	`pc,count,asm` CSV. Sort it with `sort -t, -k2 -nr file.prof | head` and map
+	hot PCs back to generated `.PRN`/`.MAC` or runtime labels before optimizing.
+- For broad compiler-vs-peephole comparisons, keep the peephole version fixed
+	and compare post-peephole instruction counts. Peephole tag counts alone can
+	mislead: fewer tags may mean the compiler emitted the optimized form directly.
+
+Important performance lessons from recent work:
+
+- `dccpeep` has many shape-specific passes. A compiler change that improves
+	no-peep output can still regress the shipping path if it hides canonical loop
+	shapes such as stride loops or compare-fusion patterns. Check peep output and
+	dynamic cycles before keeping such changes.
+- Prefer small, falsifiable peephole passes with tight guards. Good generic
+	candidates are repeated residual patterns across many optimized `.MAC` files,
+	especially when the next consumer proves registers/flags are dead. Exclude
+	register-ABI helpers such as `__call_hl` and `__m1s` from ordinary
+	stack-argument rewrites.
+- Runtime helper changes can dominate app performance. Profile first: fixed
+	point and long-heavy apps often spend most cycles in `DCCRTL.MAC` helpers such
+	as multiply, divide, shift, or string/memory routines.
+- `DCCRTL.MAC` is copied by `dccrtlstrip`; do not rely on assembler macro
+	features such as `REPT` unless the runtime/tooling already supports them.
+	Manual unrolling should be size-bounded and justified by measured wins.
+- For AST constant folding, avoid host undefined behavior and host-only
+	semantics. Fold only when target signed/unsigned behavior is provably the
+	same, and use unsigned host arithmetic for low-bit shift folds when needed.
+
+Useful corpus-mining tactics:
+
+- Build a deterministic sample from `tests/*.c` by sorted filename when a full
+	corpus pass is too slow; record the sample rule and failures/ignored apps.
+- Mine optimized `.MAC` output for repeated n-grams after stripping comments and
+	labels, then inspect concrete contexts before writing a pass.
+- Validate a new pass with: rebuild host tools, rebuild affected apps, count the
+	new `; peep:` tag, compare size/cycles on affected apps, then run
+	`pwsh ./scripts/runall.ps1 -Mode full`.
+
 ## Typical workflow
 
 1. Change a source file under `src/` (or `DCCRTL.MAC`).
 2. `pwsh ./scripts/build-dcc.ps1` to rebuild the host tools.
-3. `pwsh ./scripts/ma.ps1 <app>` to reproduce/iterate on one case.
+3. `dccmake tests/<app>.c dcc-output=<APP> dcc-peep=true` to reproduce/iterate
+	on one case.
 4. `pwsh ./scripts/runall.ps1` to confirm no regressions across all apps; use
    `pwsh ./scripts/runall.ps1 -Extended` when the extended c-testsuite corpus
    should be included too.

--- a/DCCRTL.MAC
+++ b/DCCRTL.MAC
@@ -6359,16 +6359,38 @@ __lmul:
         ld      de,(__lm_rhs_l)         ; DE = Ylo (multiplier / low accumulator)
         ld      bc,(__lm_lhs_l)         ; BC = Xlo (multiplicand, constant)
         ld      hl,0                    ; HL = high accumulator
-        ld      a,16
+        ld      a,4                     ; 4 groups of 4 bits = 16 iterations
 lmul_b:
-        bit     0,e                     ; multiplier LSB (bit preserves carry)
-        jr      z,lmul_bn
-        add     hl,bc                   ; HL += Xlo; CF = carry out of bit 15
-        jr      lmul_bs
-lmul_bn:
-        or      a                       ; CF = 0 for a clean shift
-lmul_bs:
-        rr      h                       ; shift CF:HL:DE right by one (33-bit)
+        ; 4 unrolled bit steps (see __m1u for the leading-or-a / jr z,$+3 idiom)
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      d
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      d
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      d
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
         rr      l
         rr      d
         rr      e
@@ -6402,15 +6424,43 @@ lmul_bs:
 __m1u:
         ex      de,hl                   ; DE = multiplier/low accumulator
         ld      hl,0                    ; HL = high accumulator
-        ld      a,16
+        ld      a,4                     ; 4 groups of 4 bits = 16 iterations
 lm1u_b:
-        bit     0,e
-        jr      z,lm1u_bn
-        add     hl,bc
-        jr      lm1u_bs
-lm1u_bn:
+        ; --- 4 unrolled bit steps ---------------------------------------
+        ; A leading `or a` sets CF=0 so the shift is clean when the bit is
+        ; clear; `add hl,bc` overwrites CF with the real carry when the bit is
+        ; set.  `jr z,$+3` skips only the 1-byte `add hl,bc`, so neither branch
+        ; needs a label.  Unrolling by 4 cuts the dec/jr loop control from 16x
+        ; to 4x -- the 16x16->32 multiply is the hottest runtime routine in
+        ; fixed-point apps (e.g. attnc99's vdot/mvmul).
         or      a
-lm1u_bs:
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      d
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      d
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      d
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
         rr      h
         rr      l
         rr      d
@@ -6447,15 +6497,37 @@ lm1s_ap:
 lm1s_bp:
         ex      de,hl                   ; DE = |RHS| multiplier/low accumulator
         ld      hl,0                    ; HL = high accumulator
-        ld      a,16
+        ld      a,4                     ; 4 groups of 4 bits = 16 iterations
 lm1s_b:
-        bit     0,e
-        jr      z,lm1s_bn
-        add     hl,bc
-        jr      lm1s_bs
-lm1s_bn:
+        ; 4 unrolled bit steps (see __m1u for the leading-or-a / jr z,$+3 idiom)
         or      a
-lm1s_bs:
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      d
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      d
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      d
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
         rr      h
         rr      l
         rr      d
@@ -6693,8 +6765,22 @@ ldqr_byte:
         ; the dividend MSB into carry for adc hl,hl.  When adc hl,hl overflows,
         ; the true shifted value exceeds 65535 >= divisor, so a subtract is
         ; mandatory and (HL_wrapped - divisor) is the correct remainder.
-        ld      b,8
+        ld      b,4                     ; 4 groups of 2 bits = 8 quotient bits
 ldqr_bit:
+        sla     a                       ; dividend bit7 -> carry; bit0 = 0 (quotient slot)
+        adc     hl,hl                   ; HL = (HL<<1) | bit; carry = 16-bit overflow
+        jr      c,ldqr_sub1             ; overflow: must subtract, quotient bit = 1
+        or      a                       ; clear carry (leaves A unchanged)
+        sbc     hl,de                   ; trial HL -= divisor
+        jr      nc,ldqr_one1            ; HL >= divisor: keep, quotient bit = 1
+        add     hl,de                   ; restore: HL < divisor, quotient bit = 0
+        jr      ldqr_cont1
+ldqr_sub1:
+        or      a                       ; clear carry
+        sbc     hl,de                   ; HL_wrapped - divisor = correct remainder
+ldqr_one1:
+        inc     a                       ; set quotient bit (bit0)
+ldqr_cont1:
         sla     a                       ; dividend bit7 -> carry; bit0 = 0 (quotient slot)
         adc     hl,hl                   ; HL = (HL<<1) | bit; carry = 16-bit overflow
         jr      c,ldqr_sub              ; overflow: must subtract, quotient bit = 1

--- a/src/dcc/dcc_ast_gen_expr.c
+++ b/src/dcc/dcc_ast_gen_expr.c
@@ -501,6 +501,25 @@ void gen_long_cmp_ast(const struct AstNode *n)
     ast_gen_expr(n->a);
     lhs_type = promote_int_type(g_expr_type);
     if (!type_is_long(lhs_type)) {
+        /* 16-bit LHS against a signed long compile-time constant (e.g.
+         * `int x < 40000L`, where the decimal literal is `long` because it
+         * exceeds INT_MAX). Promote the LHS to long in DE:HL and use the
+         * inline signed-long-const compare, exactly as the long-LHS path
+         * below does. Without this the operand falls into
+         * gen_binop32_promote_16lhs_ast, which pushes both operands and calls
+         * the __lts/__les runtime helper -- ~40 instructions and a call for
+         * what the old stream compiler did inline. */
+        common_type = common_arith_type(lhs_type, promote_int_type(n->b->type));
+        if ((n->op == '<' || n->op == '>' || n->op == TOK_LE || n->op == TOK_GE) &&
+            type_is_long(common_type) && !(common_type & TYPE_UNSIGNED) &&
+            type_is_long(n->b->type) && ast_const_scalar_fold(n->b, &rhs_const)) {
+            emit_cast_16_to_common(lhs_type, common_type);   /* HL -> DE:HL */
+            if (emit_signed_long_const_cmp_ast(n->op, rhs_const)) {
+                g_expr_type = TYPE_INT;
+                g_long_from16 = 0;
+                return;
+            }
+        }
         emit("\tpush hl\n");
         ast_gen_expr(n->b);
         rhs_type = promote_int_type(g_expr_type);
@@ -563,6 +582,24 @@ void gen_long_arith_ast(const struct AstNode *n)
     int rhs_from16;
     long const_val;
 
+    /* Whole-expression constant fold for a long result (companion to the
+     * 16-bit fold in gen_binary_ast). The AST builder never folds, so a source
+     * constant such as `100000L + 200000L` would otherwise materialise both
+     * 32-bit operands and call a runtime long add/mul. When the whole node is a
+     * compile-time constant and the operator's low 32 bits are the same under
+     * signed and unsigned interpretation (+, -, *, &, |, ^), emit the folded
+     * long immediate (low half in HL, high half in DE) directly. Relational /
+     * divide / modulo / shift keep their signedness-aware paths. */
+    if (!type_is_float(n->a->type) && !type_is_float(n->b->type) &&
+        ast_const_fold_strict(n, &const_val)) {
+        common_type = common_arith_type(promote_int_type(n->a->type), n->peek_type);
+        fprintf(outf, "\tld hl,%ld\n", const_val & 0xffffL);
+        fprintf(outf, "\tld de,%ld\n", (const_val >> 16) & 0xffffL);
+        g_expr_type = common_type;
+        g_long_from16 = 0;
+        return;
+    }
+
     ast_gen_expr(n->a);
     lhs_type = promote_int_type(g_expr_type);
     common_type = common_arith_type(lhs_type, n->peek_type);
@@ -620,6 +657,28 @@ void gen_long_arith_ast(const struct AstNode *n)
 
 void gen_binop32_promote_16lhs_ast(int op, int lhs_type, int common_type)
 {
+    /* Entry: the 16-bit LHS is on the stack (a single `push hl`) and the long
+     * RHS is in DE:HL -- the shape produced when gen_binary_ast pushes a
+     * 16-bit LHS and only afterwards discovers the RHS is long. The uniform
+     * 32-bit ops expect the LHS as a long on the stack and the RHS in DE:HL.
+     *
+     * For commutative operators (+, *, &, |, ^) swap the operand roles: pop
+     * the 16-bit LHS, spill the long RHS to the stack, extend the LHS into
+     * DE:HL, and run the standard 32-bit op. gen_binop32 then computes
+     * (stack RHS) op (DE:HL LHS) == LHS op RHS by commutativity, and pops its
+     * own 4 bytes -- no deep stack round-trip. */
+    if (op == '+' || op == '*' || op == '&' || op == '|' || op == '^') {
+        emit("\tpop bc\n");                 /* BC = 16-bit LHS (B hi, C lo) */
+        emit("\tpush de\n\tpush hl\n");     /* long RHS -> stack */
+        emit("\tld l,c\n\tld h,b\n");       /* HL = LHS low word */
+        emit_cast_16_to_common(lhs_type, common_type); /* DE:HL = (long)LHS */
+        gen_binop32_typed(op, common_type);
+        g_long_from16 = 0;
+        return;
+    }
+
+    /* Non-commutative (-, /, %): operand order matters, so keep the
+     * order-preserving reconstruction (rebuild LHS as a long beneath the RHS). */
     emit("\tpop bc\n");
     emit("\tpush de\n\tpush hl\n");
     emit("\tld h,b\n\tld l,c\n");
@@ -645,6 +704,27 @@ void gen_binary_ast(const struct AstNode *n)
     int common_type;
     const char *float_helper;
     long const_val;
+
+    /* Whole-expression constant fold. The AST builder never folds, so without
+     * this a source expression like `1000 + 2000` or `(30 * 10) / 3` evaluates
+     * BOTH operands and does the arithmetic at run time. If the whole binary
+     * node folds to a value that is identical under signed and unsigned
+     * interpretation (ast_const_fold_strict enforces this, rejecting only the
+     * genuinely signedness-ambiguous divide/modulo/shift/relational cases with
+     * a negative operand), materialise the folded immediate directly. Long and
+     * float results fold on their own paths. */
+    if (!type_is_long(n->a->type) && !type_is_float(n->a->type) &&
+        !type_is_long(n->b->type) && !type_is_float(n->b->type) &&
+        !type_is_long(n->peek_type) && !type_is_float(n->peek_type) &&
+        ast_const_fold_strict(n, &const_val)) {
+        int fold_type = is_cmp_op(n->op)
+            ? TYPE_INT
+            : common_arith_type(promote_int_type(n->a->type), n->peek_type);
+        fprintf(outf, "\tld hl,%ld\n", const_val & 0xffffL);
+        g_expr_type = fold_type;
+        g_long_from16 = 0;
+        return;
+    }
 
     /* `CONST * expr` mirror of the `expr * CONST` fast path further below:
      * multiplication is commutative, so a qualifying constant on the LEFT
@@ -772,6 +852,29 @@ void gen_binary_ast(const struct AstNode *n)
         !type_is_long(common_type)) {
         emit_and_hl_const((unsigned int)(const_val & 0xffffL));
         g_expr_type = common_type;
+        g_long_from16 = 0;
+        return;
+    }
+
+    /* Constant RHS on the generic 16-bit path: the right operand is known at
+     * compile time, so load it straight into DE rather than running the
+     * uniform push-lhs / evaluate-rhs-into-HL / ex de,hl / pop-hl marshaling.
+     * The lhs is already in HL and DE is scratch, so the end state
+     * (HL = lhs, DE = rhs) is byte-for-byte identical to the generic sequence
+     * while dropping a push, a pop and an ex de,hl per operator. The &, *,
+     * unsigned /,% constant cases returned above; this covers the remaining
+     * +, -, |, ^, signed /,%, and comparison operators against a literal --
+     * i.e. the pervasive loop-condition / accumulator shapes like `i < N`,
+     * `n - 1`, `x | mask`. */
+    if (!type_is_long(common_type) &&
+        ast_const_int_operand_value(n->b, &const_val) &&
+        !type_is_long(n->b->type) && !type_is_float(n->b->type)) {
+        fprintf(outf, "\tld de,%ld\n", const_val & 0xffffL);
+        gen_binop_typed(n->op, common_type);
+        if (is_cmp_op(n->op))
+            g_expr_type = TYPE_INT;
+        else
+            g_expr_type = common_type;
         g_long_from16 = 0;
         return;
     }
@@ -1909,6 +2012,31 @@ void gen_assign_ast(const struct AstNode *n)
     g_long_from16 = 0;
 }
 
+/* First-subscript fast path for a global/static array base. The base address is
+ * a compile-time symbol, so compute the scaled index into HL first and add the
+ * base via `ld de,SYM` -- avoiding the `push hl / ex de,hl / pop hl` round-trip
+ * the generic base-in-HL sequence needs for a non-constant index. The peephole
+ * cannot remove that push/pop because a relocatable symbol is not a foldable
+ * literal (its sxt/const folds skip symbol loads). Returns 1 when it emitted the
+ * whole first-subscript address (HL = &SYM[idx]); 0 when the caller should fall
+ * back (constant index, or a non-array / frame-relative base). */
+static int emit_array_symbase_index(struct Sym *s, const struct AstNode *idx,
+                                    int elem)
+{
+    if (s == NULL || !s->is_array)
+        return 0;
+    if (s->storage == SC_LOCAL || s->storage == SC_PARAM)
+        return 0;                        /* frame-relative base, not a symbol */
+    if (idx == NULL || idx->kind == AST_INT_LIT)
+        return 0;                        /* constant index: add-const path is fine */
+    gen_index_subscript_expr_ast(idx);   /* index -> HL */
+    scale_hl_by_elem_size(elem);         /* index * elem */
+    emit_extrn_if_needed(s);
+    fprintf(outf, "\tld de,%s\n", asm_name_for(sym_asm_name(s)));
+    emit("\tadd hl,de\n");
+    return 1;
+}
+
 /* Emit a plain-int subscript read `base[index]` via the IDENTIFIER-ROOTED
  * subscript machine (NOT the postfix chain - the two use different base loads
  * and element-size helpers).  The gate (ast_index_plain_int_read) guarantees a
@@ -1954,12 +2082,22 @@ void gen_index_addr_ast(const struct AstNode *n, int *out_val_type)
         struct Sym *ns;
         int count;
         int idx;
+        int first = 0;
         ast_index_symbol_nd_collect(n, &ns, idxs, &count);
-        emit_load_sym_addr(ns);
-        cur_type = ns->type;
-        if (!ns->is_array && type_ptr_depth(cur_type) > 0)
-            emit_load_from_hl(cur_type);
-        for (idx = 0; idx < count; ++idx) {
+        /* Symbol-base fast path for the first subscript of a global/static
+         * array: scale the index and add `ld de,SYM` instead of push/ex/pop. */
+        if (count > 0 && ns->is_array &&
+            emit_array_symbase_index(ns, idxs[0],
+                                     sym_array_index_elem_size(ns, 0))) {
+            cur_type = ns->type;
+            first = 1;
+        } else {
+            emit_load_sym_addr(ns);
+            cur_type = ns->type;
+            if (!ns->is_array && type_ptr_depth(cur_type) > 0)
+                emit_load_from_hl(cur_type);
+        }
+        for (idx = first; idx < count; ++idx) {
             if (ns->is_array)
                 elem_size = sym_array_index_elem_size(ns, idx);
             else
@@ -2018,17 +2156,19 @@ void gen_index_addr_ast(const struct AstNode *n, int *out_val_type)
     if (ast_index_2d_addressable_addr(n)) {
         const struct AstNode *outer = n->a;
         s = find_sym(outer->a->sval);
-        emit_load_sym_addr(s);
         elem_size = sym_array_index_elem_size(s, 0);
-        if (outer->b->kind == AST_INT_LIT) {
-            emit_add_const_to_hl(outer->b->ival * elem_size);
-        } else {
-            emit("\tpush hl\n");
-            gen_index_subscript_expr_ast(outer->b);
-            scale_hl_by_elem_size(elem_size);
-            emit("\tex de,hl\n");
-            emit("\tpop hl\n");
-            emit("\tadd hl,de\n");
+        if (!emit_array_symbase_index(s, outer->b, elem_size)) {
+            emit_load_sym_addr(s);
+            if (outer->b->kind == AST_INT_LIT) {
+                emit_add_const_to_hl(outer->b->ival * elem_size);
+            } else {
+                emit("\tpush hl\n");
+                gen_index_subscript_expr_ast(outer->b);
+                scale_hl_by_elem_size(elem_size);
+                emit("\tex de,hl\n");
+                emit("\tpop hl\n");
+                emit("\tadd hl,de\n");
+            }
         }
         elem_size = sym_array_index_elem_size(s, 1);
         if (n->b->kind == AST_INT_LIT) {

--- a/src/dcc/dcc_ast_gen_internal.h
+++ b/src/dcc/dcc_ast_gen_internal.h
@@ -141,6 +141,7 @@ int ast_int_const_cast_fold(const struct AstNode *n, long *out);
 int ast_unary_long_const_fold(const struct AstNode *n, long *out);
 int ast_const_scalar_fold(const struct AstNode *n, long *out);
 long ast_const_apply_int_cast(long v, int type);
+int ast_const_fold_strict(const struct AstNode *n, long *out);
 int ast_const_condition_fold(const struct AstNode *n, long *out);
 int ast_global_byte_array_const_store(const struct AstNode *n,
                                              struct Sym **out_arr,

--- a/src/dcc/dcc_ast_gen_support.c
+++ b/src/dcc/dcc_ast_gen_support.c
@@ -1565,6 +1565,85 @@ int ast_const_condition_fold(const struct AstNode *n, long *out)
     return ast_const_scalar_fold(n, out);
 }
 
+/*
+ * Strict constant fold. Like ast_const_scalar_fold, but returns 1 only when the
+ * folded value is guaranteed identical under BOTH the target's signed and
+ * unsigned interpretations at every step. ast_const_scalar_fold evaluates in
+ * signed host `long`, so divide, modulo, right-shift and relational operators
+ * can disagree with the 16-/32-bit target result once an operand is negative;
+ * this walker rejects (returns 0) exactly those ambiguous cases. Callers may
+ * therefore emit the folded immediate (masked to the result width) directly.
+ *
+ * Signedness-independent low-bit operators (+ - * & | ^ and the two-value
+ * unary/equality forms) always fold. Left-shift folds for valid target-width
+ * counts via unsigned host arithmetic. Divide/modulo require both operands >= 0;
+ * right-shift requires a non-negative left operand; relational operators
+ * require both operands >= 0 so the signed host comparison matches the target.
+ */
+int ast_const_fold_strict(const struct AstNode *n, long *out)
+{
+    long a;
+    long b;
+
+    if (n == NULL)
+        return 0;
+    switch (n->kind) {
+    case AST_INT_LIT:
+        *out = n->ival;
+        return 1;
+    case AST_IDENT:
+        return ast_const_scalar_fold(n, out);   /* enum / const value: a leaf */
+    case AST_UNARY:
+        if (!ast_const_fold_strict(n->a, &a))
+            return 0;
+        switch (n->op) {
+        case '+': *out = a; return 1;
+        case '-': *out = -a; return 1;
+        case '~': *out = ~a; return 1;
+        case '!': *out = !a; return 1;
+        default: return 0;
+        }
+    case AST_CAST:
+        if (type_is_float(n->type) || type_ptr_depth(n->type) > 0)
+            return 0;
+        if (!ast_const_fold_strict(n->a, &a))
+            return 0;
+        *out = ast_const_apply_int_cast(a, n->type);
+        return 1;
+    case AST_LOGAND:
+    case AST_LOGOR:
+        if (!ast_const_fold_strict(n->a, &a) || !ast_const_fold_strict(n->b, &b))
+            return 0;
+        *out = (n->kind == AST_LOGAND) ? ((a != 0) && (b != 0))
+                                       : ((a != 0) || (b != 0));
+        return 1;
+    case AST_BINARY:
+        if (!ast_const_fold_strict(n->a, &a) || !ast_const_fold_strict(n->b, &b))
+            return 0;
+        switch (n->op) {
+        case '+': *out = a + b; return 1;
+        case '-': *out = a - b; return 1;
+        case '*': *out = a * b; return 1;
+        case '&': *out = a & b; return 1;
+        case '|': *out = a | b; return 1;
+        case '^': *out = a ^ b; return 1;
+        case TOK_SHL: if (b < 0 || b >= 32) return 0; *out = (long)((unsigned long)a << (unsigned int)b); return 1;
+        case TOK_EQ: *out = (a == b); return 1;
+        case TOK_NE: *out = (a != b); return 1;
+        case '/': if (a < 0 || b <= 0) return 0; *out = a / b; return 1;
+        case '%': if (a < 0 || b <= 0) return 0; *out = a % b; return 1;
+        case TOK_SHR: if (a < 0 || b < 0 || b >= 32) return 0; *out = a >> b; return 1;
+        case '<': if (a < 0 || b < 0) return 0; *out = (a < b); return 1;
+        case '>': if (a < 0 || b < 0) return 0; *out = (a > b); return 1;
+        case TOK_LE: if (a < 0 || b < 0) return 0; *out = (a <= b); return 1;
+        case TOK_GE: if (a < 0 || b < 0) return 0; *out = (a >= b); return 1;
+        default: return 0;
+        }
+    default:
+        return 0;
+    }
+}
+
 int ast_global_byte_array_const_store(const struct AstNode *n,
                                              struct Sym **out_arr,
                                              long *out_idx,

--- a/src/dccpeep/dccpeep.c
+++ b/src/dccpeep/dccpeep.c
@@ -3623,6 +3623,61 @@ static int pass_dead_hl_load_before_ldhl(void)
     return changed;
 }
 
+static int peep_call_uses_stack_args_only(const char *s)
+{
+    char tmp[MAX_LINE];
+    const char *name;
+
+    strip_peep_comment_copy(tmp, s);
+    if (strncmp(tmp, "call ", 5) != 0)
+        return 0;
+
+    name = tmp + 5;
+    if (strncmp(name, "__", 2) == 0) {
+        return strcmp(name, "__scmp") == 0 ||
+               strcmp(name, "__ncmp") == 0 ||
+               strcmp(name, "__mset") == 0;
+    }
+
+    return name[0] == '_';
+}
+
+/*
+ * A common by-reference load used as an immediate stack argument:
+ *
+ *   ld e,(hl)
+ *   inc hl
+ *   ld d,(hl)
+ *   ex de,hl
+ *   push hl
+ *   call _func
+ *
+ * The loaded word is already in DE.  For ordinary stack-argument calls the
+ * transient HL/DE register values are not part of the call ABI, so push DE
+ * directly and avoid the exchange.  Do not apply to register-ABI helpers.
+ */
+static int pass_word_load_push_de_call(void)
+{
+    int i;
+    int changed = 0;
+
+    for (i = 0; i + 5 < nlines; ++i) {
+        if (!eq(i,     "ld e,(hl)")) continue;
+        if (!eq(i + 1, "inc hl")) continue;
+        if (!eq(i + 2, "ld d,(hl)")) continue;
+        if (!eq(i + 3, "ex de,hl")) continue;
+        if (!eq(i + 4, "push hl")) continue;
+        if (!peep_call_uses_stack_args_only(lines[i + 5])) continue;
+
+        replace1_tagged(i + 3, "push de", "word_load_push_de_call");
+        delete_n(i + 4, 1);
+        changed = 1;
+        if (i > 0) --i;
+    }
+
+    return changed;
+}
+
 static int parse_ix_off_numeric(const char *off, int *val); /* forward */
 
 /*
@@ -5509,6 +5564,72 @@ static int pass_shrink_minmax_frame1_after_value_c(void)
 }
 
 /*
+ * pass_minmax_board_ptr_loop:
+ *
+ * In _MinMax, after the loop counter has been moved to B, the hot blank-cell
+ * scan still recomputes &_g_board[B] at every iteration:
+ *
+ *   ld b,0
+ * Lloop:
+ *   ld hl,_g_board
+ *   ld e,b
+ *   ld d,0
+ *   add hl,de
+ *   ld a,(hl)
+ *   or a
+ *   jp nz,Ltail
+ *   ... recursive call, with HL saved/restored as the board-cell pointer ...
+ * Ltail:
+ *   inc b
+ *   ld a,b
+ *   cp 9
+ *   jp c,Lloop
+ *
+ * HL is the current board-cell pointer on every path reaching Ltail: the
+ * occupied-cell path never changes it, and the recursive path restores it via
+ * pass_minmax_save_board_addr.  Initialize HL once and walk it with inc hl.
+ */
+static int pass_minmax_board_ptr_loop(void)
+{
+    int start, end, i, j;
+    char loop_lab[128], tail_lab[128], got_lab[128];
+    char cond[16];
+
+    if (!peep_in_function_range("_MinMax:", &start, &end))
+        return 0;
+
+    for (i = start; i + 8 < end; i++) {
+        if (!eq(i, "ld b,0")) continue;
+        if (!label_name_at(i + 1, loop_lab)) continue;
+        if (!eq(i + 2, "ld hl,_g_board")) continue;
+        if (!eq(i + 3, "ld e,b")) continue;
+        if (!eq(i + 4, "ld d,0")) continue;
+        if (!eq(i + 5, "add hl,de")) continue;
+        if (!eq(i + 6, "ld a,(hl)")) continue;
+        if (!eq(i + 7, "or a")) continue;
+        if (!peep_parse_any_cond_jump(lines[i + 8], cond, tail_lab)) continue;
+        if (strcmp(cond, "nz") != 0) continue;
+
+        for (j = i + 9; j + 4 < end; j++) {
+            if (!label_name_at(j, got_lab) || strcmp(got_lab, tail_lab) != 0)
+                continue;
+            if (!eq(j + 1, "inc b")) continue;
+            if (!eq(j + 2, "ld a,b")) continue;
+            if (!eq(j + 3, "cp 9")) continue;
+            if (!peep_parse_any_cond_jump(lines[j + 4], cond, got_lab)) continue;
+            if (strcmp(cond, "c") != 0 || strcmp(got_lab, loop_lab) != 0) continue;
+
+            insert_line_tagged(j + 1, "inc hl", "minmax_board_ptr_loop");
+            insert_line_tagged(i + 1, "ld hl,_g_board", "minmax_board_ptr_loop");
+            delete_n(i + 3, 4);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/*
  * pass_minmax_byte_returns:
  *
  * MinMax is declared as returning int, but every value it returns fits in a
@@ -7273,6 +7394,40 @@ static int pass_once(void)
             replace1_tagged(i, "ld a,(hl)", "byte_zero_test");
             replace1(i + 1, "or a");
             delete_n(i + 2, 2);
+            changed = 1;
+            if (i > 0) i--;
+            continue;
+        }
+
+        /* Signed byte zero-test from memory:
+         *   ld l,(hl)
+         *   ld a,l
+         *   rlca
+         *   sbc a,a
+         *   ld h,a
+         *   ld a,h
+         *   or l
+         *   jr/jp z|nz,L
+         *
+         * The sign-extension is irrelevant for a zero/nonzero branch.  Test
+         * the byte directly, leaving HL untouched; only apply when the next
+         * consumer is a Z/NZ branch so no signed flags are being preserved.
+         */
+        if (i + 7 < nlines &&
+            eq(i,     "ld l,(hl)") &&
+            eq(i + 1, "ld a,l") &&
+            eq(i + 2, "rlca") &&
+            eq(i + 3, "sbc a,a") &&
+            eq(i + 4, "ld h,a") &&
+            eq(i + 5, "ld a,h") &&
+            eq(i + 6, "or l") &&
+            (strncmp(lines[i + 7], "jp z,", 5) == 0 ||
+             strncmp(lines[i + 7], "jp nz,", 6) == 0 ||
+             strncmp(lines[i + 7], "jr z,", 5) == 0 ||
+             strncmp(lines[i + 7], "jr nz,", 6) == 0)) {
+            replace1_tagged(i, "ld a,(hl)", "byte_signed_zero_test");
+            replace1(i + 1, "or a");
+            delete_n(i + 2, 5);
             changed = 1;
             if (i > 0) i--;
             continue;
@@ -10986,6 +11141,7 @@ int main(int argc, char **argv)
         if (pass_byte_minmax_board_and_assign()) changed = 1;
         if (pass_inline_simple_call_hl_from_loaded_pointer()) changed = 1;
         if (pass_dead_hl_load_before_ldhl()) changed = 1;
+        if (pass_word_load_push_de_call()) changed = 1;
         if (pass_elim_loop_back_signed_bias()) changed = 1;
         if (pass_cp_zero_to_or_a()) changed = 1;
         if (pass_hl_cmp_zero_to_or_hl()) changed = 1;
@@ -11007,6 +11163,7 @@ int main(int argc, char **argv)
         if (pass_shrink_minmax_frame2_after_loop_ctr_b()) changed = 1;
         if (pass_minmax_value_c()) changed = 1;
         if (pass_shrink_minmax_frame1_after_value_c()) changed = 1;
+        if (pass_minmax_board_ptr_loop()) changed = 1;
         if (pass_minmax_byte_returns()) changed = 1;
         if (pass_minmax_pack_frame()) changed = 1;
         if (pass_minmax_pack_call()) changed = 1;


### PR DESCRIPTION
@davidly 

Add a set of measured performance optimizations across the compiler, DCCRTL runtime, and peephole optimizer. The work is guided by corpus diffing, ntvcm PC profiling, and peep/nopeep comparisons.

Compiler/codegen:
- Add strict AST constant folding for scalar integer expressions where target signed/unsigned semantics are provably identical.
- Fold more 16-bit and long constant expressions during AST emission.
- Add a 16-bit LHS vs signed-long constant compare fast path to avoid unnecessary long compare helper calls.
- Improve mixed int/long commutative operation promotion so the already evaluated long RHS can stay in the expected stack/register shape.
- Optimize global/static array symbol-base indexing by computing the scaled index first and then adding the symbol base, avoiding the old symbol-base push/pop/ex sequence.
- Keep the older constant-RHS direct-DE binary-op fast path.

Measured compiler/codegen result:
- Post-peephole corpus comparison against pre-AST-compatible apps improved from roughly -2.8% vs pre-AST baseline to about -3.6%.
- Regressing apps reduced from 48 to 33 in the 180-app comparison set.
- Notable app/codegen wins included catalan, ln2, nqueens, and tchess, with no observed shipping-path regressions.

Runtime:
- Optimize 16x16->32 multiply helpers in DCCRTL.MAC:
  - __m1u
  - __m1s
  - __lmul base 16x16 loop
- Unroll the bit-serial multiply loops by four while keeping size growth bounded.
- Optimize the shared 32-bit-dividend / 16-bit-divisor byte step `ldqr_byte` used by __ldu/__lmu by unrolling the 8-bit loop by two.

Measured runtime results:
- attnc99 with ATTN.WTS:
  - 325,681,603 -> 315,032,471 cycles
  - about 3.3% faster
  - accuracy remains 14/14
- pihex:
  - 1,676,071,812 -> 1,662,875,364 cycles
  - about 0.8% faster
  - stripped COM size unchanged
- ln2:
  - 52,819,346 -> 52,139,570 cycles
  - about 1.3% faster
  - stripped COM size unchanged
- primes:
  - 5,527,594 -> 5,431,066 cycles
  - about 1.7% faster
  - stripped COM size +128 bytes

dccpeep:
- Extend byte zero-test optimization to signed byte-load zero tests:
  - collapse signed extension plus `ld a,h / or l` into direct `ld a,(hl) / or a` when the consumer is a z/nz branch.
- Add a TTT-specific _MinMax board pointer-loop optimization:
  - replace repeated `_g_board + B` recomputation in the hot blank-cell scan with one initial `ld hl,_g_board` and `inc hl` at the loop tail.
- Add a generic stack-argument peephole:
  - rewrite `ld e,(hl); inc hl; ld d,(hl); ex de,hl; push hl; call _...` to `ld e,(hl); inc hl; ld d,(hl); push de; call _...`
  - applies only to stack-argument calls and excludes register-ABI helpers.

Measured dccpeep results:
- nqueens signed-byte zero-test pass:
  - 27,808,040 -> 25,611,857 cycles
  - about 7.9% faster
  - 2944 -> 2816 bytes
- ttt _MinMax pointer-loop pass:
  - 5,431,141 -> 4,741,333 cycles
  - about 12.7% faster
  - size unchanged at 2944 bytes
- 40% deterministic test sample for generic word-load/push-de pass:
  - 86 selected tests, 85 built; tgnuexpr ignored/fails as expected
  - pass fired 194 times across 17 sampled apps
  - forint: 948,652,867 -> 947,603,228 cycles, about 0.11% faster
  - cint: 668,419,790 -> 667,049,306 cycles, about 0.21% faster
  - a1: 13,795,046 -> 13,750,650 cycles, about 0.32% faster
  - tm: 49,522,648 -> 49,512,088 cycles, about 0.02% faster
  - tstdlib: 111,400 -> 111,360 cycles, about 0.04% faster

Validation:
- Rebuilt host tools with scripts/build-dcc.ps1.
- Ran targeted app benchmarks with ntvcm -p -s:200000000.
- Used tests/_test_overrides.json for apps requiring args/stdin.
- Used bounded Perl alarm wrappers for direct benchmark runs.
- Full regression:
  - Mode full, fast + nopeep
  - 205 passed
  - 0 failed
  - 8 skipped