### PR TITLE
Implement C99 array parameter qualifiers

### DIFF
--- a/docs/docs/en/01-c-conformance.md
+++ b/docs/docs/en/01-c-conformance.md
@@ -82,7 +82,9 @@ portability surprises when code is moved from a hosted desktop compiler.
 | Mixed declarations and statements in nested blocks | Supported |
 | Unnamed parameters in prototypes | Supported |
 | Array parameters adjusted to pointers | Supported |
+| C99 array parameter qualifiers: `int a[const 5]`, `int a[static 5]`, `int a[volatile 5]`, `int a[restrict 5]`, `int a[const *]` | Accepted as syntax compatibility; array parameters still decay to pointers |
 | Function-typed parameters adjusted to pointers | Supported |
+| `restrict` qualifier | Accepted as source compatibility; no alias-analysis optimization semantics are provided |
 | Variadic macros and `__VA_ARGS__` | Supported |
 | Empty variadic macro arguments | Supported |
 | Designated initializers for struct and array members | Supported |
@@ -98,7 +100,6 @@ portability surprises when code is moved from a hosted desktop compiler.
 | --- | --- |
 | `long long` and 64-bit integer types | Not supported |
 | Variable-length arrays | Not supported |
-| `restrict` | Not supported |
 | `_Complex` and complex arithmetic | Not supported |
 | Full C99 compound literal value semantics | Partly supported only |
 | Flexible array member initialization | Not supported |

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -595,6 +595,8 @@ void expect(int k);
 /* ---- types ---- */
 int find_enum_const(const char *name);
 int is_type_qualifier_token(int k);
+int is_restrict_qualifier_token(void);
+void skip_parameter_array_qualifiers(void);
 void skip_type_qualifiers(void);
 int type_struct_id(int type);
 int make_struct_type(int id);

--- a/src/dcc/dcc_expr.c
+++ b/src/dcc/dcc_expr.c
@@ -232,6 +232,7 @@ int parse_funcptr_declarator(int *ptype, char *name, int namesz)
         tok = save_tok;
         return 0;
     }
+    skip_type_qualifiers();
 
     if (tok.kind == '(') {
         int depth;
@@ -461,6 +462,7 @@ int parse_abstract_funcptr_declarator(int *ptype)
         expect(')');
     } else if (tok.kind == '[') {
         while (accept('[')) {
+            skip_parameter_array_qualifiers();
             if (tok.kind != ']')
                 (void)parse_const_int_expr();
             expect(']');

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -385,9 +385,17 @@ void skip_prototype_array_suffixes(int *ptype)
     memset(g_ptr_array_dims, 0, sizeof(g_ptr_array_dims));
 
     while (accept('[')) {
+        skip_parameter_array_qualifiers();
+
         if (tok.kind == ']') {
             n = 0;
             next_token();
+        } else if (tok.kind == '*') {
+            /* C99 `[*]` unspecified-size VLA marker in a prototype; it decays
+             * to a pointer exactly like `[]`. */
+            next_token();
+            expect(']');
+            n = 0;
         } else {
             n = parse_const_int_expr();
             expect(']');

--- a/src/dcc/dcc_types.c
+++ b/src/dcc/dcc_types.c
@@ -26,9 +26,24 @@ int is_type_qualifier_token(int k)
     return k == TOK_CONST || k == TOK_VOLATILE;
 }
 
+int is_restrict_qualifier_token(void)
+{
+    /* `restrict` is a C99/C11 keyword but dcc's lexer has no dedicated token
+     * for it, so it arrives as an identifier.  Treat it as a type qualifier
+     * everywhere ordinary const/volatile qualifiers are accepted. */
+    return tok.kind == TOK_ID && !strcmp(tok.text, "restrict");
+}
+
+void skip_parameter_array_qualifiers(void)
+{
+    while (is_type_qualifier_token(tok.kind) || is_restrict_qualifier_token() ||
+           tok.kind == TOK_STATIC)
+        next_token();
+}
+
 void skip_type_qualifiers(void)
 {
-    while (is_type_qualifier_token(tok.kind))
+    while (is_type_qualifier_token(tok.kind) || is_restrict_qualifier_token())
         next_token();
 }
 

--- a/tests/_extended_test_overrides.json
+++ b/tests/_extended_test_overrides.json
@@ -11,7 +11,6 @@
     { "name": "00123", "ignore": true, "reason": "Uses double; dcc has float as its only floating type." },
     { "name": "00128", "ignore": true, "reason": "Uses long long and unsigned long long assignment cases; dcc has no 64-bit integer type." },
     { "name": "00135", "ignore": true, "reason": "Uses long long and unsigned long long constants; dcc has no 64-bit integer type." },
-    { "name": "00162", "ignore": true, "reason": "Uses C99 array parameter qualifiers (const/static/volatile/restrict inside []), not implemented by dcc." },
     { "name": "00166", "ignore": true, "reason": "Assumes host-sized int can hold large octal/hex constants; dcc int is 16-bit on Z80." },
     { "name": "00168", "ignore": true, "reason": "Expected output assumes int can hold 10!; dcc int is 16-bit on Z80 and wraps by the target data model." },
     { "name": "00174", "ignore": true, "reason": "Expected output depends on C double precision for unsuffixed floating constants; dcc has float as its only floating type." },

--- a/tests/baselines/tc99apar.txt
+++ b/tests/baselines/tc99apar.txt
@@ -1,0 +1,1 @@
+tc99apar completed with great success

--- a/tests/tc99apar.c
+++ b/tests/tc99apar.c
@@ -1,0 +1,165 @@
+/* tc99apar.c - C99 array parameter qualifier regressions. */
+#include <stdio.h>
+
+static int failures;
+
+static void check(const char *name, int got, int want)
+{
+    if (got != want) {
+        printf("FAIL %s got=%d want=%d\n", name, got, want);
+        failures++;
+    }
+}
+
+void proto_named_const(int x[const 5]);
+void proto_named_static(int x[static 5]);
+void proto_named_volatile(int x[volatile 5]);
+void proto_named_restrict(int x[restrict 5]);
+void proto_named_mix1(int x[static restrict const 5]);
+void proto_named_mix2(int x[const volatile restrict static 5]);
+void proto_unnamed_const(int [const 5]);
+void proto_unnamed_static(int [static 5]);
+void proto_unnamed_volatile(int [volatile 5]);
+void proto_unnamed_restrict(int [restrict 5]);
+void proto_unspecified_vla(int [const *]);
+void proto_callback(int (*cb)(int [const 3]), int data[static 3]);
+void proto_paren_ptr_const(int (* const));
+void proto_paren_ptr_volatile(int (* volatile));
+void proto_paren_ptr_restrict(int (* restrict));
+
+static int sum_const(int a[const 5])
+{
+    int i;
+    int sum;
+
+    sum = 0;
+    for (i = 0; i < 5; i++)
+        sum += a[i];
+    return sum;
+}
+
+static int sum_static(int a[static 5])
+{
+    return a[0] + a[1] + a[2] + a[3] + a[4];
+}
+
+static int sum_volatile(int a[volatile 5])
+{
+    int i;
+    int sum;
+
+    sum = 0;
+    for (i = 0; i < 5; i++)
+        sum += a[i];
+    return sum;
+}
+
+static int sum_restrict(int a[restrict 5])
+{
+    return a[4] - a[0];
+}
+
+static int sum_static_restrict_const(int a[static restrict const 5])
+{
+    return a[0] * 100 + a[4];
+}
+
+static int sum_qual_static(int a[const volatile restrict static 5])
+{
+    return a[1] * 10 + a[3];
+}
+
+static int set_static_restrict(int a[static restrict 5])
+{
+    a[3] = a[0] + a[4];
+    return a[3];
+}
+
+static int sum_matrix(int a[static restrict 2][3])
+{
+    return a[0][0] + a[0][2] + a[1][0] + a[1][2];
+}
+
+static int mutate_matrix(int a[const 2][3])
+{
+    a[1][1] = a[0][1] + a[1][2];
+    return a[1][1];
+}
+
+static int read_paren_const(int (* const p))
+{
+    return *p;
+}
+
+static int read_paren_volatile(int (* volatile p))
+{
+    return *p;
+}
+
+static int read_paren_restrict(int (* restrict p))
+{
+    return *p;
+}
+
+static int cb_sum3(int a[const 3])
+{
+    return a[0] + a[1] + a[2];
+}
+
+static int call_callback(int (*cb)(int [const 3]), int data[static 3])
+{
+    return cb(data);
+}
+
+int main(void)
+{
+    int a[5];
+    int b[5];
+    int m[2][3];
+    int c[3];
+    int x;
+
+    a[0] = 1;
+    a[1] = 2;
+    a[2] = 3;
+    a[3] = 4;
+    a[4] = 5;
+
+    b[0] = 10;
+    b[1] = 20;
+    b[2] = 30;
+    b[3] = 40;
+    b[4] = 50;
+
+    m[0][0] = 1;
+    m[0][1] = 2;
+    m[0][2] = 3;
+    m[1][0] = 4;
+    m[1][1] = 5;
+    m[1][2] = 6;
+
+    c[0] = 7;
+    c[1] = 8;
+    c[2] = 9;
+    x = 1234;
+
+    check("const bound", sum_const(a), 15);
+    check("static bound", sum_static(a), 15);
+    check("volatile bound", sum_volatile(a), 15);
+    check("restrict bound", sum_restrict(a), 4);
+    check("static restrict const", sum_static_restrict_const(a), 105);
+    check("qual static", sum_qual_static(a), 24);
+    check("write through static restrict", set_static_restrict(b), 60);
+    check("write result", b[3], 60);
+    check("matrix stride", sum_matrix(m), 14);
+    check("matrix mutate", mutate_matrix(m), 8);
+    check("matrix result", m[1][1], 8);
+    check("paren ptr const", read_paren_const(&x), 1234);
+    check("paren ptr volatile", read_paren_volatile(&x), 1234);
+    check("paren ptr restrict", read_paren_restrict(&x), 1234);
+    check("callback array qualifier", call_callback(cb_sum3, c), 24);
+
+    if (failures == 0)
+        printf("tc99apar completed with great success\n");
+    return failures;
+}


### PR DESCRIPTION
@davidly 

Accept C99 qualifiers in function parameter array declarators, including const, volatile, static, restrict, and prototype [*] forms. Treat restrict as a source-compatibility qualifier without adding alias-analysis semantics, and allow qualified parenthesized pointer declarators used by parameter forms.

Enable extended test 00162 and add tc99apar to cover named and unnamed array parameters, mixed qualifier ordering, multidimensional array decay, callback parameters, and parenthesized pointer qualifiers. Update the conformance docs now that this feature is implemented.