### PR TITLE
Optimize __fmul mantissa multiply in DCCRTL

### DIFF
--- a/DCCRTL.MAC
+++ b/DCCRTL.MAC
@@ -6477,6 +6477,77 @@ lm1u_b:
         ex      de,hl
         ret
 
+; __m8u: unsigned 8x16 -> 24-bit multiply, register ABI.
+;   Entry: A  = 8-bit multiplier, BC = 16-bit multiplicand.
+;   Exit:  HL:E = 24-bit product (HL = high 16 bits, E = low 8 bits).
+;   Used by __fmul for the three mantissa partial products that have an
+;   8-bit operand (Ahi*Blo, Alo*Bhi, Ahi*Bhi).  Only 8 multiplier bits are
+;   processed, so it runs half the iterations of the full 16x16 __m1u while
+;   using the identical or-a / bit-test / jr z,$+3 / add / shift idiom, here
+;   shifting the 3-byte accumulator HL:E right one bit per step.
+        public  __m8u
+__m8u:
+        ld      e,a                     ; E = multiplier / low accumulator
+        ld      hl,0                    ; HL = high accumulator
+        ; --- 8 unrolled bit steps (see __m1u for the idiom) --------------
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      e
+        or      a
+        bit     0,e
+        jr      z,$+3
+        add     hl,bc
+        rr      h
+        rr      l
+        rr      e
+        ret
+
 ; __m1s: signed 16x16 -> 32 multiply, register ABI.
 ;   Entry: BC = LHS low word, HL = RHS low word.  Exit: DE:HL = product.
         public  __m1s
@@ -11919,64 +11990,58 @@ __fmul:
         ld      (FP4),a
         ld      (FP5),a         ; accumulator = high16(Alo*Blo), high half 0
 
-        ; term = Ahi*Blo -> DE:HL (32-bit); add in full at offset 0.
-        ld      a,(AM2)
-        ld      c,a
-        ld      b,0             ; BC = 0:Ahi
+        ; term = Ahi*Blo (8x16) -> HL:E (24-bit); add in full at offset 0.
         ld      a,(BM0)
-        ld      l,a
+        ld      c,a
         ld      a,(BM1)
-        ld      h,a             ; HL = Blo
-        call    __m1u           ; DE:HL = Ahi*Blo
+        ld      b,a             ; BC = Blo (multiplicand)
+        ld      a,(AM2)         ; A = Ahi (8-bit multiplier)
+        call    __m8u           ; HL:E = Ahi*Blo (byte0=E,byte1=L,byte2=H)
         ld      a,(FP2)
-        add     a,l
+        add     a,e
         ld      (FP2),a
         ld      a,(FP3)
-        adc     a,h
+        adc     a,l
         ld      (FP3),a
         ld      a,(FP4)
-        adc     a,e
+        adc     a,h
         ld      (FP4),a
         ld      a,(FP5)
-        adc     a,d
+        adc     a,0
         ld      (FP5),a
 
-        ; term = Alo*Bhi -> DE:HL (32-bit); add in full at offset 0.
+        ; term = Alo*Bhi (16x8) -> HL:E (24-bit); add in full at offset 0.
         ld      a,(AM0)
         ld      c,a
         ld      a,(AM1)
-        ld      b,a             ; BC = Alo
-        ld      a,(BM2)
-        ld      l,a
-        ld      h,0             ; HL = 0:Bhi
-        call    __m1u           ; DE:HL = Alo*Bhi
+        ld      b,a             ; BC = Alo (multiplicand)
+        ld      a,(BM2)         ; A = Bhi (8-bit multiplier)
+        call    __m8u           ; HL:E = Alo*Bhi (byte0=E,byte1=L,byte2=H)
         ld      a,(FP2)
-        add     a,l
+        add     a,e
         ld      (FP2),a
         ld      a,(FP3)
-        adc     a,h
+        adc     a,l
         ld      (FP3),a
         ld      a,(FP4)
-        adc     a,e
+        adc     a,h
         ld      (FP4),a
         ld      a,(FP5)
-        adc     a,d
+        adc     a,0
         ld      (FP5),a
 
-        ; term = Ahi*Bhi; both operands < 256 so the product fits entirely
-        ; in HL (DE = 0 always) - add just the two bytes at offset 16.
-        ld      a,(AM2)
-        ld      c,a
-        ld      b,0             ; BC = 0:Ahi
+        ; term = Ahi*Bhi (8x8) -> HL:E; product fits in 16 bits (H = 0), so
+        ; the value is L:E - add its two bytes at offset 16.
         ld      a,(BM2)
-        ld      l,a
-        ld      h,0             ; HL = 0:Bhi
-        call    __m1u           ; HL = Ahi*Bhi (DE = 0)
+        ld      c,a
+        ld      b,0             ; BC = 0:Bhi (multiplicand)
+        ld      a,(AM2)         ; A = Ahi (8-bit multiplier)
+        call    __m8u           ; HL:E = Ahi*Bhi (H = 0, value = L:E)
         ld      a,(FP4)
-        add     a,l
+        add     a,e
         ld      (FP4),a
         ld      a,(FP5)
-        adc     a,h
+        adc     a,l
         ld      (FP5),a
 
         ; If product bit 47 is set, mantissa = product >> 24 and exponent++.
@@ -11997,28 +12062,32 @@ __fmul:
         jp      FMPAK
 
 FMNOC:
-        ; Mantissa = product >> 23.  Shift P5:P4:P3:P2 right by 7.
-        ld      b,7
-FMSR7:
+        ; Mantissa = (product >> 23) & 0FFFFFFh.  The 32-bit value in
+        ; FP5:FP4:FP3:FP2 (FP5 = high byte) has to be shifted right by 7 and
+        ; its low 24 bits kept.  Bit 7 of FP5 is guaranteed clear here (the
+        ; product-bit-47 case branched to the >>24 path above), so V < 2^31
+        ; and therefore
+        ;   (V >> 7) & 0FFFFFFh  ==  bytes 1..3 of (V << 1).
+        ; That collapses the old seven-step right shift (28 shift ops) into a
+        ; single 32-bit left shift plus three byte stores.
+        ld      a,(FP2)
+        ld      l,a
+        ld      a,(FP3)
+        ld      h,a
+        ld      a,(FP4)
+        ld      e,a
         ld      a,(FP5)
-        srl     a
-        ld      (FP5),a
-        ld      a,(FP4)
-        rr      a
-        ld      (FP4),a
-        ld      a,(FP3)
-        rr      a
-        ld      (FP3),a
-        ld      a,(FP2)
-        rr      a
-        ld      (FP2),a
-        djnz    FMSR7
-        ld      a,(FP2)
-        ld      (AM0),a
-        ld      a,(FP3)
-        ld      (AM1),a
-        ld      a,(FP4)
-        ld      (AM2),a
+        ld      d,a             ; DEHL = FP5:FP4:FP3:FP2 (D = high byte)
+        sla     l
+        rl      h
+        rl      e
+        rl      d               ; DEHL <<= 1 (discarded top bit was 0)
+        ld      a,h
+        ld      (AM0),a         ; AM0 = byte 1 of (V<<1) = low byte of V>>7
+        ld      a,e
+        ld      (AM1),a         ; AM1 = byte 2
+        ld      a,d
+        ld      (AM2),a         ; AM2 = byte 3
 
 FMPAK:
         call    FPA


### PR DESCRIPTION
@davidly - I'll let you **review** and **commit** as I saw you had done some perf optimisations in this area too.

#Headline

Overall improvement:

  33,437,400 fewer cycles
  24.73% faster than baseline

Rewrite the hot mantissa multiply path in the runtime floating-point multiply helper to avoid unnecessary full-width work.

The previous __fmul implementation had already moved away from the old 24-iteration memory-heavy bit-serial multiply, but it still used four 16x16 unsigned multiplies for the partial products. Three of those partial products have an 8-bit operand:

  Ahi * Blo
  Alo * Bhi
  Ahi * Bhi

Add a new runtime helper, __m8u, for unsigned 8x16 -> 24-bit multiplication. It uses the same register-resident shift/add idiom as __m1u, but only performs 8 unrolled bit steps instead of 16. Rewire __fmul to use __m8u for those three partial products while keeping __m1u for the true 16x16 Alo * Blo term.

Also simplify the no-carry normalization path in __fmul. When product bit 47 is clear, the code previously shifted FP5:FP4:FP3:FP2 right by 7 using repeated memory loads/stores. Since bit 7 of FP5 is known clear on that path, the low 24 bits of V >> 7 are equal to bytes 1..3 of V << 1. Use that identity to replace the seven-step right shift with a single register left shift and three stores.

This preserves the existing runtime floating-point semantics: subnormal/exponent-zero values are still treated as zero, overflow still goes through the existing infinity path, and mantissa extraction remains truncating rather than rounded. The change only reduces the amount of integer work needed to compute the same top 32 bits of the 24x24 mantissa product.

Performance impact on tests/mm.c at 200 MHz with peephole optimization and float I/O enabled:

  Baseline runtime:              135,232,878 cycles
  Register normalization shift:  124,915,578 cycles
  FMNOC left-shift identity:     122,574,678 cycles
  __m8u partial products:        101,795,478 cycles

Overall improvement:

  33,437,400 fewer cycles
  24.73% faster than baseline

The final MM.COM size increased from 6656 bytes to 6784 bytes, a 128-byte increase, because __m8u is pulled in when __fmul is linked. The helper is only retained by dccrtlstrip when referenced.

Validation performed:

  - Built tests/mm.c with: dccmake tests/mm.c dcc-output=MM dcc-peep=true dcc-floatio=true

  - Ran MM.COM under ntvcm profiling/baseline timing at 200 MHz.

  - Verified output remained exact: summ is : 465880.000000 summ is : 465880.000000

  - Profiled the optimized binary with ntvcm -g to confirm the remaining hot path shifted as expected.

  - Model-checked the new __m8u algorithm for all 256 * 65536 possible 8x16 input combinations against exact integer multiplication.

  - Checked the FMNOC shift identity under the branch invariant that FP5 bit 7 is clear.

  - Verified M80 syntax compatibility for adc a,0; that form already exists elsewhere in DCCRTL.MAC.

  - Verified dccrtlstrip keeps __m8u in RTLMIN.MAC when __fmul references it.

  - Ran the full regression suite: pwsh ./scripts/runall.ps1 -Mode full

    Result: Total apps: 219 Passed: 211 Failed: 0 Skipped: 8