### PR TITLE
Add atof and fix cooked stdin reads for scanf

### DIFF
--- a/tests/baselines/tscanin.txt
+++ b/tests/baselines/tscanin.txt
@@ -1,0 +1,3 @@
+42 -7 scanf n=2 sum=35
+hello
+scanf n=1 word=hello

--- a/tests/tscanin.c
+++ b/tests/tscanin.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+
+/* Console-stdin regression for the runtime _read -> __gchr path used by the
+ * scanf family and getchar.  That path once used a nonblocking BDOS call that
+ * reported phantom bytes instead of waiting for input; drive it here with
+ * piped stdin so the blocking behavior stays covered.
+ *
+ * The blocking console read (BDOS function 1) echoes each consumed character,
+ * so the expected output interleaves the echoed input with the program's own
+ * lines.  The input is newline-terminated and fully consumed so the test never
+ * reads past end-of-input. */
+int main(void)
+{
+    int a = 0, b = 0, n;
+    char word[16];
+
+    n = scanf("%d %d", &a, &b);
+    printf("scanf n=%d sum=%d\n", n, a + b);
+
+    n = scanf("%15s", word);
+    printf("scanf n=%d word=%s\n", n, word);
+
+    return 0;
+}


### PR DESCRIPTION
@davidly 

Implement runtime support for atof as a DCC-specific float-returning variant. DCC has no distinct double type, so stdlib.h now declares atof/strtod as returning float while preserving the familiar conversion surface for C89 source.

The new atof parser handles leading whitespace, optional sign, decimal input with optional exponent, and case-insensitive nan/inf/infinity spellings. It returns signed infinity on overflow and signed zero on underflow. The parser also preserves strtod endptr behavior for malformed exponents and no-conversion inputs, bounds huge exponent parsing, and caps accumulated significant digits so long mantissas do not overflow before exponent scaling.

Fix console stdin reads used underneath scanf/getchar. The previous _read stdin path used CP/M BDOS function 6 with E=0xff, which is nonblocking; when no key was ready, BDOS returned 0 and _read still reported one byte read. That allowed scanf to consume phantom NUL bytes instead of waiting for input.

Route stdin _read through the cooked console input helper instead. The helper now uses BDOS function 1 for blocking CP/M console input, flushes pending output before waiting, honors stdin pushback, translates CR to '\n', and treats Ctrl-Z as CP/M text EOF. _read maps that EOF sentinel to a zero-byte read so fgetc/getchar report EOF through the existing caller logic. Raw keyboard APIs (kbhit/getch) remain on the BDOS 11/6 path.

This follows the behavior expected from period CP/M C libraries. Historic compilers such as BDS C, Aztec C, Hi-Tech C, and DeSmet C generally treated scanf/getchar as cooked console input: blocking, echoed by BDOS or the console driver, line-ending translated, and Ctrl-Z recognized as text EOF. Raw no-echo keyboard input was exposed through separate APIs, matching this runtime's kbhit/getch split.

Add regression coverage for both runtime updates. tatof now compares atof/strtod behavior against a Clang oracle, including malformed exponents, no-conversion endptr cases, special values, overflow, underflow, and long mantissas. tscanin exercises scanf through the cooked CP/M console stdin path with an authored target baseline, since CP/M console input echoes and cannot be byte-matched to hosted Clang stdin.

Update the standard-library and conformance documentation to describe atof as a float-returning DCC extension, and remove stale limitations text that implied atof was not implemented.

Validated with:
- tatof Clang/dcc/baseline comparison
- tscanin stdin regression
- dccrtlstrip kept atof when used and stripped it when unused
- MkDocs strict build
- full regression: 221 apps, 213 passed, 0 failed, 8 skipped