### PR TITLE
feat(dcc): implement C99 variable-length array (VLA) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # macOS Finder / Desktop Services metadata
+*.dSYM/
 .DS_Store
 .DS_Store?
 .AppleDouble

--- a/docs/docs/en/01-c-conformance.md
+++ b/docs/docs/en/01-c-conformance.md
@@ -84,6 +84,7 @@ portability surprises when code is moved from a hosted desktop compiler.
 | Unnamed parameters in prototypes | Supported |
 | Array parameters adjusted to pointers | Supported |
 | C99 array parameter qualifiers: `int a[const 5]`, `int a[static 5]`, `int a[volatile 5]`, `int a[restrict 5]`, `int a[const *]` | Accepted as syntax compatibility; array parameters still decay to pointers |
+| Variable-length arrays (local) | Supported when the only variable dimension is the outermost, with constant inner dimensions (`a[n]`, `a[n][3]`). The array decays to a pointer to stack-allocated storage and is reclaimed at ordinary block-scope exit, including loop iterations, `break`, and `continue` |
 | Function-typed parameters adjusted to pointers | Supported |
 | `restrict` qualifier | Accepted as source compatibility; no alias-analysis optimization semantics are provided |
 | Variadic macros and `__VA_ARGS__` | Supported |
@@ -100,13 +101,19 @@ portability surprises when code is moved from a hosted desktop compiler.
 | C99 feature | Status |
 | --- | --- |
 | `long long` and 64-bit integer types | Not supported |
-| Variable-length arrays | Not supported |
+| Variable-length arrays with a variable inner dimension (`a[n][m]`) | Not supported; the runtime row stride is not modelled (variable outermost dimension is supported, above) |
+| `goto`/`case` entry into VLA scopes | Not supported; jumps that could bypass VLA allocation are rejected |
+| `sizeof` applied to a whole VLA | Not supported; the size is not a compile-time constant, so it is rejected rather than silently miscomputed (`sizeof vla[i]` on a constant-size subobject is fine) |
 | `_Complex` and complex arithmetic | Not supported |
 | Full C99 compound literal value semantics | Partly supported only |
 | Flexible array member initialization | Not supported |
 | C99 external `inline` linkage rules | Not implemented |
 | Full C99 floating-point environment | Outside the CP/M 2.2 target model |
 | Full C99 hosted library | Outside the CP/M 2.2 target model |
+
+For the practical VLA guide — supported forms, block-scope reclamation in loops
+and recursion, and worked examples — see
+[Variable-length arrays](03-types-and-conventions.md#variable-length-arrays).
 
 ## C11 additions
 

--- a/docs/docs/en/03-types-and-conventions.md
+++ b/docs/docs/en/03-types-and-conventions.md
@@ -134,3 +134,72 @@ int main(void)
   storage for their uninitialized globals so multiple modules do not overlap the
   final application's synthetic BSS range. The zeroing guarantee above describes
   the normal final app translation unit linked with `DCCRTL.MAC` / `RTLMIN.MAC`.
+
+## Variable-length arrays
+
+DCC supports a practical subset of C99 variable-length arrays (VLAs):
+a **local array whose size is a run-time value**, allocated on the stack when
+its declaration is reached and released when its block is left. This is meant
+for runtime-sized scratch storage on the 16-bit Z80/CP/M target, not full
+variably-modified type support. The [C conformance](01-c-conformance.md) page
+lists the summary status; this section is the practical guide.
+
+### Supported
+
+A local array whose **outermost** dimension is a run-time expression, with any
+constant inner dimensions:
+
+```c
+void f(int n)
+{
+    int  a[n];          /* 1-D VLA                        */
+    char buf[n + 1];    /* any run-time size expression   */
+    int  grid[n][3];    /* variable outer, constant inner */
+    /* a, buf, grid decay to pointers exactly like fixed arrays */
+}
+```
+
+- The size expression is evaluated **once**, when the declaration is reached.
+- In multidimensional arrays such as `grid[n][3]`, the inner dimensions must be
+  compile-time constants because they define the row stride used for indexing.
+- **Block-scope reclamation.** The array lives until its enclosing block exits,
+  so a VLA inside a loop does not grow the stack — each iteration reuses the
+  same storage:
+
+  ```c
+  for (i = 0; i < iters; i++) {
+      int scratch[n];     /* allocated and freed every iteration */
+      /* ... use scratch ... */
+  }                       /* stack pointer restored here each pass */
+  ```
+
+- Reclamation happens on **every** normal exit from the block: fall-through,
+  `break`, `continue`, `return`, and a `goto` that leaves the scope.
+- Recursion works: each call frame gets its own VLA and releases it on return.
+- With `-fstack-check`, the run-time allocation is bounds-checked, so an
+  oversized VLA aborts gracefully instead of colliding with the heap. VLAs draw
+  from the same `-stack` reserve as ordinary locals; size it for the deepest
+  expected allocation (see [Building and linking](02-build-and-link.md)).
+
+### Not supported (diagnosed, never miscompiled)
+
+- A **variable inner** dimension, e.g. `int a[n][m]`, because the row stride
+  would be a run-time value. Only the outermost dimension may vary. Use an
+  explicit index computation or `malloc` for a fully dynamic 2-D array.
+- `sizeof` applied to a **whole** VLA. Its size would be a run-time value; DCC
+  rejects it rather than silently return the wrong value. `sizeof a[0]` and
+  other constant-size subobjects are fine. Track the length yourself:
+
+  ```c
+  int a[n];
+  /* sizeof a;              -> error: not a compile-time size */
+  /* memset(a, 0, sizeof a) -> would be wrong; use the count: */
+  memset(a, 0, (size_t)n * sizeof a[0]);   /* sizeof a[0] is a constant */
+  ```
+
+- Jumping **into** a VLA's scope with `goto`, `case`, or `default` (which would
+  bypass the allocation) is rejected, matching a conforming compiler.
+- Variably-modified **types** beyond the array object itself — VLA `typedef`s,
+  pointers-to-VLA (`int (*p)[n]`), and run-time-bound VLA function parameters —
+  are not modelled.
+

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -232,6 +232,7 @@ struct Sym {
     char (*init_labels)[64];
     int *init_sizes;
     int is_array;
+    int is_vla;     /* C99 variable-length array: slot holds a runtime pointer */
     int array_len;
     int elem_size; /* stride per first-dimension element */
     int dim_count; /* C array dimensions, e.g. a[2][3] -> 2 */
@@ -446,6 +447,11 @@ extern int g_static_local_func_index;
 extern int g_static_local_seq;
 void enter_scope(void);
 void leave_scope(void);
+int vla_scope_ensure_save_slot(void);
+int vla_active_scope_depth(void);
+void emit_vla_save_sp(int off);
+void emit_vla_restore_sp(int off);
+void emit_vla_restore_for_flow(int floor_depth);
 struct Sym *find_local_decl(const char *name);
 
 extern int errors;
@@ -486,6 +492,9 @@ extern char ulabel_names[MAX_USER_LABELS][64];
 extern int  ulabel_ids[MAX_USER_LABELS];
 extern int  ulabel_defined[MAX_USER_LABELS];
 extern int  ulabel_referenced[MAX_USER_LABELS];
+extern int  ulabel_vla_depth[MAX_USER_LABELS];
+extern int  ulabel_ref_vla_depth[MAX_USER_LABELS];
+extern int  ulabel_ref_vla_restored[MAX_USER_LABELS];
 extern int  nulabels;
 
 /* enum constants (file-scoped) */
@@ -512,6 +521,23 @@ extern int g_ptr_array_dims[8];
 extern int g_ptr_array_elem_size;
 extern int g_last_array_dim_count;
 extern int g_last_array_dims[8];
+
+/* C99 VLA: parse_array_declarator_dims() captures the first-dimension size
+ * expression here when it is not a constant, so the local-declaration codegen
+ * can re-emit it at the declaration site to allocate the block at run time. */
+extern int g_vla_pending;
+extern long g_vla_dim_posi;
+extern long g_vla_dim_tok_start;
+extern int g_vla_dim_line;
+extern int g_vla_dim_tok_line;
+extern struct Token g_vla_dim_tok;
+
+/* C99 VLA block-scope reclamation: for each open block scope depth, the frame
+ * offset of a hidden slot holding the SP to restore to when the scope exits
+ * (0 = the scope has no VLA).  flow_scope_depth records the scope depth at each
+ * loop/switch entry so break/continue can reclaim the VLAs allocated inside. */
+extern int g_vla_scope_off[MAX_SCOPE_DEPTH];
+extern int flow_scope_depth[MAX_FLOW];
 
 /* ------------------------------------------------------------------------- *
  * Cross-module function prototypes, grouped by owning module. (Generated to
@@ -733,6 +759,7 @@ void emit_init_auto_char_array_from_string(struct Sym *s, const char *str);
 int find_or_alloc_user_label_index(const char *name);
 int mark_user_label_reference(const char *name);
 int define_user_label(const char *name);
+int find_or_alloc_user_label_index(const char *name);
 void check_undefined_user_labels(void);
 int parse_enum_const_value(void);
 void gen_post_update_symbol_addr_value(struct Sym *s, int op);

--- a/src/dcc/dcc_ast_build.c
+++ b/src/dcc/dcc_ast_build.c
@@ -274,6 +274,8 @@ static int ast_sizeof_expr_value(const struct AstNode *n)
     case AST_IDENT:
         s = find_sym(n->sval);
         if (s != NULL && s->is_array) {
+            if (s->is_vla && asm_suppress_depth == 0)
+                error_here("sizeof applied to a variable-length array is not supported");
             total = sym_array_total_elems(s);
             if (total <= 0)
                 total = 1;

--- a/src/dcc/dcc_ast_gen_stmt.c
+++ b/src/dcc/dcc_ast_gen_stmt.c
@@ -191,6 +191,7 @@ void ast_gen_switch_stmt(const struct AstNode *n)
     enter_scope();
     break_stack[nflow] = lend;
     cont_stack[nflow] = (nflow > 0) ? cont_stack[nflow - 1] : lend;
+    flow_scope_depth[nflow] = g_scope_depth;
     nflow++;
 
     if (ast_sw_depth < AST_MAX_SW_NEST) {
@@ -593,6 +594,7 @@ void ast_gen_for_stmt(const struct AstNode *n)
 
     break_stack[nflow] = lend;
     cont_stack[nflow] = linc;
+    flow_scope_depth[nflow] = g_scope_depth;
     nflow++;
     if (n->sym != NULL) {
         /* Cyclic-byte-fill fast path (see ast_for_mod_fill_supported): the
@@ -799,16 +801,58 @@ void ast_gen_stmt(const struct AstNode *n)
         gen_return_ast(n);
         break;
     case AST_BREAK:
+        emit_vla_restore_for_flow(flow_scope_depth[nflow - 1]);
         emit_jp_label("jp", break_stack[nflow - 1]);
         break;
     case AST_CONTINUE:
+        emit_vla_restore_for_flow(flow_scope_depth[nflow - 1]);
         emit_jp_label("jp", cont_stack[nflow - 1]);
         break;
     case AST_GOTO:
-        emit_jp_label("jp", mark_user_label_reference(n->sval));
+        {
+            int li;
+            int active_depth;
+            li = find_or_alloc_user_label_index(n->sval);
+            ulabel_referenced[li] = 1;
+            active_depth = vla_active_scope_depth();
+            if (ulabel_defined[li]) {
+                if (ulabel_vla_depth[li] > g_scope_depth) {
+                    error_here("goto into a variable-length array scope is not supported");
+                } else if (active_depth != 0 && ulabel_vla_depth[li] < g_scope_depth) {
+                    emit_vla_restore_for_flow(ulabel_vla_depth[li]);
+                }
+            } else if (active_depth != 0) {
+                if (ulabel_ref_vla_depth[li] != 0 &&
+                    ulabel_ref_vla_depth[li] != g_scope_depth)
+                    error_here("goto across different variable-length array scopes is not supported");
+                ulabel_ref_vla_depth[li] = g_scope_depth;
+            }
+            if (active_depth != 0 && !ulabel_defined[li]) {
+                /* One-pass codegen cannot know whether an unresolved forward label
+                 * will be inside this same VLA scope or outside it.  Emit the
+                 * safe form: restore now so forward goto-out is correct; if the
+                 * label later proves to be inside a VLA scope, diagnose it. */
+                emit_vla_restore_for_flow(0);
+                ulabel_ref_vla_restored[li] = 1;
+            }
+            emit_jp_label("jp", ulabel_ids[li]);
+        }
         break;
     case AST_LABEL:
-        emit_label(define_user_label(n->sval));
+        {
+            int li;
+            li = find_or_alloc_user_label_index(n->sval);
+            if (vla_active_scope_depth() != 0 && ulabel_referenced[li] &&
+                ulabel_ref_vla_depth[li] != g_scope_depth)
+                error_here("goto into a variable-length array scope is not supported");
+            if (vla_active_scope_depth() != 0 && ulabel_ref_vla_restored[li])
+                error_here("forward goto within a variable-length array scope is not supported");
+            if (vla_active_scope_depth() == 0 && ulabel_ref_vla_depth[li] != 0) {
+                ulabel_ref_vla_depth[li] = 0;
+                ulabel_ref_vla_restored[li] = 0;
+            }
+            emit_label(define_user_label(n->sval));
+        }
         ast_gen_stmt(n->b);
         break;
     case AST_CASE: {
@@ -819,6 +863,8 @@ void ast_gen_stmt(const struct AstNode *n)
 
         if (ast_sw_depth <= 0)
             fatal("case label outside switch");
+        if (vla_active_scope_depth() != 0)
+            error_here("case label inside a variable-length array scope is not supported");
         cv = n->ival;
         lab = -1;
         sw = &ast_sw_ctx[ast_sw_depth - 1];
@@ -838,6 +884,8 @@ void ast_gen_stmt(const struct AstNode *n)
 
         if (ast_sw_depth <= 0)
             fatal("default label outside switch");
+        if (vla_active_scope_depth() != 0)
+            error_here("default label inside a variable-length array scope is not supported");
         sw = &ast_sw_ctx[ast_sw_depth - 1];
         if (sw->def_lab >= 0)
             emit_label(sw->def_lab);
@@ -873,6 +921,7 @@ void ast_gen_stmt(const struct AstNode *n)
         }
         break_stack[nflow] = lend;
         cont_stack[nflow] = ltop;
+        flow_scope_depth[nflow] = g_scope_depth;
         nflow++;
         ast_gen_stmt(n->b);
         nflow--;
@@ -892,6 +941,7 @@ void ast_gen_stmt(const struct AstNode *n)
         emit_label(ltop);
         break_stack[nflow] = lend;
         cont_stack[nflow] = lcont;
+        flow_scope_depth[nflow] = g_scope_depth;
         nflow++;
         ast_gen_stmt(n->b);
         nflow--;
@@ -935,6 +985,11 @@ void ast_gen_stmt(const struct AstNode *n)
             ast_gen_stmt(n->list[i]);
             dead = ast_stmt_exits(n->list[i]);
         }
+        /* Reclaim this scope's VLAs on fall-through exit (unreachable when the
+         * block always exits; break/continue/return reclaim on their own). */
+        if (!dead && g_scope_depth < MAX_SCOPE_DEPTH &&
+            g_vla_scope_off[g_scope_depth] != 0)
+            emit_vla_restore_sp(g_vla_scope_off[g_scope_depth]);
         leave_scope();
         break;
     }

--- a/src/dcc/dcc_constexpr.c
+++ b/src/dcc/dcc_constexpr.c
@@ -50,17 +50,14 @@ long parse_const_long_primary(void)
             }
             expect(')');
         } else {
-            if (starts_type()) {
-                int t;
-                int sz;
-                error_here("expected an expression");
-                parse_type_name_decl(&t, &sz);
-                (void)t;
-                (void)sz;
-            } else {
-                error_here("'(' expected after sizeof in constant expression");
-            }
-            v = 2;
+            int t;
+            int sz;
+            /* sizeof unary-expression without parentheses.  Do not consume
+             * following binary operators: sizeof a + 1 is (sizeof a) + 1,
+             * not sizeof(a + 1). */
+            if (!sizeof_parse_primary_type(&t, &sz))
+                sz = 2;
+            v = sz;
         }
         return sign * v;
     }

--- a/src/dcc/dcc_decl.c
+++ b/src/dcc/dcc_decl.c
@@ -836,6 +836,63 @@ void emit_init_auto_array_from_list(struct Sym *s, int elem_type)
     }
 }
 
+/*
+ * Allocate a C99 variable-length array at run time.  parse_array_declarator_dims
+ * captured the (non-constant) first-dimension expression; re-seek the lexer to
+ * it, evaluate it into HL, scale by the element size, carve the block off the
+ * stack below SP, and store the resulting base pointer into the VLA's frame
+ * slot.  The block is reclaimed at block-scope exit by restoring SP from the
+ * scope's hidden `#vlasp` save slot (see emit_vla_save_sp/emit_vla_restore_sp),
+ * and by the function epilogue's `ld sp,ix` on any remaining return path.
+ */
+static void emit_vla_alloc(struct Sym *s)
+{
+    long r_posi;
+    long r_tok_start;
+    int r_line;
+    int r_tok_line;
+    struct Token r_tok;
+
+    r_posi = posi;
+    r_tok_start = tok_start_pos;
+    r_line = line_no;
+    r_tok_line = tok_line;
+    r_tok = tok;
+
+    posi = g_vla_dim_posi;
+    tok_start_pos = g_vla_dim_tok_start;
+    line_no = g_vla_dim_line;
+    tok_line = g_vla_dim_tok_line;
+    tok = g_vla_dim_tok;
+
+    ast_emit_init_expr();               /* HL = element count */
+
+    posi = r_posi;
+    tok_start_pos = r_tok_start;
+    line_no = r_line;
+    tok_line = r_tok_line;
+    tok = r_tok;
+
+    if (s->elem_size > 1)
+        emit_mul_hl_const((long)s->elem_size);   /* HL = size in bytes */
+
+    /* SP -= size; the new SP is the block base, stored into the slot. */
+    emit("\tex de,hl\n");
+    emit("\tld hl,0\n");
+    emit("\tadd hl,sp\n");
+    emit("\tor a\n");
+    emit("\tsbc hl,de\n");
+    emit("\tld sp,hl\n");
+    if (opt_stack_check)
+        emit_runtime_call("__stchk");
+    emit("\tld hl,0\n");
+    emit("\tadd hl,sp\n");
+    emit("\tpush hl\n");
+    emit_load_frame_addr_hl(s);         /* HL = &slot (may clobber DE) */
+    emit("\tpop de\n");                 /* DE = block base */
+    emit("\tld (hl),e\n\tinc hl\n\tld (hl),d\n");
+}
+
 void gen_local_decl_after_type(int base)
 {
     int type, bytes, arrlen;
@@ -971,7 +1028,9 @@ void gen_local_decl_after_type(int base)
         freshly_allocated = 0;
         if (!s) {
             bytes = type_size(type);
-            if (total_elems > 0)
+            if (g_vla_pending)
+                bytes = 2;              /* VLA: reserve only a pointer slot */
+            else if (total_elems > 0)
                 bytes = object_array_size(type, total_elems);
 
             s = add_local_alloc(name, type, bytes);
@@ -982,6 +1041,23 @@ void gen_local_decl_after_type(int base)
                 s->elem_size = current_field_array_elem_size ? current_field_array_elem_size : type_size(type);
                 if (s->elem_size <= 0) s->elem_size = 2;
                 copy_last_array_dims_to_sym(s);
+                if (g_vla_pending) {
+                    /* VLA: the frame slot holds a runtime pointer to the
+                     * block.  Keep the elem_size set above - the element size
+                     * for a[n], or the (constant) row stride for a[n][C] - so
+                     * both indexing and the allocation size are correct for
+                     * the variable outer dimension. */
+                    s->is_vla = 1;
+                    s->array_len = 0;
+                    if (s->elem_size <= 0) s->elem_size = 1;
+                    /* Save SP once per scope, before its first VLA, so the
+                     * scope's VLAs can be reclaimed at block/loop exit. */
+                    {
+                        int vsp_off = vla_scope_ensure_save_slot();
+                        if (vsp_off != 0)
+                            emit_vla_save_sp(vsp_off);
+                    }
+                }
             } else if (g_ptr_array_dim_count > 0) {
                 int pi;
                 s->elem_size = g_ptr_array_elem_size;
@@ -992,6 +1068,15 @@ void gen_local_decl_after_type(int base)
         }
         g_ptr_array_dim_count = 0;
         g_ptr_array_elem_size = 0;
+
+        if (g_vla_pending) {
+            /* A variable inner dimension (runtime row stride) already errored
+             * during the declarator parse; only a variable outer dimension
+             * with constant inner dimensions reaches here. */
+            if (freshly_allocated)
+                emit_vla_alloc(s);
+            g_vla_pending = 0;
+        }
 
         if (s->is_const_value) {
             if (accept('=')) {

--- a/src/dcc/dcc_expr.c
+++ b/src/dcc/dcc_expr.c
@@ -547,6 +547,155 @@ int char_array_string_initializer_size(int base_type)
  * already uses Sym.elem_size as the stride for the first index, so bufs[i]
  * points at the correct row without needing a full C array type system.
  */
+static void skip_array_dim_balanced(int open, int close)
+{
+    int depth;
+
+    if (tok.kind != open)
+        return;
+    depth = 1;
+    next_token();
+    while (tok.kind != TOK_EOF && depth > 0) {
+        if (tok.kind == open)
+            depth++;
+        else if (tok.kind == close)
+            depth--;
+        next_token();
+    }
+}
+
+static void skip_sizeof_array_dim_operand(void)
+{
+    int done;
+
+    if (tok.kind == TOK_SIZEOF)
+        next_token();
+
+    while (tok.kind == TOK_SIZEOF || tok.kind == '*' || tok.kind == '&' ||
+           tok.kind == '+' || tok.kind == '-' || tok.kind == '!' ||
+           tok.kind == '~') {
+        if (tok.kind == TOK_SIZEOF)
+            next_token();
+        else
+            next_token();
+    }
+
+    if (tok.kind == '(') {
+        skip_array_dim_balanced('(', ')');
+        return;
+    }
+
+    if (tok.kind == TOK_ID || tok.kind == TOK_NUM || tok.kind == TOK_CHARLIT ||
+        tok.kind == TOK_STR || tok.kind == TOK_WSTR) {
+        next_token();
+        done = 0;
+        while (!done) {
+            if (tok.kind == '[') {
+                skip_array_dim_balanced('[', ']');
+            } else if (tok.kind == '(') {
+                skip_array_dim_balanced('(', ')');
+            } else if (tok.kind == '.' || tok.kind == TOK_ARROW) {
+                next_token();
+                if (tok.kind == TOK_ID)
+                    next_token();
+            } else {
+                done = 1;
+            }
+        }
+    }
+}
+
+static int array_dim_has_runtime_identifier(void)
+{
+    long save_pos;
+    long save_tok_start;
+    int save_line;
+    int save_tok_line;
+    struct Token save_tok;
+    int depth;
+    int has_runtime;
+
+    save_pos = posi;
+    save_tok_start = tok_start_pos;
+    save_line = line_no;
+    save_tok_line = tok_line;
+    save_tok = tok;
+
+    depth = 0;
+    has_runtime = 0;
+    while (tok.kind != TOK_EOF) {
+        if (depth == 0 && tok.kind == ']')
+            break;
+        if (tok.kind == TOK_SIZEOF) {
+            skip_sizeof_array_dim_operand();
+            continue;
+        }
+        if (tok.kind == '(') {
+            /* A parenthesized construct that begins with a type is a cast (or
+             * parenthesized type): its type-name identifiers (e.g. size_t in
+             * (size_t)8) are not runtime values, so skip the whole `(type)`
+             * and keep scanning the operand.  An ordinary parenthesized
+             * expression is counted normally so its identifiers are seen. */
+            next_token();
+            if (starts_type()) {
+                int d2 = 1;
+                while (tok.kind != TOK_EOF && d2 > 0) {
+                    if (tok.kind == '(')
+                        d2++;
+                    else if (tok.kind == ')')
+                        d2--;
+                    next_token();
+                }
+            } else {
+                depth++;
+            }
+            continue;
+        }
+        if (tok.kind == TOK_ID && find_enum_const(tok.text) < 0) {
+            has_runtime = 1;
+            break;
+        }
+        if (tok.kind == '[' || tok.kind == '{')
+            depth++;
+        else if (tok.kind == ')' || tok.kind == ']' || tok.kind == '}') {
+            if (depth > 0)
+                depth--;
+        }
+        next_token();
+    }
+
+    posi = save_pos;
+    tok_start_pos = save_tok_start;
+    line_no = save_line;
+    tok_line = save_tok_line;
+    tok = save_tok;
+    return has_runtime;
+}
+
+/*
+ * Skip tokens up to the `]` that closes the current array dimension, honoring
+ * nested brackets/parens/braces so a subscript or call inside the dimension
+ * expression (e.g. `b[a[n-1] + 2]`) does not stop early on an inner `]`.  The
+ * opening `[` of the dimension has already been consumed by the caller; on
+ * return the closing `]` has been consumed too.
+ */
+static void skip_array_dim_to_close(void)
+{
+    int depth = 0;
+    while (tok.kind != TOK_EOF) {
+        if (depth == 0 && tok.kind == ']')
+            break;
+        if (tok.kind == '(' || tok.kind == '[' || tok.kind == '{')
+            depth++;
+        else if (tok.kind == ')' || tok.kind == '}')
+            { if (depth > 0) depth--; }
+        else if (tok.kind == ']')
+            { if (depth > 0) depth--; }
+        next_token();
+    }
+    expect(']');
+}
+
 void parse_array_declarator_dims(int base_type,
                                         int *total_len,
                                         int *first_stride_bytes,
@@ -562,6 +711,7 @@ void parse_array_declarator_dims(int base_type,
 
     ndims = 0;
     g_last_array_dim_count = 0;
+    g_vla_pending = 0;
     memset(g_last_array_dims, 0, sizeof(g_last_array_dims));
 
     while (accept('[')) {
@@ -571,14 +721,33 @@ void parse_array_declarator_dims(int base_type,
                     ? char_array_string_initializer_size(base_type)
                     : 0;
         } else {
-            if (tok.kind == TOK_ID && find_enum_const(tok.text) < 0) {
-                if (asm_suppress_depth == 0)
-                    error_here("variable length arrays are not supported; use malloc and an explicit pointer");
-                next_token();
-                while (tok.kind != ']' && tok.kind != TOK_EOF)
-                    next_token();
-                expect(']');
-                n = 0;
+            if (array_dim_has_runtime_identifier()) {
+                /*
+                 * Non-constant array bound.  A local VLA whose only variable
+                 * dimension is the first is supported: capture the dimension
+                 * expression so the declaration codegen can evaluate it at run
+                 * time and allocate the block below SP (the array then decays
+                 * to that pointer).  Capture in every pass - including the
+                 * frame-sizing scan (asm_suppress_depth > 0) - so scan and
+                 * codegen reserve the identical pointer slot.  A variable inner
+                 * dimension has a runtime stride and is rejected below (the
+                 * error is emitted only when not suppressed, i.e. at codegen).
+                 */
+                if (ndims == 0) {
+                    g_vla_pending = 1;
+                    g_vla_dim_posi = posi;
+                    g_vla_dim_tok_start = tok_start_pos;
+                    g_vla_dim_line = line_no;
+                    g_vla_dim_tok_line = tok_line;
+                    g_vla_dim_tok = tok;
+                    skip_array_dim_to_close();
+                    n = 0;
+                } else {
+                    if (asm_suppress_depth == 0)
+                        error_here("variable length arrays are not supported; use malloc and an explicit pointer");
+                    skip_array_dim_to_close();
+                    n = 0;
+                }
             } else {
                 n = parse_const_int_expr();
                 expect(']');
@@ -803,6 +972,9 @@ int find_or_alloc_user_label_index(const char *name)
     ulabel_ids[nulabels] = new_label();
     ulabel_defined[nulabels] = 0;
     ulabel_referenced[nulabels] = 0;
+    ulabel_vla_depth[nulabels] = 0;
+    ulabel_ref_vla_depth[nulabels] = 0;
+    ulabel_ref_vla_restored[nulabels] = 0;
     return nulabels++;
 }
 
@@ -823,6 +995,7 @@ int define_user_label(const char *name)
     if (ulabel_defined[i])
         error_here("duplicate goto label");
     ulabel_defined[i] = 1;
+    ulabel_vla_depth[i] = g_scope_depth;
     return ulabel_ids[i];
 }
 

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -1619,6 +1619,7 @@ void scan_local_decl_after_type(int base)
 
         bytes = type_size(type);
         if (total_elems > 0) bytes *= total_elems;
+        if (g_vla_pending) bytes = 2;   /* VLA: reserve only a pointer slot */
 
         /* A name already present in the innermost open block is a redefinition.
          * find_local_decl() only searches the current scope (and ignores
@@ -1647,6 +1648,17 @@ void scan_local_decl_after_type(int base)
                 s->elem_size = current_field_array_elem_size ? current_field_array_elem_size : type_size(type);
                 if (s->elem_size <= 0) s->elem_size = 2;
                 copy_last_array_dims_to_sym(s);
+                if (g_vla_pending) {
+                    /* VLA: keep the elem_size set above (element size for
+                     * a[n], row stride for a[n][C]); the slot holds a runtime
+                     * pointer, mirrored by gen_local_decl_after_type. */
+                    s->is_vla = 1;
+                    s->array_len = 0;
+                    if (s->elem_size <= 0) s->elem_size = 1;
+                    /* Reserve this scope's SP-save slot (first VLA only) so the
+                     * frame matches the codegen pass, which also emits it. */
+                    vla_scope_ensure_save_slot();
+                }
             } else if (g_ptr_array_dim_count > 0) {
                 int pi;
                 s->elem_size = g_ptr_array_elem_size;
@@ -1660,7 +1672,7 @@ void scan_local_decl_after_type(int base)
 
         if (s && !s->is_const_value && accept('=')) {
             scan_initializer_or_decl_tail();
-        } else if (freshly_allocated && !local_name_used_ahead(source_name)) {
+        } else if (freshly_allocated && !g_vla_pending && !local_name_used_ahead(source_name)) {
             /* No initializer, and never referenced again in this scope:
              * add_local_alloc just appended this Sym as the last local and
              * reserved its frame space, so popping both back off is safe -
@@ -1715,6 +1727,16 @@ void scan_static_local_decl_after_type(int base)
             if (arrlen == 0)
                 parse_array_declarator_dims(type, &arrlen, &first_stride_bytes, 1);
             current_field_array_elem_size = first_stride_bytes;
+        }
+        if (g_vla_pending) {
+            /* A static (or file-scope) array cannot have a run-time bound:
+             * its storage is a fixed global, not stack-allocated.  Reject
+             * rather than silently emit a wrong-sized static array.  Clear the
+             * flag so it does not leak into the next declarator. */
+            if (asm_suppress_depth == 0)
+                error_here("variable length array declaration cannot have static storage duration");
+            g_vla_pending = 0;
+            arrlen = 0;
         }
         if (arrlen == 0 && g_typedef_array_len > 0)
             arrlen = g_typedef_array_len;

--- a/src/dcc/dcc_state.c
+++ b/src/dcc/dcc_state.c
@@ -168,6 +168,9 @@ char ulabel_names[MAX_USER_LABELS][64];
 int  ulabel_ids[MAX_USER_LABELS];
 int  ulabel_defined[MAX_USER_LABELS];
 int  ulabel_referenced[MAX_USER_LABELS];
+int  ulabel_vla_depth[MAX_USER_LABELS];
+int  ulabel_ref_vla_depth[MAX_USER_LABELS];
+int  ulabel_ref_vla_restored[MAX_USER_LABELS];
 int  nulabels;
 
 /* Enum constants (file-scoped) */
@@ -194,3 +197,12 @@ int g_ptr_array_dims[8];
 int g_ptr_array_elem_size;
 int g_last_array_dim_count;
 int g_last_array_dims[8];
+
+int g_vla_pending;
+long g_vla_dim_posi;
+long g_vla_dim_tok_start;
+int g_vla_dim_line;
+int g_vla_dim_tok_line;
+struct Token g_vla_dim_tok;
+int g_vla_scope_off[MAX_SCOPE_DEPTH];
+int flow_scope_depth[MAX_FLOW];

--- a/src/dcc/dcc_symbols.c
+++ b/src/dcc/dcc_symbols.c
@@ -129,6 +129,77 @@ void enter_scope(void)
     if (g_scope_depth >= MAX_SCOPE_DEPTH)
         fatal("too many nested block scopes");
     g_scope_watermark[g_scope_depth++] = nlocals;
+    /* A freshly opened scope has no VLA save slot yet. */
+    if (g_scope_depth < MAX_SCOPE_DEPTH)
+        g_vla_scope_off[g_scope_depth] = 0;
+}
+
+/*
+ * Ensure the current block scope has a hidden slot in which to save SP before
+ * its first VLA is allocated, so the scope's VLAs can be reclaimed when it
+ * exits.  Called by BOTH the frame-sizing scan and codegen at the first VLA in
+ * a scope, so the two passes reserve the identical slot (local_size is
+ * monotonic).  Returns the slot's frame offset, or 0 if the scope already has
+ * one / on overflow.
+ */
+int vla_scope_ensure_save_slot(void)
+{
+    struct Sym *s;
+
+    if (g_scope_depth < 0 || g_scope_depth >= MAX_SCOPE_DEPTH)
+        return 0;
+    if (g_vla_scope_off[g_scope_depth] != 0)
+        return 0;                       /* already allocated for this scope */
+    s = add_local_alloc("#vlasp", TYPE_INT, 2);
+    g_vla_scope_off[g_scope_depth] = s->offset;
+    return s->offset;
+}
+
+int vla_active_scope_depth(void)
+{
+    int d;
+    for (d = 1; d <= g_scope_depth && d < MAX_SCOPE_DEPTH; ++d)
+        if (g_vla_scope_off[d] != 0)
+            return d;
+    return 0;
+}
+
+/* HL-free helper: save the current SP into the frame slot at `off`. */
+void emit_vla_save_sp(int off)
+{
+    emit("\tld hl,0\n\tadd hl,sp\n");   /* HL = SP */
+    emit("\tpush hl\n");                /* stash SP value */
+    emit("\tpush ix\n\tpop hl\n");      /* HL = IX */
+    fprintf(outf, "\tld de,%d\n\tadd hl,de\n", off);
+    emit("\tpop de\n");                 /* DE = SP value */
+    emit("\tld (hl),e\n\tinc hl\n\tld (hl),d\n");
+}
+
+/* Restore SP from the frame slot at `off`, reclaiming that scope's VLAs. */
+void emit_vla_restore_sp(int off)
+{
+    emit("\tpush ix\n\tpop hl\n");      /* HL = IX */
+    fprintf(outf, "\tld de,%d\n\tadd hl,de\n", off);
+    emit("\tld a,(hl)\n\tinc hl\n\tld h,(hl)\n\tld l,a\n");  /* HL = saved SP */
+    emit("\tld sp,hl\n");
+}
+
+/*
+ * Reclaim VLAs when leaving a loop/switch via break or continue.  Restore SP to
+ * the outermost active VLA save slot among the scopes being exited (depths
+ * greater than floor_depth); restoring an outer slot reclaims every inner
+ * scope's VLAs, so only one restore is needed.  Emits nothing when no VLA was
+ * declared inside the loop.
+ */
+void emit_vla_restore_for_flow(int floor_depth)
+{
+    int d;
+    for (d = floor_depth + 1; d <= g_scope_depth && d < MAX_SCOPE_DEPTH; ++d) {
+        if (g_vla_scope_off[d] != 0) {
+            emit_vla_restore_sp(g_vla_scope_off[d]);
+            return;
+        }
+    }
 }
 
 void leave_scope(void)
@@ -472,6 +543,14 @@ void emit_load_frame_addr_hl(struct Sym *s)
 
 void emit_load_sym_addr(struct Sym *s)
 {
+    if (s->is_vla) {
+        /* A VLA's storage is allocated at run time below SP; its frame slot
+         * holds a pointer to that block.  The array decays to that pointer
+         * value, so load the slot contents rather than the slot's address. */
+        emit_load_frame_addr_hl(s);
+        emit("\tld a,(hl)\n\tinc hl\n\tld h,(hl)\n\tld l,a\n");
+        return;
+    }
     if (s->storage == SC_LOCAL || s->storage == SC_PARAM) {
         emit_load_frame_addr_hl(s);
     } else {
@@ -1027,59 +1106,73 @@ int sizeof_parse_primary_type(int *typep, int *sizep)
     sz = is_arr ? s->size : type_size(type);
     elem_size = s->elem_size ? s->elem_size : type_size(type);
     if (elem_size <= 0) elem_size = 1;
-    next_token();
+    {
+        /* sizeof of a whole VLA needs its runtime byte size, which is not a
+         * compile-time constant; reject rather than silently use the pointer
+         * slot size.  Indexing/field access below reduces to a constant-size
+         * subobject, so only the bare VLA operand is diagnosed (checked after
+         * the postfix loop via vla_whole). */
+        int vla_whole = s->is_vla;
+        next_token();
 
-    for (;;) {
-        if (tok.kind == '[') {
-            skip_balanced_bracket('[', ']');
-            if (is_arr) {
-                sz = elem_size;
+        for (;;) {
+            if (tok.kind == '[') {
+                skip_balanced_bracket('[', ']');
+                vla_whole = 0;
+                if (is_arr) {
+                    sz = elem_size;
+                    is_arr = 0;
+                } else {
+                    type = type_decay_ptr(type);
+                    sz = type_size(type);
+                    if (sz <= 0) sz = 1;
+                }
+            } else if (tok.kind == '(') {
+                /* Function call expression: sizeof uses the function return
+                 * type.  Arguments are not evaluated; just skip the list. */
+                skip_balanced_bracket('(', ')');
                 is_arr = 0;
-            } else {
-                type = type_decay_ptr(type);
+                vla_whole = 0;
                 sz = type_size(type);
-                if (sz <= 0) sz = 1;
-            }
-        } else if (tok.kind == '(') {
-            /* Function call expression: sizeof uses the function return type.
-             * Arguments are not evaluated; just skip the argument list. */
-            skip_balanced_bracket('(', ')');
-            is_arr = 0;
-            sz = type_size(type);
-            if (sz <= 0) sz = 2;
-        } else if (tok.kind == '.' || tok.kind == TOK_ARROW) {
-            int arrow;
+                if (sz <= 0) sz = 2;
+            } else if (tok.kind == '.' || tok.kind == TOK_ARROW) {
+                int arrow;
 
-            arrow = tok.kind == TOK_ARROW;
-            next_token();
-
-            if (tok.kind != TOK_ID) {
-                error_here("field name expected");
-                break;
-            }
-
-            if (arrow)
-                sid = base_struct_id_from_type(type_decay_ptr(type));
-            else
-                sid = base_struct_id_from_type(type);
-
-            fd = find_field_def(sid, tok.text);
-            if (!fd) {
-                error_here("unknown struct field");
+                arrow = tok.kind == TOK_ARROW;
+                vla_whole = 0;
                 next_token();
+
+                if (tok.kind != TOK_ID) {
+                    error_here("field name expected");
+                    break;
+                }
+
+                if (arrow)
+                    sid = base_struct_id_from_type(type_decay_ptr(type));
+                else
+                    sid = base_struct_id_from_type(type);
+
+                fd = find_field_def(sid, tok.text);
+                if (!fd) {
+                    error_here("unknown struct field");
+                    next_token();
+                    break;
+                }
+
+                next_token();
+
+                type = fd->is_array ? fd->elem_type : fd->type;
+                sz = fd->is_array ? fd->size : fd->size;
+                is_arr = fd->is_array;
+                elem_size = fd->elem_size ? fd->elem_size : type_size(type);
+                if (elem_size <= 0) elem_size = 1;
+            } else {
                 break;
             }
-
-            next_token();
-
-            type = fd->is_array ? fd->elem_type : fd->type;
-            sz = fd->is_array ? fd->size : fd->size;
-            is_arr = fd->is_array;
-            elem_size = fd->elem_size ? fd->elem_size : type_size(type);
-            if (elem_size <= 0) elem_size = 1;
-        } else {
-            break;
         }
+
+        if (vla_whole && asm_suppress_depth == 0)
+            error_here("sizeof applied to a variable-length array is not supported");
     }
 
     *typep = type;

--- a/tests/_extended_test_overrides.json
+++ b/tests/_extended_test_overrides.json
@@ -20,7 +20,7 @@
     { "name": "00200", "ignore": true, "reason": "Uses long long generic-selection cases; dcc has no 64-bit integer type." },
     { "name": "00203", "ignore": true, "reason": "Uses long long constants; dcc has no 64-bit integer type." },
     { "name": "00204", "ignore": true, "reason": "Tests host ABI details with double, long double, long long, uint64_t, and int64_t; those are outside dcc's CP/M/Z80 model." },
-    { "name": "00207", "ignore": true, "reason": "Contains a true C99 variable-length array; dcc does not implement VLAs. The constant-expression array bounds in the same test are not VLAs." },
+    { "name": "00207", "ignore": false, "reason": "C99 single-variable-dimension VLA (char test[argc]); dcc now supports VLAs whose only variable dimension is the outermost, so this builds and runs." },
     { "name": "00212", "ignore": true, "reason": "Checks LLP64/LP64/ILP32 host data models; dcc is a 16-bit-pointer CP/M/Z80 target." },
     { "name": "00213", "ignore": true, "reason": "GNU statement-expression support is not implemented yet." },
     { "name": "00214", "ignore": true, "reason": "GNU statement-expression and __builtin_expect support is not implemented yet." },

--- a/tests/_test_overrides.json
+++ b/tests/_test_overrides.json
@@ -18,6 +18,8 @@
     { "name": "tpfio", "dcc_floatio": true, "dcc_longio": false },
     { "name": "tplng", "dcc_floatio": false, "dcc_longio": true },
     { "name": "tvplain", "dcc_floatio": false, "dcc_longio": false },
+    { "name": "tvla", "stack_size": 1024 },
+    { "name": "tvlax", "stack_size": 2048 },
     { "name": "triangle", "stack_size": 768 },
     { "name": "catalan", "stack_size": 768 },
     { "name": "fileops", "host": true },

--- a/tests/baselines/tvla.txt
+++ b/tests/baselines/tvla.txt
@@ -1,0 +1,3 @@
+tvla start
+checks=32 failures=0
+tvla ok

--- a/tests/baselines/tvlax.txt
+++ b/tests/baselines/tvlax.txt
@@ -1,0 +1,3 @@
+tvlax start
+checks=7 failures=0
+tvlax ok

--- a/tests/diagnostics/baselines/sizeof-constant-expression-missing-lparen.txt
+++ b/tests/diagnostics/baselines/sizeof-constant-expression-missing-lparen.txt
@@ -1,4 +1,4 @@
-<source>:2: error DCC-E1005: '(' expected after sizeof in constant expression near 'x'
+<source>:2: error DCC-E0201: use of undeclared identifier 'x' near 'x'
         A = sizeof x
                    ^
 dcc: 1 error(s)

--- a/tests/diagnostics/baselines/sizeof-constant-expression-missing-paren.txt
+++ b/tests/diagnostics/baselines/sizeof-constant-expression-missing-paren.txt
@@ -1,4 +1,4 @@
-<source>:2: error DCC-E0403: expected an expression near 'int'
+<source>:2: error DCC-E1001: unsupported sizeof expression near 'int'
         A = sizeof int
                    ^
 dcc: 1 error(s)

--- a/tests/diagnostics/baselines/variable-length-array.txt
+++ b/tests/diagnostics/baselines/variable-length-array.txt
@@ -1,4 +1,4 @@
-<source>:3: error DCC-E0601: variable length arrays are not supported; use malloc and an explicit pointer near 'n'
-        int a[n];
-              ^
+<source>:3: error DCC-E0601: variable length arrays are not supported; use malloc and an explicit pointer near 'm'
+        int a[n][m];
+                 ^
 dcc: 1 error(s)

--- a/tests/diagnostics/baselines/vla-goto-into.txt
+++ b/tests/diagnostics/baselines/vla-goto-into.txt
@@ -1,0 +1,4 @@
+<source>:10: error DCC-E0001: goto into a variable-length array scope is not supported near '}'
+    }
+    ^
+dcc: 1 error(s)

--- a/tests/diagnostics/baselines/vla-sizeof.txt
+++ b/tests/diagnostics/baselines/vla-sizeof.txt
@@ -1,0 +1,4 @@
+<source>:4: error DCC-E0001: sizeof applied to a variable-length array is not supported near ';'
+        return (int)sizeof a;
+                            ^
+dcc: 1 error(s)

--- a/tests/diagnostics/baselines/vla-static.txt
+++ b/tests/diagnostics/baselines/vla-static.txt
@@ -1,0 +1,4 @@
+<source>:3: error DCC-E0001: variable length array declaration cannot have static storage duration near ';'
+        static int a[n];
+                       ^
+dcc: 1 error(s)

--- a/tests/diagnostics/baselines/vla-switch-label.txt
+++ b/tests/diagnostics/baselines/vla-switch-label.txt
@@ -1,0 +1,4 @@
+<source>:12: error DCC-E0001: default label inside a variable-length array scope is not supported near 'return'
+        return 0;
+        ^
+dcc: 1 error(s)

--- a/tests/diagnostics/variable-length-array.c
+++ b/tests/diagnostics/variable-length-array.c
@@ -1,5 +1,5 @@
-int f(int n)
+int f(int n, int m)
 {
-    int a[n];
+    int a[n][m];
     return 0;
 }

--- a/tests/diagnostics/vla-goto-into.c
+++ b/tests/diagnostics/vla-goto-into.c
@@ -1,0 +1,10 @@
+int f(int n)
+{
+    goto inside;
+    {
+        int a[n];
+inside:
+        a[0] = 5;
+        return a[0];
+    }
+}

--- a/tests/diagnostics/vla-sizeof.c
+++ b/tests/diagnostics/vla-sizeof.c
@@ -1,0 +1,5 @@
+int f(int n)
+{
+    int a[n];
+    return (int)sizeof a;
+}

--- a/tests/diagnostics/vla-static.c
+++ b/tests/diagnostics/vla-static.c
@@ -1,0 +1,5 @@
+int f(int n)
+{
+    static int a[n];
+    return n;
+}

--- a/tests/diagnostics/vla-switch-label.c
+++ b/tests/diagnostics/vla-switch-label.c
@@ -1,0 +1,13 @@
+int f(int n, int x)
+{
+    switch (x) {
+    case 1:
+        ;
+        int a[n];
+        a[0] = 1;
+        break;
+    default:
+        break;
+    }
+    return 0;
+}

--- a/tests/tvla.c
+++ b/tests/tvla.c
@@ -1,0 +1,472 @@
+/*
+ * tvla.c - C99 variable-length array support (the subset dcc implements:
+ * a local array whose only variable dimension is the outermost, with constant
+ * inner dimensions).  Exercises 1-D int/char VLAs, a 2-D VLA with a constant
+ * inner dimension, VLA decay to a pointer argument, and a computed size.
+ * Output is a deterministic PASS/FAIL summary.
+ */
+#include <stdio.h>
+#include <setjmp.h>
+
+static int checks = 0;
+static int failures = 0;
+
+static void check_int(const char *name, int got, int want)
+{
+    checks++;
+    if (got != want) {
+        failures++;
+        printf("FAIL %s got %d want %d\n", name, got, want);
+    }
+}
+
+/* The VLA decays to a plain pointer here, exactly like a fixed array. */
+static int sum_ints(int *p, int n)
+{
+    int i;
+    int s = 0;
+    for (i = 0; i < n; i++)
+        s += p[i];
+    return s;
+}
+
+static int vla_1d(int n)
+{
+    int a[n];
+    int i;
+    for (i = 0; i < n; i++)
+        a[i] = i * i;
+    return sum_ints(a, n);
+}
+
+static int vla_char(int n)
+{
+    char buf[n];
+    int i;
+    for (i = 0; i < n - 1; i++)
+        buf[i] = (char)('a' + i);
+    buf[n - 1] = 0;
+    return (int)buf[0] + (int)buf[n - 2];
+}
+
+static int vla_2d(int rows)
+{
+    int a[rows][3];
+    int i, j, s;
+    for (i = 0; i < rows; i++)
+        for (j = 0; j < 3; j++)
+            a[i][j] = i * 10 + j;
+    s = 0;
+    for (i = 0; i < rows; i++)
+        for (j = 0; j < 3; j++)
+            s += a[i][j];
+    return s;
+}
+
+static int vla_computed(int n)
+{
+    int a[n * 2 + 1];
+    int i;
+    int count = n * 2 + 1;
+    for (i = 0; i < count; i++)
+        a[i] = 1;
+    return sum_ints(a, count);
+}
+
+static int vla_parenthesized_bound(int n)
+{
+    int a[(n + 1)];
+    a[n] = 17;
+    return a[n];
+}
+
+static int vla_leading_const_bound(int n)
+{
+    int a[1 + n];
+    a[n] = 19;
+    return a[n];
+}
+
+/* Bound expression containing an array subscript: the dimension parser must
+ * skip to the dimension's own ']' without stopping on the inner subscript. */
+static int vla_subscript_bound(int n)
+{
+    int len[1];
+    len[0] = n;
+    {
+        int a[len[0] + 2];
+        int i, m = len[0] + 2, s = 0;
+        for (i = 0; i < m; i++) a[i] = i;
+        for (i = 0; i < m; i++) s += a[i];
+        return s;                       /* 0+1+...+(n+1) */
+    }
+}
+
+/* Bound expression that is a function call. */
+static int idn(int x) { return x; }
+static int vla_call_bound(int n)
+{
+    int a[idn(n)];
+    int i, s = 0;
+    for (i = 0; i < n; i++) a[i] = 2;
+    for (i = 0; i < n; i++) s += a[i];
+    return s;                           /* 2*n */
+}
+
+/* A second VLA whose bound subscripts the FIRST (also a VLA).  This is the
+ * exact shape the dimension parser once mis-handled: the inner subscript's ']'
+ * must not terminate the outer dimension. */
+static int vla_dependent_bound(int n)
+{
+    int a[n];
+    int i, s = 0;
+    for (i = 0; i < n; i++) a[i] = i + 1;
+    {
+        int b[a[n - 1] + 2];            /* size = n + 2, from a VLA subscript */
+        int m = a[n - 1] + 2;
+        for (i = 0; i < m; i++) b[i] = i;
+        for (i = 0; i < m; i++) s += b[i];   /* 0+1+...+(n+1) */
+    }
+    for (i = 0; i < n; i++) s += a[i];       /* + (1+2+...+n) */
+    return s;
+}
+
+/* Bounds using sizeof of an identifier are constant expressions, not VLAs. */
+static int fixed_sizeof_bounds(int n)
+{
+    int a[sizeof n];
+    int b[sizeof n + 1];
+    int acount;
+    int bcount;
+
+    acount = (int)(sizeof a / sizeof a[0]);
+    bcount = (int)(sizeof b / sizeof b[0]);
+    return (acount == (int)sizeof n) &&
+           (bcount == (int)sizeof n + 1);
+}
+
+/* A cast of a constant bound is a constant expression, not a VLA: the cast's
+ * type-name (e.g. size_t) must not be mistaken for a runtime dimension. */
+static int fixed_cast_bounds(void)
+{
+    int a[(size_t)8];
+    int b[(unsigned)4 + 1];
+    int acount = (int)(sizeof a / sizeof a[0]);
+    int bcount = (int)(sizeof b / sizeof b[0]);
+    return (acount == 8) && (bcount == 5);
+}
+
+/* Three-dimensional VLA: variable outer, constant inner dims. */
+static int vla_3d(int n)
+{
+    int a[n][2][3];
+    int i, j, k, s = 0;
+    for (i = 0; i < n; i++)
+        for (j = 0; j < 2; j++)
+            for (k = 0; k < 3; k++)
+                a[i][j][k] = i + j + k;
+    for (i = 0; i < n; i++)
+        for (j = 0; j < 2; j++)
+            for (k = 0; k < 3; k++)
+                s += a[i][j][k];
+    return s;
+}
+
+/* A VLA declared inside a loop body must be reclaimed each iteration (C99
+ * block scope). Running many iterations would overflow the CP/M stack if it
+ * leaked; the accumulation is kept within 16-bit range so the result matches
+ * on both a 16-bit-int target and a 32-bit host. */
+static int vla_in_loop(int iters, int n)
+{
+    int i, j;
+    int last = 0;
+    for (i = 0; i < iters; i++) {
+        int a[n];
+        for (j = 0; j < n; j++)
+            a[j] = (i + j) & 15;
+        last = a[n - 1];
+        if ((i & 1) == 0)
+            continue;               /* continue must reclaim too */
+        last += a[0];
+    }
+    return last;
+}
+
+/* Nested block scopes, each with its own VLA, inside a loop. */
+static int vla_nested(int m)
+{
+    int total = 0;
+    int k;
+    for (k = 0; k < m; k++) {
+        char b[k + 2];
+        int t;
+        for (t = 0; t < k + 1; t++)
+            b[t] = (char)t;
+        {
+            int inner[k + 1];
+            int u;
+            for (u = 0; u <= k; u++)
+                inner[u] = b[u];
+            total += inner[k];
+        }
+    }
+    return total;
+}
+
+static int vla_goto_out(int iters, int n)
+{
+    int i;
+    int value = 0;
+    for (i = 0; i < iters; i++) {
+        {
+            int a[n];
+            a[0] = i & 15;
+            value = a[0];
+            goto out;
+        }
+out:
+        ;
+    }
+    return value;
+}
+
+/* Bound is the for-init loop variable; size changes each iteration. */
+static int vla_forinit_dep(int n)
+{
+    int i, s = 0;
+    for (i = 1; i <= n; i++) {
+        int a[i];
+        int j;
+        for (j = 0; j < i; j++) a[j] = 1;
+        for (j = 0; j < i; j++) s += a[j];
+    }
+    return s;                           /* 1+2+...+n */
+}
+
+/* A fixed local declared after the VLA still gets a correct frame slot. */
+static int vla_fixed_after(int n)
+{
+    int a[n];
+    int tail = 77;
+    int i, s = 0;
+    for (i = 0; i < n; i++) a[i] = i;
+    for (i = 0; i < n; i++) s += a[i];
+    return s + tail;
+}
+
+/* A large fixed array in the same scope pushes the VLA slots past the
+ * signed-byte IX offset range, exercising the ld de,offset save/restore path. */
+static int vla_big_frame(int n)
+{
+    int big[80];
+    int a[n];
+    int i, s = 0;
+    for (i = 0; i < 80; i++) big[i] = 1;
+    for (i = 0; i < n; i++) a[i] = 2;
+    for (i = 0; i < 80; i++) s += big[i];
+    for (i = 0; i < n; i++) s += a[i];
+    return s;                           /* 80 + 2n */
+}
+
+/* Conditional sibling VLAs in if/else at the same block depth. */
+static int vla_cond_sibling(int n, int c)
+{
+    int s = 0, i;
+    if (c) {
+        int a[n];
+        for (i = 0; i < n; i++) a[i] = 3;
+        for (i = 0; i < n; i++) s += a[i];
+    } else {
+        int b[n + 1];
+        for (i = 0; i < n + 1; i++) b[i] = 5;
+        for (i = 0; i < n + 1; i++) s += b[i];
+    }
+    return s;
+}
+
+/* A side-effecting bound is evaluated exactly once. */
+static int vla_side_bound(int n)
+{
+    int calls = n;
+    int a[calls++];
+    int i, s = 0;
+    for (i = 0; i < n; i++) a[i] = 4;
+    for (i = 0; i < n; i++) s += a[i];
+    return s + calls;                   /* 4n + (n+1) */
+}
+
+/* VLAs in distinct switch case blocks, including fall-through. */
+static int vla_switch(int n, int x)
+{
+    int s = 0, i;
+    switch (x) {
+    case 1: {
+        int a[n];
+        for (i = 0; i < n; i++) a[i] = 1;
+        for (i = 0; i < n; i++) s += a[i];
+    }   /* fall through */
+    case 2: {
+        int b[n + 1];
+        for (i = 0; i < n + 1; i++) b[i] = 10;
+        for (i = 0; i < n + 1; i++) s += b[i];
+        break;
+    }
+    default:
+        s = -1;
+    }
+    return s;
+}
+
+/* return from within a nested VLA block; the epilogue restores SP. */
+static int vla_return_nested(int n)
+{
+    {
+        int a[n];
+        int i, s = 0;
+        for (i = 0; i < n; i++) a[i] = 2;
+        for (i = 0; i < n; i++) s += a[i];
+        return s;                       /* 2n */
+    }
+}
+
+/* setjmp/longjmp across a VLA: longjmp unwinds SP past the allocation. */
+static jmp_buf vla_jb;
+static int vla_longjmp(int n)
+{
+    int hit = 0;
+    if (setjmp(vla_jb) != 0)
+        return 999;
+    {
+        int a[n];
+        int i;
+        for (i = 0; i < n; i++) a[i] = i;
+        hit = a[n - 1];
+        longjmp(vla_jb, 1);
+    }
+    return hit;
+}
+
+/* VLA of pointers (element size is a target pointer, not the base type). */
+static char vla_pool[10] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+static int vla_ptr_elem(int n)
+{
+    char *a[n];
+    int i, s = 0;
+    for (i = 0; i < n; i++) a[i] = &vla_pool[i];
+    for (i = 0; i < n; i++) s += (int)*a[i];
+    return s;                           /* 0+1+...+(n-1) */
+}
+
+/* Pointer arithmetic and difference within a VLA. */
+static int vla_ptr_diff(int n)
+{
+    int a[n];
+    int *p = a;
+    int *q = a + (n - 1);
+    a[0] = 5;
+    a[n - 1] = 9;
+    return (int)(q - p) + *q - *p;      /* (n-1) + 9 - 5 */
+}
+
+/* A long-typed bound expression cast to int. */
+static int vla_long_bound(int n)
+{
+    long m = (long)n + 1;
+    int a[(int)m];
+    int i, s = 0;
+    for (i = 0; i < (int)m; i++) a[i] = 1;
+    for (i = 0; i < (int)m; i++) s += a[i];
+    return s;                           /* n+1 */
+}
+
+/* A 2-D VLA passed to a callee that indexes it as g[][3]. */
+static int vla_sum2d(int rows, int g[][3])
+{
+    int i, j, s = 0;
+    for (i = 0; i < rows; i++)
+        for (j = 0; j < 3; j++)
+            s += g[i][j];
+    return s;
+}
+static int vla_pass2d(int rows)
+{
+    int grid[rows][3];
+    int i, j;
+    for (i = 0; i < rows; i++)
+        for (j = 0; j < 3; j++)
+            grid[i][j] = i + j;
+    return vla_sum2d(rows, grid);
+}
+
+int main(void)
+{
+    printf("tvla start\n");
+
+    /* 1-D: 0+1+4+9+16 = 30 */
+    check_int("vla_1d(5)", vla_1d(5), 30);
+    /* 0+1+4+...+81 = 285 */
+    check_int("vla_1d(10)", vla_1d(10), 285);
+
+    /* 'a' (97) + buf[4]='e' (101) = 198 */
+    check_int("vla_char(6)", vla_char(6), 198);
+
+    /* rows=2: (0+1+2)+(10+11+12) = 36 */
+    check_int("vla_2d(2)", vla_2d(2), 36);
+    /* rows=4: 3+33+63+93 = 192 */
+    check_int("vla_2d(4)", vla_2d(4), 192);
+
+    /* size = 3*2+1 = 7 ones */
+    check_int("vla_computed(3)", vla_computed(3), 7);
+
+    check_int("vla_paren", vla_parenthesized_bound(4), 17);
+    check_int("vla_leadconst", vla_leading_const_bound(4), 19);
+
+    /* Bound with a subscript: sum 0..(n+1) for n=5 -> 21 */
+    check_int("vla_subscript_bound", vla_subscript_bound(5), 21);
+    /* Bound is a call: 2*n for n=6 -> 12 */
+    check_int("vla_call_bound", vla_call_bound(6), 12);
+    /* Second VLA sized from a subscript of the first VLA:
+     * sum 0..(n+1) plus 1..n for n=5 -> 21 + 15 = 36 */
+    check_int("vla_dependent_bound", vla_dependent_bound(5), 36);
+    /* sizeof n in an array bound is a fixed-size array, not a VLA. */
+    check_int("fixed_sizeof_bounds", fixed_sizeof_bounds(123), 1);
+    /* A cast of a constant bound is a fixed-size array, not a VLA. */
+    check_int("fixed_cast_bounds", fixed_cast_bounds(), 1);
+    /* 3-D VLA (variable outer, constant inner) for n=3 -> 45 */
+    check_int("vla_3d", vla_3d(3), 45);
+
+    /* 3000 iterations must not overflow the stack; last iter (i=2999, odd):
+     * a[7]=(3006)&15=14, a[0]=(2999)&15=7 -> 21 */
+    check_int("vla_in_loop", vla_in_loop(3000, 8), 21);
+
+    /* sum of inner[k] = b[k] = k, for k=0..9 -> 45 */
+    check_int("vla_nested", vla_nested(10), 45);
+
+    /* Forward goto out of a VLA scope must reclaim the allocation. */
+    check_int("vla_goto_out", vla_goto_out(3000, 8), 7);
+
+    /* --- edge cases: distinct frame / control-flow / decay paths --- */
+    check_int("vla_forinit_dep", vla_forinit_dep(5), 15);
+    check_int("vla_fixed_after", vla_fixed_after(6), 92);
+    check_int("vla_big_frame", vla_big_frame(4), 88);
+    check_int("vla_cond_true", vla_cond_sibling(4, 1), 12);
+    check_int("vla_cond_false", vla_cond_sibling(4, 0), 25);
+    check_int("vla_side_bound", vla_side_bound(5), 26);
+    check_int("vla_switch_fall", vla_switch(3, 1), 43);
+    check_int("vla_switch_one", vla_switch(3, 2), 40);
+    check_int("vla_switch_def", vla_switch(3, 9), -1);
+    check_int("vla_return_nested", vla_return_nested(6), 12);
+    check_int("vla_longjmp", vla_longjmp(5), 999);
+    check_int("vla_ptr_elem", vla_ptr_elem(6), 15);
+    check_int("vla_ptr_diff", vla_ptr_diff(4), 7);
+    check_int("vla_long_bound", vla_long_bound(5), 6);
+    check_int("vla_pass2d", vla_pass2d(4), 30);
+
+    printf("checks=%d failures=%d\n", checks, failures);
+    if (failures != 0) {
+        printf("tvla FAIL\n");
+        return 1;
+    }
+    printf("tvla ok\n");
+    return 0;
+}

--- a/tests/tvlax.c
+++ b/tests/tvlax.c
@@ -1,0 +1,209 @@
+/*
+ * tvlax.c - stress test for C99 variable-length arrays, focused on stack
+ * reclamation (no stack-pointer leakage) across loops, recursion, nested
+ * scopes, and goto-out block exits.
+ *
+ * Key idea: the address of a VLA's first element is the stack pointer right
+ * after the block allocates the array.  So capturing (the low bits of)
+ * &a[0] and comparing it across iterations / recursion levels / repeated
+ * calls is a portable, well-defined (pointer-equality only) probe of the
+ * stack pointer:
+ *
+ *   - in a loop, a correctly reclaimed VLA is re-allocated at the SAME
+ *     address every iteration; a leak makes the address drift downward;
+ *   - after a function fully returns, the stack is empty again, so a second
+ *     identical call must place its VLA at the SAME address as the first;
+ *   - a deeper recursion frame must sit at a DIFFERENT (lower) address than
+ *     its caller, and the caller's data must survive the deeper call.
+ *
+ * dcc treats `volatile` as a no-op (source compatibility only), so this test
+ * deliberately avoids relying on it: the address-stability checks work purely
+ * through defined pointer/integer comparisons and hold identically under a
+ * host compiler (clang) and under dcc.  All arithmetic is kept within 16-bit
+ * range so a 16-bit-int target and a 32-bit host agree.  Output is a
+ * deterministic PASS/FAIL summary; the baseline is generated with clang.
+ */
+#include <stdio.h>
+
+static int checks = 0;
+static int failures = 0;
+
+static void ok(const char *name, int cond)
+{
+    checks++;
+    if (!cond) {
+        failures++;
+        printf("FAIL %s\n", name);
+    }
+}
+
+/*
+ * Low bits of a pointer as an unsigned integer.  On the dcc target this is the
+ * full 16-bit pointer; on a 32/64-bit host it is the low 32 bits.  Either way,
+ * equality and inequality of stack addresses are preserved, which is all these
+ * checks rely on.
+ */
+static unsigned addr_of(void *p)
+{
+    return (unsigned)(unsigned long)p;
+}
+
+/* ---- 1. Loop: the VLA base address must not drift across iterations ---- */
+static int loop_stable(int iters, int n)
+{
+    unsigned first = 0;
+    int stable = 1;
+    int i, j, guard = 0;
+
+    for (i = 0; i < iters; i++) {
+        int a[n];
+        for (j = 0; j < n; j++)
+            a[j] = (i + j) & 7;
+        if (i == 0)
+            first = addr_of(&a[0]);
+        else if (addr_of(&a[0]) != first)
+            stable = 0;
+        guard += a[n - 1];
+    }
+    (void)guard;
+    return stable;
+}
+
+/* ---- 2. Recursion: frames distinct, data intact, reclaimed between calls -- */
+static int rec_distinct = 1;
+static int rec_intact = 1;
+
+static unsigned rec_probe(int depth, int n)
+{
+    int a[n];
+    int j;
+    unsigned base = addr_of(&a[0]);
+
+    for (j = 0; j < n; j++)
+        a[j] = (depth * 3 + j) & 255;
+
+    if (depth > 0) {
+        unsigned deeper = rec_probe(depth - 1, n);
+        if (deeper == base)
+            rec_distinct = 0;          /* deeper frame overlapped this one */
+    }
+
+    /* Our own VLA must be untouched by the deeper call. */
+    for (j = 0; j < n; j++)
+        if (a[j] != ((depth * 3 + j) & 255))
+            rec_intact = 0;
+
+    return base;
+}
+
+/* ---- 3. Nested loops: outer and inner VLA bases both stable ---- */
+static int nested_stable(int outer, int inner, int n)
+{
+    unsigned ofirst = 0;
+    unsigned ifirst = 0;
+    int ostable = 1;
+    int istable = 1;
+    int i, k, j, guard = 0;
+
+    for (i = 0; i < outer; i++) {
+        int oa[n];
+        for (j = 0; j < n; j++)
+            oa[j] = (i + j) & 15;
+        if (i == 0)
+            ofirst = addr_of(&oa[0]);
+        else if (addr_of(&oa[0]) != ofirst)
+            ostable = 0;
+
+        for (k = 0; k < inner; k++) {
+            int ia[n];
+            for (j = 0; j < n; j++)
+                ia[j] = (k + j) & 15;
+            if (i == 0 && k == 0)
+                ifirst = addr_of(&ia[0]);
+            else if (addr_of(&ia[0]) != ifirst)
+                istable = 0;
+            guard += ia[n - 1];
+        }
+        guard += oa[n - 1];
+    }
+    (void)guard;
+    return ostable && istable;
+}
+
+/* ---- 4. goto out of a VLA block: base stable across iterations ---- */
+static int goto_stable(int iters, int n)
+{
+    unsigned first = 0;
+    int stable = 1;
+    int i, j, guard = 0;
+
+    for (i = 0; i < iters; i++) {
+        {
+            int a[n];
+            for (j = 0; j < n; j++)
+                a[j] = (i + j) & 15;
+            if (i == 0)
+                first = addr_of(&a[0]);
+            else if (addr_of(&a[0]) != first)
+                stable = 0;
+            guard += a[0];
+            goto next;
+        }
+    next:
+        guard += 1;
+    }
+    (void)guard;
+    return stable;
+}
+
+/* ---- 5. A value check that also depends on correct reclamation ----
+ * If VLAs leaked, deep repeated allocation would eventually corrupt or run
+ * out of stack; keeping a running checksum that must match a known total is a
+ * second, content-based confirmation that every element was addressable. */
+static int checksum_loop(int iters, int n)
+{
+    int i, j, sum = 0;
+    for (i = 0; i < iters; i++) {
+        int a[n];
+        for (j = 0; j < n; j++)
+            a[j] = 1;
+        for (j = 0; j < n; j++)
+            sum = (sum + a[j]) & 0x7fff;
+    }
+    return sum;                        /* iters*n mod 32768 */
+}
+
+int main(void)
+{
+    unsigned c1;
+    unsigned c2;
+
+    printf("tvlax start\n");
+
+    /* 1. loop address stability (SP must not leak over 3000 iterations) */
+    ok("loop base stable", loop_stable(3000, 8));
+
+    /* 2. recursion: two identical top-level calls reclaim to the same base */
+    c1 = rec_probe(20, 8);
+    c2 = rec_probe(20, 8);
+    ok("recursion reclaimed between calls", c1 == c2);
+    ok("recursion frames distinct", rec_distinct);
+    ok("recursion frames intact", rec_intact);
+
+    /* 3. nested loops: both VLA levels stable across all iterations */
+    ok("nested bases stable", nested_stable(40, 40, 6));
+
+    /* 4. goto out of a VLA scope reclaims each iteration */
+    ok("goto-out base stable", goto_stable(3000, 8));
+
+    /* 5. content checksum: 500*4 = 2000 mod 32768 */
+    ok("checksum", checksum_loop(500, 4) == 2000);
+
+    printf("checks=%d failures=%d\n", checks, failures);
+    if (failures != 0) {
+        printf("tvlax FAIL\n");
+        return 1;
+    }
+    printf("tvlax ok\n");
+    return 0;
+}


### PR DESCRIPTION
@davidly 

there is one area I might address tomorrow: "invest in the label-scope pre-pass to make forward-goto fully C99-complete"

otherewise I think between opus and gpt they edge cases have been squashed...

Add runtime-sized automatic arrays to the dcc front end and Z80 codegen, with correct stack allocation, block-scope reclamation, and diagnostics for the unsupported corners of C99 VLA semantics.

Front end / declarations (dcc_decl.c, dcc_expr.c, dcc_constexpr.c)
- Detect a non-constant first array dimension and mark the symbol as a VLA (Symbol.is_vla); the slot holds a runtime pointer to the allocated block rather than inline storage.
- Capture the bound token span at parse time (g_vla_pending / g_vla_dim_*) so the dimension expression can be re-emitted at the declaration site to size and allocate the array on entry to its scope.
- Support the full range of bound-expression forms: parenthesized bounds, leading-constant and computed bounds, nested-bracket bounds (e.g. int b[a[n-1]+2]) via bracket-depth-aware skipping, call and dependent bounds, side-effecting bounds (evaluated exactly once), and long-typed bounds narrowed to int.
- Multi-dimensional VLAs with a runtime outer dimension and constant inner dimensions, including decay-to-pointer and passing a 2-D VLA to a callee.
- Fix parse_const_long_primary so `sizeof n` (no parens) is accepted in a constant array bound.
- Distinguish a cast-of-constant bound `int a[(size_t)8]` from a VLA: the scanner skips leading `(type)` casts via starts_type().

Codegen / stack management (dcc_ast_gen_stmt.c, dcc_func.c, dcc_symbols.c, dcc_state.c)
- Allocate VLA storage by adjusting SP at the declaration site and record a saved-SP slot per scope (vla_scope_ensure_save_slot, emit_vla_save_sp/emit_vla_restore_sp).
- Reclaim VLA frames on every scope exit and non-local flow: loop break/continue, return, and forward goto-out all restore SP to the correct floor depth (emit_vla_restore_for_flow, flow_scope_depth / g_vla_scope_off tracking).
- Integrate with stack-check and correctly unwind SP across setjmp/longjmp.

Diagnostics (rejected rather than miscompiled)
- sizeof applied to a whole VLA is a compile error (previously silently returned pointer size, breaking memset(a,0,sizeof a)); sizeof on a VLA subobject/element is still allowed.
- static storage duration on a VLA is rejected.
- goto into a VLA scope, and goto across different VLA scopes, are rejected.
- case/default labels inside a VLA scope are rejected.

Docs
- Document VLA support and limitations in the C-conformance and types-and-conventions references.

Tests
- tests/tvla.c: 32-check functional regression suite covering 1-D/char/ multi-dim VLAs, computed/parenthesized/dependent/side-effecting/long bounds, loops, nesting, recursion, goto-out, conditional siblings, switch-case blocks, return from nested scope, longjmp unwind, VLA of pointers, pointer arithmetic, and 2-D pass-to-callee.
- tests/tvlax.c: stack-leakage stress test verifying SP is fully reclaimed across loops, recursion, nesting, and goto-out (address-stability probe).
- New diagnostic cases + baselines: vla-goto-into, vla-switch-label, vla-sizeof, vla-static; update variable-length-array and sizeof-constant-expression baselines.
- Test overrides: tvla stack_size 1024, tvlax stack_size 2048.

.gitignore: ignore *.dSYM/ (macOS build artifacts).

Validation: full suite 221 passed / 0 failed; extended suite 161 passed / 0 failed (00207 now passes); all VLA diagnostics pass. tvla/tvlax match their clang baselines with peephole on and off.