### PR TITLE
feat(dcc): complete C99 goto support for variable-length array scopes

### DIFF
--- a/.github/skills/dcc-cpm-z80/SKILL.md
+++ b/.github/skills/dcc-cpm-z80/SKILL.md
@@ -163,10 +163,17 @@ host-sized-int expectations, hosted byte-stream stdio behavior, wide-character
 Unicode library behavior, POSIX services, locale, signal, time, C11 threads, and
 C11 atomics.
 
-Automatic one-dimensional VLAs with a simple identifier bound, such as
-`char buf[n]`, are supported by reserving stack space at runtime. Keep them
-small: heap and stack still share the CP/M transient program area and have no
-guard beyond explicit stack checking.
+Automatic VLAs (local arrays whose **outermost** dimension is a run-time value)
+are supported by reserving stack space when the declaration is reached, e.g.
+`char buf[n]` or `int grid[n][3]` (inner dimensions must be compile-time
+constants). The storage is released at block-scope exit — including each loop
+iteration, `break`, `continue`, `return`, and a `goto` that leaves the scope
+(forward or backward, across nested VLA scopes). Rejected, never miscompiled:
+a variable **inner** dimension (`a[n][m]`), `sizeof` on a **whole** VLA (use
+`sizeof a[0]` times the count), and jumping **into** a VLA scope via `goto`,
+`case`, or `default`. Keep them small: heap and stack still share the CP/M
+transient program area and have no guard beyond explicit stack checking
+(`-fstack-check` bounds-checks each VLA allocation).
 
 **Identifiers:** full internal significance; externals stay distinct well past
 C89's 6-char minimum (verified to ~13 chars), and only ~16+ identical leading

--- a/docs/docs/en/01-c-conformance.md
+++ b/docs/docs/en/01-c-conformance.md
@@ -84,7 +84,7 @@ portability surprises when code is moved from a hosted desktop compiler.
 | Unnamed parameters in prototypes | Supported |
 | Array parameters adjusted to pointers | Supported |
 | C99 array parameter qualifiers: `int a[const 5]`, `int a[static 5]`, `int a[volatile 5]`, `int a[restrict 5]`, `int a[const *]` | Accepted as syntax compatibility; array parameters still decay to pointers |
-| Variable-length arrays (local) | Supported when the only variable dimension is the outermost, with constant inner dimensions (`a[n]`, `a[n][3]`). The array decays to a pointer to stack-allocated storage and is reclaimed at ordinary block-scope exit, including loop iterations, `break`, and `continue` |
+| Variable-length arrays (local) | Supported when the only variable dimension is the outermost, with constant inner dimensions (`a[n]`, `a[n][3]`). The array decays to a pointer to stack-allocated storage and is reclaimed at ordinary block-scope exit, including loop iterations, `break`, `continue`, `return`, and a `goto` that leaves the scope (forward or backward, across any number of nested VLA scopes) |
 | Function-typed parameters adjusted to pointers | Supported |
 | `restrict` qualifier | Accepted as source compatibility; no alias-analysis optimization semantics are provided |
 | Variadic macros and `__VA_ARGS__` | Supported |
@@ -102,7 +102,7 @@ portability surprises when code is moved from a hosted desktop compiler.
 | --- | --- |
 | `long long` and 64-bit integer types | Not supported |
 | Variable-length arrays with a variable inner dimension (`a[n][m]`) | Not supported; the runtime row stride is not modelled (variable outermost dimension is supported, above) |
-| `goto`/`case` entry into VLA scopes | Not supported; jumps that could bypass VLA allocation are rejected |
+| `goto`/`case` entry into VLA scopes | Not supported; a jump that would bypass a VLA's allocation is rejected. Jumps that *leave* VLA scopes — `break`, `continue`, `return`, and forward or backward `goto` — are fully supported and reclaim the stack correctly |
 | `sizeof` applied to a whole VLA | Not supported; the size is not a compile-time constant, so it is rejected rather than silently miscomputed (`sizeof vla[i]` on a constant-size subobject is fine) |
 | `_Complex` and complex arithmetic | Not supported |
 | Full C99 compound literal value semantics | Partly supported only |

--- a/docs/docs/en/03-types-and-conventions.md
+++ b/docs/docs/en/03-types-and-conventions.md
@@ -174,7 +174,10 @@ void f(int n)
   ```
 
 - Reclamation happens on **every** normal exit from the block: fall-through,
-  `break`, `continue`, `return`, and a `goto` that leaves the scope.
+  `break`, `continue`, `return`, and a `goto` that leaves the scope. A `goto`
+  out of one or more VLA scopes is fully supported in **both** directions
+  (forward and backward) and restores the stack to exactly the target label's
+  scope, even when it leaves several nested VLA scopes at once.
 - Recursion works: each call frame gets its own VLA and releases it on return.
 - With `-fstack-check`, the run-time allocation is bounds-checked, so an
   oversized VLA aborts gracefully instead of colliding with the heap. VLAs draw
@@ -198,7 +201,8 @@ void f(int n)
   ```
 
 - Jumping **into** a VLA's scope with `goto`, `case`, or `default` (which would
-  bypass the allocation) is rejected, matching a conforming compiler.
+  bypass the allocation) is rejected, matching a conforming compiler. (Jumping
+  *out of* a VLA scope is fine and reclaims the stack — see above.)
 - Variably-modified **types** beyond the array object itself — VLA `typedef`s,
   pointers-to-VLA (`int (*p)[n]`), and run-time-bound VLA function parameters —
   are not modelled.

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -452,6 +452,11 @@ int vla_active_scope_depth(void);
 void emit_vla_save_sp(int off);
 void emit_vla_restore_sp(int off);
 void emit_vla_restore_for_flow(int floor_depth);
+int  vla_record_fwd_goto(int label_index, int line);
+void vla_resolve_fwd_gotos(int label_index, int real_id);
+void vla_snapshot_user_label(int label_index);
+int  vla_jump_enters_label_scope(int label_index);
+void emit_vla_restore_to_label_scope(int label_index);
 struct Sym *find_local_decl(const char *name);
 
 extern int errors;
@@ -492,9 +497,11 @@ extern char ulabel_names[MAX_USER_LABELS][64];
 extern int  ulabel_ids[MAX_USER_LABELS];
 extern int  ulabel_defined[MAX_USER_LABELS];
 extern int  ulabel_referenced[MAX_USER_LABELS];
-extern int  ulabel_vla_depth[MAX_USER_LABELS];
-extern int  ulabel_ref_vla_depth[MAX_USER_LABELS];
-extern int  ulabel_ref_vla_restored[MAX_USER_LABELS];
+extern int  ulabel_vla_snap_depth[MAX_USER_LABELS];
+extern int  ulabel_vla_snap_off[MAX_USER_LABELS][MAX_SCOPE_DEPTH];
+/* A forward goto issued from OUTSIDE every VLA scope: if the label turns out to
+ * be inside a VLA scope, that jump enters the scope of a VLA and is rejected. */
+extern int  ulabel_shallow_fwd_ref[MAX_USER_LABELS];
 extern int  nulabels;
 
 /* enum constants (file-scoped) */
@@ -538,6 +545,24 @@ extern struct Token g_vla_dim_tok;
  * loop/switch entry so break/continue can reclaim the VLAs allocated inside. */
 extern int g_vla_scope_off[MAX_SCOPE_DEPTH];
 extern int flow_scope_depth[MAX_FLOW];
+
+/* C99 forward-goto VLA fixups.  A forward goto issued from within a VLA scope
+ * cannot know its target label's scope until the label is emitted later, so the
+ * jump is routed to a per-goto fixup stub.  Each pending entry snapshots the
+ * goto's active VLA save-slot offsets (offsets uniquely identify a scope
+ * instance); when the target label is reached, vla_resolve_fwd_gotos() emits
+ * each stub, restoring SP to reclaim exactly the VLA scopes the goto leaves and
+ * rejecting jumps that would enter a VLA scope. */
+#define MAX_VLA_FWD_GOTOS MAX_LOCALS
+struct VlaFwdGoto {
+    int label_index;                 /* target label (index into ulabel_*)   */
+    int fixup_id;                    /* stub label the goto jumps to          */
+    int snap_depth;                  /* g_scope_depth at the goto             */
+    int snap_off[MAX_SCOPE_DEPTH];   /* g_vla_scope_off snapshot at the goto  */
+    int line;                        /* goto source line, for diagnostics     */
+};
+extern struct VlaFwdGoto g_vla_fwd_gotos[MAX_VLA_FWD_GOTOS];
+extern int g_vla_fwd_ngoto;
 
 /* ------------------------------------------------------------------------- *
  * Cross-module function prototypes, grouped by owning module. (Generated to

--- a/src/dcc/dcc_ast_gen_stmt.c
+++ b/src/dcc/dcc_ast_gen_stmt.c
@@ -816,41 +816,38 @@ void ast_gen_stmt(const struct AstNode *n)
             ulabel_referenced[li] = 1;
             active_depth = vla_active_scope_depth();
             if (ulabel_defined[li]) {
-                if (ulabel_vla_depth[li] > g_scope_depth) {
+                /* Backward goto: the label's scope is already known. */
+                if (vla_jump_enters_label_scope(li)) {
                     error_here("goto into a variable-length array scope is not supported");
-                } else if (active_depth != 0 && ulabel_vla_depth[li] < g_scope_depth) {
-                    emit_vla_restore_for_flow(ulabel_vla_depth[li]);
+                } else if (active_depth != 0) {
+                    emit_vla_restore_to_label_scope(li);
                 }
+                emit_jp_label("jp", ulabel_ids[li]);
             } else if (active_depth != 0) {
-                if (ulabel_ref_vla_depth[li] != 0 &&
-                    ulabel_ref_vla_depth[li] != g_scope_depth)
-                    error_here("goto across different variable-length array scopes is not supported");
-                ulabel_ref_vla_depth[li] = g_scope_depth;
+                /* Forward goto from within a VLA scope: the target label has not
+                 * been emitted yet, so route the jump through a deferred fixup
+                 * stub that vla_resolve_fwd_gotos() completes once the label's
+                 * own scope (and hence the exact SP to restore) is known. */
+                int fixup = vla_record_fwd_goto(li, n->line);
+                emit_jp_label("jp", fixup);
+            } else {
+                /* Forward goto from outside every VLA scope.  Nothing to
+                 * reclaim; if the label proves to be inside a VLA scope the
+                 * label site rejects it as a jump into that scope. */
+                ulabel_shallow_fwd_ref[li] = 1;
+                emit_jp_label("jp", ulabel_ids[li]);
             }
-            if (active_depth != 0 && !ulabel_defined[li]) {
-                /* One-pass codegen cannot know whether an unresolved forward label
-                 * will be inside this same VLA scope or outside it.  Emit the
-                 * safe form: restore now so forward goto-out is correct; if the
-                 * label later proves to be inside a VLA scope, diagnose it. */
-                emit_vla_restore_for_flow(0);
-                ulabel_ref_vla_restored[li] = 1;
-            }
-            emit_jp_label("jp", ulabel_ids[li]);
         }
         break;
     case AST_LABEL:
         {
             int li;
             li = find_or_alloc_user_label_index(n->sval);
-            if (vla_active_scope_depth() != 0 && ulabel_referenced[li] &&
-                ulabel_ref_vla_depth[li] != g_scope_depth)
+            if (vla_active_scope_depth() != 0 && ulabel_shallow_fwd_ref[li])
                 error_here("goto into a variable-length array scope is not supported");
-            if (vla_active_scope_depth() != 0 && ulabel_ref_vla_restored[li])
-                error_here("forward goto within a variable-length array scope is not supported");
-            if (vla_active_scope_depth() == 0 && ulabel_ref_vla_depth[li] != 0) {
-                ulabel_ref_vla_depth[li] = 0;
-                ulabel_ref_vla_restored[li] = 0;
-            }
+            /* Emit any deferred forward-goto fixup stubs before the real label
+             * (they jump to it and fall-through is guarded). */
+            vla_resolve_fwd_gotos(li, ulabel_ids[li]);
             emit_label(define_user_label(n->sval));
         }
         ast_gen_stmt(n->b);

--- a/src/dcc/dcc_expr.c
+++ b/src/dcc/dcc_expr.c
@@ -972,9 +972,9 @@ int find_or_alloc_user_label_index(const char *name)
     ulabel_ids[nulabels] = new_label();
     ulabel_defined[nulabels] = 0;
     ulabel_referenced[nulabels] = 0;
-    ulabel_vla_depth[nulabels] = 0;
-    ulabel_ref_vla_depth[nulabels] = 0;
-    ulabel_ref_vla_restored[nulabels] = 0;
+    ulabel_vla_snap_depth[nulabels] = 0;
+    memset(ulabel_vla_snap_off[nulabels], 0, sizeof(ulabel_vla_snap_off[nulabels]));
+    ulabel_shallow_fwd_ref[nulabels] = 0;
     return nulabels++;
 }
 
@@ -995,7 +995,7 @@ int define_user_label(const char *name)
     if (ulabel_defined[i])
         error_here("duplicate goto label");
     ulabel_defined[i] = 1;
-    ulabel_vla_depth[i] = g_scope_depth;
+    vla_snapshot_user_label(i);
     return ulabel_ids[i];
 }
 

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -1835,6 +1835,7 @@ void scan_function_body(void)
     g_scope_depth = 0;
     g_compound_literal_seq = 0;
     g_licm_seq = 0;
+    g_vla_fwd_ngoto = 0;
 
     expect('{');
     enter_scope();              /* function body block */

--- a/src/dcc/dcc_state.c
+++ b/src/dcc/dcc_state.c
@@ -168,9 +168,9 @@ char ulabel_names[MAX_USER_LABELS][64];
 int  ulabel_ids[MAX_USER_LABELS];
 int  ulabel_defined[MAX_USER_LABELS];
 int  ulabel_referenced[MAX_USER_LABELS];
-int  ulabel_vla_depth[MAX_USER_LABELS];
-int  ulabel_ref_vla_depth[MAX_USER_LABELS];
-int  ulabel_ref_vla_restored[MAX_USER_LABELS];
+int  ulabel_vla_snap_depth[MAX_USER_LABELS];
+int  ulabel_vla_snap_off[MAX_USER_LABELS][MAX_SCOPE_DEPTH];
+int  ulabel_shallow_fwd_ref[MAX_USER_LABELS];
 int  nulabels;
 
 /* Enum constants (file-scoped) */
@@ -206,3 +206,5 @@ int g_vla_dim_tok_line;
 struct Token g_vla_dim_tok;
 int g_vla_scope_off[MAX_SCOPE_DEPTH];
 int flow_scope_depth[MAX_FLOW];
+struct VlaFwdGoto g_vla_fwd_gotos[MAX_VLA_FWD_GOTOS];
+int g_vla_fwd_ngoto;

--- a/src/dcc/dcc_stmt.c
+++ b/src/dcc/dcc_stmt.c
@@ -41,10 +41,11 @@ void gen_compound(void)
 {
     int dead;
 
+    /* Forward-goto VLA fixups are function-scoped; start each body run clean. */
+    g_vla_fwd_ngoto = 0;
     expect('{');
     enter_scope();
     dead = 0;
-
     while (tok.kind != TOK_EOF && tok.kind != '}') {
         if (tok.kind == TOK_TYPEDEF) {
             parse_typedef_decl();

--- a/src/dcc/dcc_symbols.c
+++ b/src/dcc/dcc_symbols.c
@@ -202,6 +202,185 @@ void emit_vla_restore_for_flow(int floor_depth)
     }
 }
 
+/*
+ * Record a forward goto issued from within a VLA scope.  Single-pass codegen
+ * cannot yet know whether the (not-yet-emitted) target label sits inside the
+ * same VLA scopes, an enclosing one, or outside them all, so the exact SP to
+ * restore is unknown here.  Snapshot the goto's active VLA save-slot offsets
+ * and hand back a fresh stub label id; the caller jumps there, and
+ * vla_resolve_fwd_gotos() later emits the stub once the label's scope is known.
+ * Returns the stub label id (a fresh label even on overflow so the emitted jump
+ * is still well-formed).
+ */
+int vla_record_fwd_goto(int label_index, int line)
+{
+    struct VlaFwdGoto *g;
+    int fixup;
+    int d, i, same;
+
+    /* Reuse an existing pending stub when another goto already targets this
+     * label with the identical active-VLA snapshot: same target and same
+     * scope offsets mean identical reclaim, so one shared stub suffices (and
+     * a fresh label is not consumed). */
+    for (i = 0; i < g_vla_fwd_ngoto; ++i) {
+        g = &g_vla_fwd_gotos[i];
+        if (g->label_index != label_index || g->snap_depth != g_scope_depth)
+            continue;
+        same = 1;
+        for (d = 0; d < MAX_SCOPE_DEPTH; ++d) {
+            int off = (d <= g_scope_depth) ? g_vla_scope_off[d] : 0;
+            if (g->snap_off[d] != off) { same = 0; break; }
+        }
+        if (same)
+            return g->fixup_id;
+    }
+
+    fixup = new_label();
+    if (g_vla_fwd_ngoto >= MAX_VLA_FWD_GOTOS) {
+        if (asm_suppress_depth == 0)
+            fatal("too many forward gotos out of variable-length array scopes");
+        return fixup;
+    }
+    g = &g_vla_fwd_gotos[g_vla_fwd_ngoto++];
+    g->label_index = label_index;
+    g->fixup_id = fixup;
+    g->line = line;
+    g->snap_depth = g_scope_depth;
+    for (d = 0; d < MAX_SCOPE_DEPTH; ++d)
+        g->snap_off[d] = (d <= g_scope_depth) ? g_vla_scope_off[d] : 0;
+    return fixup;
+}
+
+/* Is frame-slot offset `off` one of the VLA scopes currently active (i.e. an
+ * enclosing scope of the point being emitted)?  Offsets are monotonic and never
+ * reused, so a matching offset means the very same scope instance. */
+static int vla_off_active_now(int off)
+{
+    int d;
+    if (off == 0)
+        return 0;
+    for (d = 1; d <= g_scope_depth && d < MAX_SCOPE_DEPTH; ++d)
+        if (g_vla_scope_off[d] == off)
+            return 1;
+    return 0;
+}
+
+static int vla_off_in_label_scope(int label_index, int off)
+{
+    int d;
+    if (off == 0)
+        return 0;
+    for (d = 1; d <= ulabel_vla_snap_depth[label_index] && d < MAX_SCOPE_DEPTH; ++d)
+        if (ulabel_vla_snap_off[label_index][d] == off)
+            return 1;
+    return 0;
+}
+
+void vla_snapshot_user_label(int label_index)
+{
+    int d;
+    if (label_index < 0 || label_index >= MAX_USER_LABELS)
+        return;
+    ulabel_vla_snap_depth[label_index] = g_scope_depth;
+    for (d = 0; d < MAX_SCOPE_DEPTH; ++d)
+        ulabel_vla_snap_off[label_index][d] = (d <= g_scope_depth) ? g_vla_scope_off[d] : 0;
+}
+
+int vla_jump_enters_label_scope(int label_index)
+{
+    int d;
+    if (label_index < 0 || label_index >= MAX_USER_LABELS)
+        return 0;
+    for (d = 1; d <= ulabel_vla_snap_depth[label_index] && d < MAX_SCOPE_DEPTH; ++d) {
+        int off = ulabel_vla_snap_off[label_index][d];
+        if (off != 0 && !vla_off_active_now(off))
+            return 1;
+    }
+    return 0;
+}
+
+void emit_vla_restore_to_label_scope(int label_index)
+{
+    int d;
+    if (label_index < 0 || label_index >= MAX_USER_LABELS)
+        return;
+    for (d = 1; d <= g_scope_depth && d < MAX_SCOPE_DEPTH; ++d) {
+        int off = g_vla_scope_off[d];
+        if (off != 0 && !vla_off_in_label_scope(label_index, off)) {
+            emit_vla_restore_sp(off);
+            return;
+        }
+    }
+}
+
+/*
+ * Emit the deferred SP-fixup stubs for every forward goto that targeted this
+ * label from inside a VLA scope, now that the label's own scope is known.  For
+ * each such goto: verify the C99 constraint that the jump does not enter the
+ * scope of a VLA (every VLA scope still active at the label must also have been
+ * active at the goto), then restore SP to reclaim exactly the VLA scopes the
+ * goto is leaving before jumping to the real label.  Emits nothing when no
+ * forward goto targeted this label.  Must be called just before the real label
+ * is emitted; `real_id` is that label's id.
+ */
+void vla_resolve_fwd_gotos(int label_index, int real_id)
+{
+    int i, d, k;
+    int any;
+    int bad;
+
+    any = 0;
+    for (i = 0; i < g_vla_fwd_ngoto; ++i)
+        if (g_vla_fwd_gotos[i].label_index == label_index) { any = 1; break; }
+    if (!any)
+        return;
+
+    /* Fall-through from the preceding statement must land on the real label,
+     * not run into the stubs that sit just above it. */
+    emit_jp_label("jp", real_id);
+
+    for (i = 0; i < g_vla_fwd_ngoto; ++i) {
+        struct VlaFwdGoto *g = &g_vla_fwd_gotos[i];
+        if (g->label_index != label_index)
+            continue;
+
+        /* Jump-into check: each VLA scope active at the label must be one that
+         * was also active at the goto (same frame slot). */
+        bad = 0;
+        for (d = 1; d <= g_scope_depth && d < MAX_SCOPE_DEPTH; ++d) {
+            int off = g_vla_scope_off[d];
+            int seen = 0;
+            if (off == 0)
+                continue;
+            for (k = 1; k <= g->snap_depth && k < MAX_SCOPE_DEPTH; ++k)
+                if (g->snap_off[k] == off) { seen = 1; break; }
+            if (!seen) {
+                dcc_error_at(tok.file[0] ? tok.file :
+                                 (input_name ? input_name : "<input>"),
+                             g->line, -1,
+                             "goto into a variable-length array scope is not supported",
+                             NULL);
+                bad = 1;
+                break;
+            }
+        }
+        if (bad)
+            continue;
+
+        emit_label(g->fixup_id);
+        /* Reclaim the goto's inner VLA scopes the label is not within: restore
+         * the outermost such slot (which reclaims it and every deeper scope). */
+        for (k = 1; k <= g->snap_depth && k < MAX_SCOPE_DEPTH; ++k) {
+            int off = g->snap_off[k];
+            if (off != 0 && !vla_off_active_now(off)) {
+                emit_vla_restore_sp(off);
+                break;
+            }
+        }
+        emit_jp_label("jp", real_id);
+    }
+}
+
 void leave_scope(void)
 {
     if (g_scope_depth <= 0)

--- a/tests/baselines/tvla.txt
+++ b/tests/baselines/tvla.txt
@@ -1,3 +1,3 @@
 tvla start
-checks=32 failures=0
+checks=37 failures=0
 tvla ok

--- a/tests/diagnostics/baselines/vla-goto-backward-into.txt
+++ b/tests/diagnostics/baselines/vla-goto-backward-into.txt
@@ -1,0 +1,4 @@
+<source>:13: error DCC-E0001: goto into a variable-length array scope is not supported near 'return'
+        return 0;
+        ^
+dcc: 1 error(s)

--- a/tests/diagnostics/vla-goto-backward-into.c
+++ b/tests/diagnostics/vla-goto-backward-into.c
@@ -1,0 +1,14 @@
+int f(int n)
+{
+    {
+        int a[n];
+inside:
+        a[0] = 1;
+    }
+    {
+        int b[n];
+        b[0] = 2;
+        goto inside;
+    }
+    return 0;
+}

--- a/tests/tvla.c
+++ b/tests/tvla.c
@@ -398,6 +398,100 @@ static int vla_pass2d(int rows)
     return vla_sum2d(rows, grid);
 }
 
+/* Forward goto whose target label is in the SAME VLA scope (no SP change). */
+static int vla_fwd_same(int n)
+{
+    int a[n];
+    int i, s = 0;
+    for (i = 0; i < n; i++)
+        a[i] = i;
+    if (a[0] == 0)
+        goto here;
+    s += 999;
+here:
+    for (i = 0; i < n; i++)
+        s += a[i];
+    return s;                     /* 0+1+2+3+4 = 10 for n=5 */
+}
+
+/* Forward goto that exits an inner VLA scope but stays inside an outer VLA
+ * scope; the outer VLA must remain valid after the jump. */
+static int vla_fwd_exit_inner(int n)
+{
+    int a[n];
+    int i, s = 0;
+    for (i = 0; i < n; i++)
+        a[i] = 1;
+    {
+        int b[n * 2];
+        for (i = 0; i < n * 2; i++)
+            b[i] = 2;
+        if (b[0] == 2)
+            goto done;            /* reclaim b, keep a */
+        s += 555;
+    }
+done:
+    for (i = 0; i < n; i++)
+        s += a[i];
+    return s;                     /* n for n>0 */
+}
+
+/* Forward goto that exits every VLA scope, landing on a non-VLA label. */
+static int vla_fwd_exit_all(int n)
+{
+    int s = 0;
+    {
+        int a[n];
+        int i;
+        for (i = 0; i < n; i++)
+            a[i] = 3;
+        if (a[0] == 3)
+            goto out;
+        s += 1;
+    }
+out:
+    return s + 7;                 /* 7 */
+}
+
+/* Forward goto inside a loop, jumping over work but staying in the VLA scope;
+ * the loop then reclaims and re-allocates the VLA each iteration. */
+static int vla_fwd_in_loop(int n)
+{
+    int i, s = 0;
+    for (i = 0; i < n; i++) {
+        int a[n];
+        int j;
+        for (j = 0; j < n; j++)
+            a[j] = j;
+        if (a[0] == 0)
+            goto skip;
+        s += 100;
+    skip:
+        s += a[i];
+    }
+    return s;                     /* 0+1+2+3+4 = 10 for n=5 */
+}
+
+/* Backward goto that exits an inner VLA scope while staying inside an outer VLA
+ * scope; the inner VLA must be reclaimed on every backward jump so SP does not
+ * leak, and the outer VLA must stay valid across the jumps. */
+static int vla_back_exit_inner(int iters, int n)
+{
+    int a[n];
+    int i = 0, s = 0;
+    a[0] = 7;
+again:
+    {
+        int b[n];
+        b[0] = i;
+        s = a[0] + (b[0] & 15);   /* a survives the backward jump */
+        i++;
+        if (i < iters)
+            goto again;           /* reclaim b, back into a's scope */
+    }
+    return s;                     /* i=2999 -> 7 + (2999&15) = 14 */
+}
+
 int main(void)
 {
     printf("tvla start\n");
@@ -461,6 +555,12 @@ int main(void)
     check_int("vla_ptr_diff", vla_ptr_diff(4), 7);
     check_int("vla_long_bound", vla_long_bound(5), 6);
     check_int("vla_pass2d", vla_pass2d(4), 30);
+
+    check_int("vla_fwd_same", vla_fwd_same(5), 10);
+    check_int("vla_fwd_exit_inner", vla_fwd_exit_inner(4), 4);
+    check_int("vla_fwd_exit_all", vla_fwd_exit_all(3), 7);
+    check_int("vla_fwd_in_loop", vla_fwd_in_loop(5), 10);
+    check_int("vla_back_exit_inner", vla_back_exit_inner(3000, 8), 14);
 
     printf("checks=%d failures=%d\n", checks, failures);
     if (failures != 0) {


### PR DESCRIPTION
@davidly 
Make forward goto fully C99-complete for functions using VLAs, and fix a related scope-identity hole in the backward-goto path, so a goto may leave VLA scopes (in either direction, across any nesting) while jumps that would enter a VLA scope are still rejected.

Background
----------
The prior VLA support reclaimed the stack on ordinary block exit, break, continue, return, and backward goto, but conservatively rejected forward goto issued from within a VLA scope: single-pass codegen cannot know the target label's scope (and therefore the exact SP to restore) at the goto site. The backward path, meanwhile, compared only the numeric block-scope depth, which could not distinguish two different VLA scope instances at the same depth.

Forward goto (deferred fixup stubs)
-----------------------------------
A forward goto from inside a VLA scope now records a pending fixup: it snapshots the goto's active VLA save-slot offsets and jumps to a per-goto stub label (vla_record_fwd_goto). When the target label is reached, the label site emits each stub (vla_resolve_fwd_gotos), restoring SP to reclaim exactly the VLA scopes the goto leaves, then jumping to the real label; fall-through is guarded so it lands on the real label rather than running into the stubs. A jump that would enter a VLA scope active at the label but not at the goto is diagnosed. Identical (same label, same scope snapshot) forward gotos share one stub, so straight-line code with many `goto`s does not exhaust the table.

Scope identity via frame offsets
--------------------------------
Both directions now key off the hidden #vlasp save-slot offset of each scope. Offsets are monotonic and never reused, so a matching offset denotes the very same scope instance -- exact identity, not just equal depth. Labels snapshot their active VLA scope offsets at definition (vla_snapshot_user_label); backward gotos use vla_jump_enters_label_scope / emit_vla_restore_to_label_scope to reject true jump-into cases and restore SP to the label's scope otherwise. This fixes a case where a backward goto into a previous sibling VLA scope was silently accepted and failed only at link time.

Diagnostics remain single-pass-safe: the jump-into error is gated by asm_suppress_depth, so it fires once during real codegen and not during the frame-sizing scans.

Implementation
--------------
- src/dcc/dcc.h, dcc_state.c: add the pending-forward-goto table (VlaFwdGoto, g_vla_fwd_gotos, MAX_VLA_FWD_GOTOS = MAX_LOCALS) and per-label VLA scope snapshots (ulabel_vla_snap_depth/off); add ulabel_shallow_fwd_ref; remove the now-dead ulabel_vla_depth / ulabel_ref_vla_depth / ulabel_ref_vla_restored state.
- src/dcc/dcc_symbols.c: vla_record_fwd_goto, vla_resolve_fwd_gotos, vla_snapshot_user_label, vla_jump_enters_label_scope, emit_vla_restore_to_label_scope, and offset-membership helpers.
- src/dcc/dcc_ast_gen_stmt.c: rewrite AST_GOTO/AST_LABEL to use the fixup mechanism (forward, in-VLA), the shallow-forward-ref check (forward, out of all VLAs), and offset-based backward handling.
- src/dcc/dcc_expr.c: initialize/snapshot the new label state in find_or_alloc_user_label_index / define_user_label.
- src/dcc/dcc_stmt.c, dcc_func.c: reset g_vla_fwd_ngoto at gen_compound and scan_function_body entry so the table is function-scoped.

Tests
-----
- tests/tvla.c (+baseline): add functional regressions -- forward goto in the same VLA scope, exiting an inner VLA into an outer one, exiting all VLAs to a plain label, forward goto inside a loop, and a 3000-iteration backward goto that exits an inner VLA each pass to detect SP leaks.
- tests/diagnostics/vla-goto-backward-into.c (+baseline): reject a backward goto into a previous sibling VLA scope.

Docs
----
- docs 01-c-conformance.md, 03-types-and-conventions.md: state that goto leaving a VLA scope (forward or backward, across nested scopes) is supported and reclaims the stack, while only jumps into a VLA scope are rejected.
- .github/skills/dcc-cpm-z80/SKILL.md: replace the "1-D VLA only" note with an accurate summary (outermost-variable dimension, block-scope reclamation across loops/break/continue/return/goto-out, and the rejected cases).

Validation: full suite 221/0, extended 161/0, VLA diagnostics pass; forward and backward goto cases match clang with peephole on and off.