### PR TITLE
feat(dcc): support higher-rank VLA pointer indexing

### DIFF
--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -111,6 +111,19 @@
 #define MAX_ENUM_CONSTS 512
 #define MAX_INCLUDE_DIRS 32
 
+/*
+ * Maximum number of array dimensions for a single object (array rank), and the
+ * maximum subscript depth when indexing.  C99/C11 5.2.4.1 "Translation limits"
+ * requires a conforming implementation to support at least 12 pointer, array,
+ * and function declarators in any combination modifying one type, so array rank
+ * is capped at 12.  Indexing a pointer-to-array adds one subscript level beyond
+ * the pointed-to array's rank, so index/dereference-chain buffers are sized one
+ * larger.
+ */
+#define MAX_ARRAY_DIMS 12
+#define MAX_INDEX_DEPTH (MAX_ARRAY_DIMS + 1)
+
+
 /* ------------------------------------------------------------------------- *
  * Type-kind bit encoding. A "type" is an int: low bits select the base kind,
  * high bits are flags (pointer levels, unsignedness, struct). STRUCT_SHIFT
@@ -236,7 +249,7 @@ struct Sym {
     int array_len;
     int elem_size; /* stride per first-dimension element */
     int dim_count; /* C array dimensions, e.g. a[2][3] -> 2 */
-    int dims[8];   /* dims[0] may be 0 until inferred for a[][N] */
+    int dims[MAX_ARRAY_DIMS];   /* dims[0] may be 0 until inferred for a[][N] */
     int needs_extrn; /* 1 = symbol has external linkage and may need EXTRN if referenced */
     int is_defined;  /* 1 = this translation unit emits storage/PUBLIC for the symbol */
     int is_static;   /* file-scope static: internal linkage, mangle and do not PUBLIC */
@@ -524,10 +537,10 @@ extern int g_proto_types[MAX_PROTO_PARAMS];
 extern int g_funcptr_decl_array_len;
 extern int g_funcptr_is_funcret_decl;
 extern int g_ptr_array_dim_count;
-extern int g_ptr_array_dims[8];
+extern int g_ptr_array_dims[MAX_ARRAY_DIMS];
 extern int g_ptr_array_elem_size;
 extern int g_last_array_dim_count;
-extern int g_last_array_dims[8];
+extern int g_last_array_dims[MAX_ARRAY_DIMS];
 
 /* C99 VLA: parse_array_declarator_dims() captures the first-dimension size
  * expression here when it is not a constant, so the local-declaration codegen

--- a/src/dcc/dcc_ast_gen.c
+++ b/src/dcc/dcc_ast_gen.c
@@ -638,7 +638,7 @@ int ast_index_symbol_nd_collect(const struct AstNode *n, struct Sym **out_sym,
                                        const struct AstNode **idxs, int *out_count)
 {
     const struct AstNode *cur;
-    const struct AstNode *rev[8];
+    const struct AstNode *rev[MAX_INDEX_DEPTH];
     struct Sym *s;
     int count;
     int i;
@@ -646,7 +646,7 @@ int ast_index_symbol_nd_collect(const struct AstNode *n, struct Sym **out_sym,
     cur = n;
     count = 0;
     while (cur != NULL && cur->kind == AST_INDEX) {
-        if (count >= 8 || cur->b == NULL)
+        if (count >= MAX_INDEX_DEPTH || cur->b == NULL)
             return 0;
         rev[count++] = cur->b;
         cur = cur->a;
@@ -675,7 +675,7 @@ int ast_index_symbol_nd_collect(const struct AstNode *n, struct Sym **out_sym,
 
 int ast_index_symbol_nd_elem_type(const struct AstNode *n, int *out_type)
 {
-    const struct AstNode *idxs[8];
+    const struct AstNode *idxs[MAX_INDEX_DEPTH];
     struct Sym *s;
     int count;
 
@@ -698,7 +698,7 @@ int ast_index_deref_pointer_array_collect(const struct AstNode *n,
                                                  int *out_count,
                                                  int *out_type)
 {
-    const struct AstNode *rev[8];
+    const struct AstNode *rev[MAX_INDEX_DEPTH];
     const struct AstNode *root;
     const struct AstNode *base;
     struct Sym *s;
@@ -711,7 +711,7 @@ int ast_index_deref_pointer_array_collect(const struct AstNode *n,
     count = 0;
     root = n;
     while (root != NULL && root->kind == AST_INDEX) {
-        if (count >= 8 || root->b == NULL)
+        if (count >= MAX_INDEX_DEPTH || root->b == NULL)
             return 0;
         rev[count++] = root->b;
         root = root->a;
@@ -734,6 +734,132 @@ int ast_index_deref_pointer_array_collect(const struct AstNode *n,
         if (!ast_index_subscript_supported(rev[count - 1 - i]))
             return 0;
     }
+    if (out_sym != NULL)
+        *out_sym = s;
+    if (out_base != NULL)
+        *out_base = base;
+    if (out_count != NULL)
+        *out_count = count;
+    if (out_type != NULL)
+        *out_type = elem;
+    return 1;
+}
+
+/* Is `n` a bare identifier naming a pointer-to-array local/param (the base of
+ * a dereference chain)?  A pointer with one or more array dimensions
+ * (dim_count > 0) such as `int (*p)[3]` or `int (*p)[2][3]`. */
+static int ast_is_pointer_array_ident(const struct AstNode *n)
+{
+    struct Sym *s;
+
+    if (n == NULL || n->kind != AST_IDENT)
+        return 0;
+    s = find_sym(n->sval);
+    if (s == NULL || s->is_const_value || s->storage == SC_FUNC || s->is_array)
+        return 0;
+    return type_ptr_depth(s->type) > 0 && s->dim_count > 0;
+}
+
+/* Recognise an explicit pointer-to-array dereference chain that is the exact
+ * desugaring of a multidimensional subscript on a pointer-to-array:
+ *
+ *     *(*(p + i) + j)          <=> p[i][j]        (p is int (*)[C])
+ *     *(*(*(p + i) + j) + k)   <=> p[i][j][k]     (p is int (*)[B][C])
+ *
+ * Each `*( PTR + INDEX )` layer strips one dimension; the innermost PTR is the
+ * base pointer identifier and every outer PTR is the next inner layer.  A chain
+ * of `count` layers indexes a pointer whose element has `count - 1` array
+ * dimensions (the final `*` loads the scalar element).  Indices are returned in
+ * first-dimension-first order in idxs[] (caller supplies room for DCC_MAX_DEREF
+ * _CHAIN entries).  Declining (0) is always safe: the caller falls back to
+ * generic per-layer codegen. */
+int ast_deref_pointer_array_chain_collect(const struct AstNode *n,
+                                                 struct Sym **out_sym,
+                                                 const struct AstNode **out_base,
+                                                 const struct AstNode **idxs,
+                                                 int *out_count,
+                                                 int *out_type)
+{
+    const struct AstNode *rev[DCC_MAX_DEREF_CHAIN];
+    const struct AstNode *cur;
+    const struct AstNode *base;
+    struct Sym *s;
+    int count;
+    int elem;
+    int i;
+
+    count = 0;
+    base = NULL;
+    cur = n;
+
+    /* Peel `*( PTR + INDEX )` layers from the outside in. */
+    for (;;) {
+        const struct AstNode *add;
+        const struct AstNode *ptr_side;
+        const struct AstNode *idx_side;
+
+        if (cur == NULL || cur->kind != AST_UNARY || cur->op != '*' || cur->a == NULL)
+            return 0;
+        add = cur->a;
+        if (add->kind != AST_BINARY || add->op != '+' ||
+            add->a == NULL || add->b == NULL)
+            return 0;
+
+        /* The pointer operand is either the next inner deref layer (an
+         * AST_UNARY '*') or, at the innermost level, the base pointer-to-array
+         * identifier; the other operand is the subscript. */
+        if (add->a->kind == AST_UNARY && add->a->op == '*') {
+            ptr_side = add->a;
+            idx_side = add->b;
+        } else if (add->b->kind == AST_UNARY && add->b->op == '*') {
+            ptr_side = add->b;
+            idx_side = add->a;
+        } else if (ast_is_pointer_array_ident(add->a)) {
+            ptr_side = add->a;
+            idx_side = add->b;
+        } else if (ast_is_pointer_array_ident(add->b)) {
+            ptr_side = add->b;
+            idx_side = add->a;
+        } else {
+            return 0;
+        }
+
+        if (count >= DCC_MAX_DEREF_CHAIN)
+            return 0;
+        rev[count++] = idx_side;
+
+        if (ptr_side->kind == AST_IDENT) {
+            base = ptr_side;
+            break;
+        }
+        cur = ptr_side;
+    }
+
+    /* A single `*(p + i)` layer is an ordinary pointer read handled elsewhere;
+     * only genuine multidimensional chains (>= 2 layers) are claimed here. */
+    if (count < 2 || base == NULL)
+        return 0;
+
+    s = find_sym(base->sval);
+    if (s == NULL || s->is_const_value || s->storage == SC_FUNC || s->is_array)
+        return 0;
+    if (type_ptr_depth(s->type) <= 0 || s->dim_count != count - 1)
+        return 0;
+
+    elem = type_decay_ptr(s->type);
+    if ((elem & 15) == TYPE_VOID || type_size(elem) <= 0)
+        return 0;
+
+    /* rev[] holds indices outermost-first (last dimension first); reverse to
+     * first-dimension-first order and validate each subscript. */
+    for (i = 0; i < count; ++i) {
+        const struct AstNode *ix = rev[count - 1 - i];
+        if (!ast_index_subscript_supported(ix))
+            return 0;
+        if (idxs != NULL)
+            idxs[i] = ix;
+    }
+
     if (out_sym != NULL)
         *out_sym = s;
     if (out_base != NULL)
@@ -903,14 +1029,19 @@ int ast_index_reversed_pointer_expr_elem_type(const struct AstNode *n, int *out_
 
     if (n == NULL || n->kind != AST_INDEX || n->a == NULL || n->b == NULL)
         return 0;
-    if (!ast_index_subscript_supported(n->a))
-        return 0;
+    /* Check the (cheap) pointer operand first.  The subscript check on n->a can
+     * recurse through the whole index-support machinery, so for the common case
+     * where n->b is plainly not a pointer (e.g. an ordinary multidimensional
+     * array subscript arr[i][j]), bailing here avoids an exponential re-walk of
+     * a deeply nested index chain. */
     if (!ast_pointer_expr_type(n->b, &ptr_type, &no_deref) || no_deref)
         return 0;
     if (type_ptr_depth(ptr_type) <= 0)
         return 0;
     elem = type_decay_ptr(ptr_type);
     if ((elem & 15) == TYPE_VOID || type_size(elem) <= 0)
+        return 0;
+    if (!ast_index_subscript_supported(n->a))
         return 0;
     *out_type = elem;
     return 1;
@@ -1254,6 +1385,15 @@ int ast_deref_lvalue_plain_int_type(const struct AstNode *n, int *out_type)
 
     if (n == NULL || n->kind != AST_UNARY || n->op != '*')
         return 0;
+    if (ast_deref_pointer_array_chain_collect(n, NULL, NULL, NULL, NULL, &base)) {
+        if (!ast_is_plain_int_type(base))
+            return 0;
+        sz = type_size(base);
+        if (sz != 1 && sz != 2)
+            return 0;
+        *out_type = base;
+        return 1;
+    }
     if (n->a != NULL && n->a->kind == AST_POSTFIX &&
         (n->a->op == TOK_INC || n->a->op == TOK_DEC) &&
         n->a->a != NULL && n->a->a->kind == AST_IDENT) {
@@ -1296,6 +1436,10 @@ int ast_deref_lvalue_type(const struct AstNode *n, int *out_type)
 
     if (n == NULL || n->kind != AST_UNARY || n->op != '*')
         return 0;
+    if (ast_deref_pointer_array_chain_collect(n, NULL, NULL, NULL, NULL, &base)) {
+        *out_type = base;
+        return 1;
+    }
     if (n->a != NULL && n->a->kind == AST_POSTFIX &&
         (n->a->op == TOK_INC || n->a->op == TOK_DEC) &&
         n->a->a != NULL && n->a->a->kind == AST_IDENT) {
@@ -1651,6 +1795,9 @@ int ast_deref_plain_int_read(const struct AstNode *n)
     if (n->a == NULL)
         return 0;
     if (ast_va_arg_deref_type(n, &base))
+        return ast_is_plain_int_type(base) &&
+               (type_size(base) == 1 || type_size(base) == 2);
+    if (ast_deref_pointer_array_chain_collect(n, NULL, NULL, NULL, NULL, &base))
         return ast_is_plain_int_type(base) &&
                (type_size(base) == 1 || type_size(base) == 2);
     if (n->a->kind != AST_IDENT) {

--- a/src/dcc/dcc_ast_gen_expr.c
+++ b/src/dcc/dcc_ast_gen_expr.c
@@ -289,6 +289,13 @@ void gen_unary_ast(const struct AstNode *n)
             gen_va_arg_deref_ast(n, base);
             return;
         }
+        if (ast_deref_pointer_array_chain_collect(n, NULL, NULL, NULL, NULL, &base)) {
+            gen_deref_addr_ast(n, &base);
+            emit_load_from_hl(base);
+            g_expr_type = base;
+            g_long_from16 = 0;
+            return;
+        }
         if (n->a->kind != AST_IDENT) {
             gen_pointer_expr_ast(n->a, &ptr_type, &no_deref);
             base = no_deref ? ptr_type : type_decay_ptr(ptr_type);
@@ -2157,7 +2164,7 @@ void gen_index_addr_ast(const struct AstNode *n, int *out_val_type)
     }
 
     if (ast_index_symbol_nd_addressable_addr(n)) {
-        const struct AstNode *idxs[8];
+        const struct AstNode *idxs[MAX_INDEX_DEPTH];
         struct Sym *ns;
         int count;
         int idx;
@@ -2199,7 +2206,7 @@ void gen_index_addr_ast(const struct AstNode *n, int *out_val_type)
     }
 
     {
-        const struct AstNode *idxs[8];
+        const struct AstNode *idxs[MAX_INDEX_DEPTH];
         const struct AstNode *base;
         struct Sym *ps;
         int count;
@@ -3439,9 +3446,47 @@ void gen_pointer_expr_ast(const struct AstNode *n, int *out_type,
 void gen_deref_addr_ast(const struct AstNode *n, int *out_val_type)
 {
     struct Sym *s;
+    struct Sym *ps;
+    const struct AstNode *base_expr;
+    const struct AstNode *idxs[DCC_MAX_DEREF_CHAIN];
+    int idx_count;
     int no_deref;
     int ptr_type;
     int base;
+    int elem_size;
+
+    if (ast_deref_pointer_array_chain_collect(n, &ps, &base_expr, idxs,
+                                              &idx_count, &base)) {
+        int d;
+        int di;
+        gen_pointer_expr_ast(base_expr, &ptr_type, &no_deref);
+
+        for (d = 0; d < idx_count; ++d) {
+            /* Stride for dimension d is the element size scaled by the product
+             * of all inner dimensions from d onward: dimension 0 spans a whole
+             * pointed-to array object, the last index spans one element. */
+            elem_size = type_size(base);
+            if (elem_size <= 0)
+                elem_size = 2;
+            for (di = d; di < ps->dim_count; ++di)
+                if (ps->dims[di] > 0)
+                    elem_size *= ps->dims[di];
+
+            if (idxs[d]->kind == AST_INT_LIT) {
+                emit_add_const_to_hl(idxs[d]->ival * elem_size);
+            } else {
+                emit("\tpush hl\n");
+                gen_index_subscript_expr_ast(idxs[d]);
+                scale_hl_by_elem_size(elem_size);
+                emit("\tex de,hl\n");
+                emit("\tpop hl\n");
+                emit("\tadd hl,de\n");
+            }
+        }
+
+        *out_val_type = base;
+        return;
+    }
 
     if (n->a->kind == AST_POSTFIX &&
         (n->a->op == TOK_INC || n->a->op == TOK_DEC) &&

--- a/src/dcc/dcc_ast_gen_internal.h
+++ b/src/dcc/dcc_ast_gen_internal.h
@@ -16,6 +16,13 @@ extern int ast_switch_gate_depth;
 extern struct AstSwCtx ast_sw_ctx[AST_MAX_SW_NEST];
 extern int ast_sw_depth;
 
+/* Maximum length of a pointer-to-array dereference chain
+ * (*(*(...(p + i0)...) + iN)).  A chain of N layers indexes a pointer whose
+ * element has N-1 array dimensions; the compiler caps array rank at
+ * MAX_ARRAY_DIMS, so the longest possible chain is MAX_ARRAY_DIMS + 1 layers. */
+#define DCC_MAX_DEREF_CHAIN MAX_INDEX_DEPTH
+
+
 int ident_supported(const char *name);
 int is_cmp_op(int op);
 int is_shift_op(int op);
@@ -43,6 +50,12 @@ int ast_index_symbol_nd_collect(const struct AstNode *n, struct Sym **out_sym,
 int ast_index_symbol_nd_elem_type(const struct AstNode *n, int *out_type);
 int ast_index_symbol_nd_addressable_addr(const struct AstNode *n);
 int ast_index_deref_pointer_array_collect(const struct AstNode *n,
+                                                 struct Sym **out_sym,
+                                                 const struct AstNode **out_base,
+                                                 const struct AstNode **idxs,
+                                                 int *out_count,
+                                                 int *out_type);
+int ast_deref_pointer_array_chain_collect(const struct AstNode *n,
                                                  struct Sym **out_sym,
                                                  const struct AstNode **out_base,
                                                  const struct AstNode **idxs,

--- a/src/dcc/dcc_ast_gen_support.c
+++ b/src/dcc/dcc_ast_gen_support.c
@@ -31,6 +31,17 @@ int ast_expr_yields_bool01(const struct AstNode *n)
     }
 }
 
+/* RHS acceptable for storing into a plain-int (char/int) array or pointer
+ * element via assignment `n`.  A plain-int RHS always works.  A long-typed RHS
+ * is also accepted for a plain `=`: the element store path evaluates the RHS to
+ * DE:HL and writes only the low word (int) or low byte (char), i.e. it
+ * truncates to the element width - exactly the C conversion for `int_elem =
+ * long_value`.  Compound ops are left to the plain-int-only path. */
+static int ast_int_elem_assign_rhs_ok(const struct AstNode *n)
+{
+    return ast_value_is_plain_int(n->b) ||
+           (n->op == '=' && ast_value_is_long_word(n->b));
+}
 
 int ast_gen_supported(const struct AstNode *n)
 {
@@ -274,7 +285,7 @@ int ast_gen_supported(const struct AstNode *n)
                 if (!ast_is_plain_int_type(elem))
                     return 0;
                 return (type_size(elem) == 1 || type_size(elem) == 2) &&
-                       ast_value_is_plain_int(n->b);
+                       ast_int_elem_assign_rhs_ok(n);
             }
             if (ast_index_pointer_expr_elem_type(n->a, &elem)) {
                 if (type_is_long(elem))
@@ -291,7 +302,7 @@ int ast_gen_supported(const struct AstNode *n)
                 if (!ast_is_plain_int_type(elem))
                     return 0;
                 return (type_size(elem) == 1 || type_size(elem) == 2) &&
-                       ast_value_is_plain_int(n->b);
+                       ast_int_elem_assign_rhs_ok(n);
             }
             if (n->op == '=' && ast_index_addressable_addr(n->a)) {
                 if (ast_index_2d_array_elem_type(n->a, &elem)) {
@@ -348,7 +359,7 @@ int ast_gen_supported(const struct AstNode *n)
                 if (!ast_is_plain_int_type(elem))
                     return 0;
                 return (type_size(elem) == 1 || type_size(elem) == 2) &&
-                       ast_value_is_plain_int(n->b);
+                       ast_int_elem_assign_rhs_ok(n);
             }
             if (ast_index_pointer_array_elem_type(n->a, &elem)) {
                 if (n->op != '=')
@@ -408,7 +419,7 @@ int ast_gen_supported(const struct AstNode *n)
             if (!ast_index_plain_int_read(n->a))
                 return 0;
             if (n->a->a->kind == AST_IDENT) {
-                if (!ast_value_is_plain_int(n->b))
+                if (!ast_int_elem_assign_rhs_ok(n))
                     return 0;
                 base = find_sym(n->a->a->sval);
                 decayed = base->is_array ? type_add_ptr(base->type) : base->type;

--- a/src/dcc/dcc_decl.c
+++ b/src/dcc/dcc_decl.c
@@ -1133,7 +1133,7 @@ void gen_local_decl_after_type(int base)
                 int pi;
                 s->elem_size = g_ptr_array_elem_size;
                 s->dim_count = g_ptr_array_dim_count;
-                for (pi = 0; pi < 8; ++pi)
+                for (pi = 0; pi < MAX_ARRAY_DIMS; ++pi)
                     s->dims[pi] = (pi < g_ptr_array_dim_count) ? g_ptr_array_dims[pi] : 0;
             }
         }

--- a/src/dcc/dcc_diag_emit.c
+++ b/src/dcc/dcc_diag_emit.c
@@ -76,6 +76,7 @@ const char *dcc_diag_code_for_message(const char *msg)
     if (dcc_msg_has(msg, "multiple storage classes in declaration")) return "DCC-E0540";
     if (dcc_msg_has(msg, "variable length arrays are not supported")) return "DCC-E0601";
     if (dcc_msg_has(msg, "subscripted value is not an array or pointer")) return "DCC-E0602";
+    if (dcc_msg_has(msg, "too many array dimensions")) return "DCC-E0603";
     if (dcc_msg_has(msg, "break statement outside loop or switch")) return "DCC-E0701";
     if (dcc_msg_has(msg, "continue statement outside loop")) return "DCC-E0702";
     if (dcc_msg_has(msg, "case label outside switch")) return "DCC-E0703";

--- a/src/dcc/dcc_expr.c
+++ b/src/dcc/dcc_expr.c
@@ -375,7 +375,7 @@ int parse_funcptr_declarator(int *ptype, char *name, int namesz)
             next_token();
         expect(')');
     } else if (tok.kind == '[') {
-        int dims[8];
+        int dims[MAX_ARRAY_DIMS];
         int ndims;
         int i;
         int n;
@@ -393,7 +393,7 @@ int parse_funcptr_declarator(int *ptype, char *name, int namesz)
                 expect(']');
             }
             if (n < 0) n = 0;
-            if (ndims < 8) dims[ndims++] = n;
+            if (ndims < MAX_ARRAY_DIMS) dims[ndims++] = n;
         }
 
         elem_bytes = type_size(ptype[0]);
@@ -408,7 +408,7 @@ int parse_funcptr_declarator(int *ptype, char *name, int namesz)
         }
         g_ptr_array_dim_count = ndims;
         g_ptr_array_elem_size = total > 0 ? total * elem_bytes : elem_bytes;
-        for (i = 0; i < ndims && i < 8; ++i)
+        for (i = 0; i < ndims && i < MAX_ARRAY_DIMS; ++i)
             g_ptr_array_dims[i] = dims[i];
     }
 
@@ -701,15 +701,17 @@ void parse_array_declarator_dims(int base_type,
                                         int *first_stride_bytes,
                                         int allow_empty_first)
 {
-    int dims[8];
+    int dims[MAX_ARRAY_DIMS];
     int ndims;
     int i;
     int n;
     int elem_bytes;
     int total;
     int inner;
+    int overflowed;
 
     ndims = 0;
+    overflowed = 0;
     g_last_array_dim_count = 0;
     g_vla_pending = 0;
     memset(g_last_array_dims, 0, sizeof(g_last_array_dims));
@@ -756,8 +758,16 @@ void parse_array_declarator_dims(int base_type,
 
         if (n < 0)
             n = 0;
-        if (ndims < 8)
+        if (ndims < MAX_ARRAY_DIMS) {
             dims[ndims++] = n;
+        } else {
+            /* Array rank exceeds the supported maximum (C99/C11 5.2.4.1
+             * guarantees at least 12).  Emit one diagnostic and keep ndims
+             * capped so the dims[] buffer is never indexed out of range. */
+            if (!overflowed && asm_suppress_depth == 0)
+                error_here("too many array dimensions");
+            overflowed = 1;
+        }
     }
 
     if (ndims == 0) {
@@ -792,7 +802,7 @@ void parse_array_declarator_dims(int base_type,
     first_stride_bytes[0] = (ndims > 1 && inner > 0) ? inner * elem_bytes : elem_bytes;
 
     g_last_array_dim_count = ndims;
-    for (i = 0; i < ndims && i < 8; ++i)
+    for (i = 0; i < ndims && i < MAX_ARRAY_DIMS; ++i)
         g_last_array_dims[i] = dims[i];
 }
 

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -574,7 +574,7 @@ int current_void_is_empty_param_list(void)
 
 void skip_prototype_array_suffixes(int *ptype)
 {
-    int dims[8];
+    int dims[MAX_ARRAY_DIMS];
     int ndims = 0;
     int i, n, inner, elem_bytes;
     int orig_type = *ptype;
@@ -603,7 +603,7 @@ void skip_prototype_array_suffixes(int *ptype)
             expect(']');
         }
         if (n < 0) n = 0;
-        if (ndims < 8) dims[ndims] = n;
+        if (ndims < MAX_ARRAY_DIMS) dims[ndims] = n;
         ndims++;
     }
 
@@ -629,7 +629,7 @@ void skip_prototype_array_suffixes(int *ptype)
 
     g_ptr_array_dim_count = ndims - 1;
     g_ptr_array_elem_size = (inner > 0) ? inner * elem_bytes : elem_bytes;
-    for (i = 0; i < ndims - 1 && i < 8; ++i)
+    for (i = 0; i < ndims - 1 && i < MAX_ARRAY_DIMS; ++i)
         g_ptr_array_dims[i] = dims[i + 1];
 }
 
@@ -828,7 +828,7 @@ void parse_old_style_param_declarations(void)
                 if (g_ptr_array_dim_count > 0) {
                     s->elem_size = g_ptr_array_elem_size;
                     s->dim_count = g_ptr_array_dim_count;
-                    for (pi = 0; pi < 8; ++pi)
+                    for (pi = 0; pi < MAX_ARRAY_DIMS; ++pi)
                         s->dims[pi] = (pi < g_ptr_array_dim_count) ? g_ptr_array_dims[pi] : 0;
                 }
                 g_ptr_array_dim_count = 0;
@@ -934,7 +934,7 @@ void parse_param_list(void)
             if (ps && g_ptr_array_dim_count > 0) {
                 ps->elem_size = g_ptr_array_elem_size;
                 ps->dim_count = g_ptr_array_dim_count;
-                for (pi = 0; pi < 8; ++pi)
+                for (pi = 0; pi < MAX_ARRAY_DIMS; ++pi)
                     ps->dims[pi] = (pi < g_ptr_array_dim_count) ? g_ptr_array_dims[pi] : 0;
             }
             g_ptr_array_dim_count = 0;
@@ -1680,7 +1680,7 @@ void scan_local_decl_after_type(int base)
                 int pi;
                 s->elem_size = g_ptr_array_elem_size;
                 s->dim_count = g_ptr_array_dim_count;
-                for (pi = 0; pi < 8; ++pi)
+                for (pi = 0; pi < MAX_ARRAY_DIMS; ++pi)
                     s->dims[pi] = (pi < g_ptr_array_dim_count) ? g_ptr_array_dims[pi] : 0;
             }
         }
@@ -3529,11 +3529,11 @@ void parse_function_or_global(int base_type)
             int first_dim = g_funcptr_decl_array_len;
             int base_size = type_size(type);
             int dim_count = 0;
-            int dims[8];
+            int dims[MAX_ARRAY_DIMS];
             int i;
             int inner_count;
 
-            for (i = 0; i < 8; ++i)
+            for (i = 0; i < MAX_ARRAY_DIMS; ++i)
                 dims[i] = 0;
 
             if (g_funcptr_decl_array_len > 0) {
@@ -3553,8 +3553,14 @@ void parse_function_or_global(int base_type)
                     d = parse_const_int_expr();
                     expect(']');
                 }
-                if (dim_count < 8)
+                if (dim_count < MAX_ARRAY_DIMS) {
                     dims[dim_count++] = d;
+                } else {
+                    /* Array rank exceeds the supported maximum (C99/C11
+                     * 5.2.4.1 guarantees at least 12); keep dim_count capped
+                     * so dims[] is never indexed out of range. */
+                    error_here("too many array dimensions");
+                }
             }
 
             if (dim_count > 0) {
@@ -3619,7 +3625,7 @@ void parse_function_or_global(int base_type)
                 s->is_array = 1;
                 s->array_len = arrlen;
                 s->dim_count = dim_count;
-                for (i = 0; i < 8; ++i)
+                for (i = 0; i < MAX_ARRAY_DIMS; ++i)
                     s->dims[i] = (i < dim_count) ? dims[i] : 0;
 
                 if (dim_count > 1)
@@ -3636,7 +3642,7 @@ void parse_function_or_global(int base_type)
                 int pi;
                 s->elem_size = g_ptr_array_elem_size;
                 s->dim_count = g_ptr_array_dim_count;
-                for (pi = 0; pi < 8; ++pi)
+                for (pi = 0; pi < MAX_ARRAY_DIMS; ++pi)
                     s->dims[pi] = (pi < g_ptr_array_dim_count) ? g_ptr_array_dims[pi] : 0;
             }
             g_ptr_array_dim_count = 0;

--- a/src/dcc/dcc_state.c
+++ b/src/dcc/dcc_state.c
@@ -193,10 +193,10 @@ int g_proto_types[MAX_PROTO_PARAMS];
 int g_funcptr_decl_array_len;
 int g_funcptr_is_funcret_decl;
 int g_ptr_array_dim_count;
-int g_ptr_array_dims[8];
+int g_ptr_array_dims[MAX_ARRAY_DIMS];
 int g_ptr_array_elem_size;
 int g_last_array_dim_count;
-int g_last_array_dims[8];
+int g_last_array_dims[MAX_ARRAY_DIMS];
 
 int g_vla_pending;
 long g_vla_dim_posi;

--- a/src/dcc/dcc_types.c
+++ b/src/dcc/dcc_types.c
@@ -228,7 +228,7 @@ void copy_last_array_dims_to_sym(struct Sym *s)
     int i;
 
     s->dim_count = g_last_array_dim_count;
-    for (i = 0; i < 8; ++i)
+    for (i = 0; i < MAX_ARRAY_DIMS; ++i)
         s->dims[i] = (i < g_last_array_dim_count) ? g_last_array_dims[i] : 0;
 }
 

--- a/tests/_test_overrides.json
+++ b/tests/_test_overrides.json
@@ -18,7 +18,7 @@
     { "name": "tpfio", "dcc_floatio": true, "dcc_longio": false },
     { "name": "tplng", "dcc_floatio": false, "dcc_longio": true },
     { "name": "tvplain", "dcc_floatio": false, "dcc_longio": false },
-    { "name": "tvla", "stack_size": 1024 },
+    { "name": "tvla", "stack_size": 8192 },
     { "name": "tvlax", "stack_size": 2048 },
     { "name": "triangle", "stack_size": 768 },
     { "name": "catalan", "stack_size": 768 },

--- a/tests/baselines/tvla.txt
+++ b/tests/baselines/tvla.txt
@@ -1,3 +1,3 @@
 tvla start
-checks=37 failures=0
+checks=41 failures=0
 tvla ok

--- a/tests/diagnostics/baselines/too-many-array-dimensions.txt
+++ b/tests/diagnostics/baselines/too-many-array-dimensions.txt
@@ -1,0 +1,4 @@
+<source>:10: error DCC-E0603: too many array dimensions near ';'
+        int a[2][2][2][2][2][2][2][2][2][2][2][2][2];
+                                                    ^
+dcc: 1 error(s)

--- a/tests/diagnostics/too-many-array-dimensions.c
+++ b/tests/diagnostics/too-many-array-dimensions.c
@@ -1,0 +1,12 @@
+/*
+ * Array rank exceeding the supported maximum must be rejected.  C99/C11
+ * 5.2.4.1 "Translation limits" requires an implementation to support at least
+ * 12 pointer, array, and function declarators in any combination; dcc caps
+ * array rank at 12, so a 13-dimension array is a diagnostic, not a silent
+ * truncation.
+ */
+int f(void)
+{
+    int a[2][2][2][2][2][2][2][2][2][2][2][2][2];
+    return 0;
+}

--- a/tests/tvla.c
+++ b/tests/tvla.c
@@ -398,6 +398,76 @@ static int vla_pass2d(int rows)
     return vla_sum2d(rows, grid);
 }
 
+static int vla_ptr2d_deref_chain(int rows)
+{
+    int grid[rows][3];
+    int (*p)[3] = grid;
+    int i, j, s = 0;
+    for (i = 0; i < rows; i++)
+        for (j = 0; j < 3; j++)
+            *(*(p + i) + j) = i * 10 + j;
+    for (i = 0; i < rows; i++)
+        for (j = 0; j < 3; j++)
+            s += *(*(p + i) + j);
+    return s;
+}
+
+/* Three-dimensional pointer-to-array dereference chain: the explicit
+ * *(*(*(p + i) + j) + k) desugaring of p[i][j][k], written for both a store
+ * and a read, must match the bracket form. */
+static int vla_ptr3d_deref_chain(int rows)
+{
+    int cube[rows][2][3];
+    int (*p)[2][3] = cube;
+    int i, j, k, s = 0;
+    for (i = 0; i < rows; i++)
+        for (j = 0; j < 2; j++)
+            for (k = 0; k < 3; k++)
+                *(*(*(p + i) + j) + k) = i * 100 + j * 10 + k;
+    for (i = 0; i < rows; i++)
+        for (j = 0; j < 2; j++)
+            for (k = 0; k < 3; k++)
+                s += *(*(*(p + i) + j) + k);
+    return s;
+}
+
+/* Storing a long-typed RHS into an int VLA element uses the truncating element
+ * store path (the RHS is long because the literal 1000L is long, forcing long
+ * arithmetic).  Values are kept within 16 bits so the result is identical on a
+ * 16-bit-int target and a 32-bit host baseline. */
+static int vla_long_rhs_store(int n)
+{
+    int a[n];
+    int i, s = 0;
+    for (i = 0; i < n; i++)
+        a[i] = 1000L + i;
+    for (i = 0; i < n; i++)
+        s += a[i];
+    return s;                           /* sum(1000 + i) for i in [0, n) */
+}
+
+/* Ten-dimensional VLA (variable first dimension, constant inner dims) accessed
+ * through a full ten-level explicit dereference chain.  Confirms the chain
+ * lowering is fully generalised well beyond 2-D/3-D: C99/C11 5.2.4.1 guarantees
+ * support for at least 12 array declarators, and dcc caps rank at 12. */
+static int vla_ptr10d_deref_chain(int rows)
+{
+    int cube[rows][2][2][2][2][2][2][2][2][2];
+    int (*p)[2][2][2][2][2][2][2][2][2] = cube;
+    int a, b, c, d, e, f, g, h, i, j, s = 0;
+    for (a = 0; a < rows; a++)
+     for (b = 0; b < 2; b++) for (c = 0; c < 2; c++) for (d = 0; d < 2; d++)
+      for (e = 0; e < 2; e++) for (f = 0; f < 2; f++) for (g = 0; g < 2; g++)
+       for (h = 0; h < 2; h++) for (i = 0; i < 2; i++) for (j = 0; j < 2; j++)
+        *(*(*(*(*(*(*(*(*(*(p + a) + b) + c) + d) + e) + f) + g) + h) + i) + j) = 1;
+    for (a = 0; a < rows; a++)
+     for (b = 0; b < 2; b++) for (c = 0; c < 2; c++) for (d = 0; d < 2; d++)
+      for (e = 0; e < 2; e++) for (f = 0; f < 2; f++) for (g = 0; g < 2; g++)
+       for (h = 0; h < 2; h++) for (i = 0; i < 2; i++) for (j = 0; j < 2; j++)
+        s += *(*(*(*(*(*(*(*(*(*(p + a) + b) + c) + d) + e) + f) + g) + h) + i) + j);
+    return s;                           /* rows * 2^9 */
+}
+
 /* Forward goto whose target label is in the SAME VLA scope (no SP change). */
 static int vla_fwd_same(int n)
 {
@@ -555,6 +625,10 @@ int main(void)
     check_int("vla_ptr_diff", vla_ptr_diff(4), 7);
     check_int("vla_long_bound", vla_long_bound(5), 6);
     check_int("vla_pass2d", vla_pass2d(4), 30);
+    check_int("vla_ptr2d_deref_chain", vla_ptr2d_deref_chain(4), 192);
+    check_int("vla_ptr3d_deref_chain", vla_ptr3d_deref_chain(3), 1908);
+    check_int("vla_ptr10d_deref_chain", vla_ptr10d_deref_chain(2), 1024);
+    check_int("vla_long_rhs_store", vla_long_rhs_store(5), 5010);
 
     check_int("vla_fwd_same", vla_fwd_same(5), 10);
     check_int("vla_fwd_exit_inner", vla_fwd_exit_inner(4), 4);


### PR DESCRIPTION
@davidly 

Teach the AST code generator to recognise explicit pointer-to-array dereference chains as equivalent to multidimensional subscripting.

Previously dcc could compile bracketed forms such as:

    p[i][j]
    p[i][j][k]

but rejected the explicit pointer-arithmetic spelling:

    *(*(p + i) + j)
    *(*(*(p + i) + j) + k)

for pointer-to-array values, often surfacing as the generic "DCC-E1002: unsupported for statement" when the expression appeared inside a loop body. Add a collector for these dereference chains, validate each index expression, preserve first-dimension-first index order, and emit the same scaled address calculation used for ordinary multidimensional array access.

Generalise the implementation beyond the original 2D case so it works for higher-rank pointer-to-array expressions up to the compiler's configured array-rank limit.

Raise the ordinary symbol array-rank storage from the old ad hoc 8-element limit to a named MAX_ARRAY_DIMS value of 12. C99/C11 translation limits require support for at least 12 pointer/array/function declarators in combination modifying one type, so use that as dcc's array-rank cap. Add MAX_INDEX_DEPTH for index/dereference-chain scratch buffers, since indexing a pointer-to-array can add one level beyond the pointed-to array rank.

Plumb the new limit through declaration parsing, global/function/local dimension storage, pointer-array metadata, and dimension-copy paths. Emit a clear DCC-E0603 "too many array dimensions" diagnostic when declarations exceed the supported rank instead of silently truncating dimension metadata or falling through to a later generic unsupported-expression error.

Also fix two related support-gate issues found while testing deep VLA cases:

- Reorder the reversed pointer-index support check so the cheap pointer operand test runs before recursively checking the would-be subscript. This avoids exponential re-walking of ordinary deep index chains such as arr[i][j][k]... and prevents valid 12D cases from appearing to hang at compile time.

- Allow plain int array/VLA element assignment from a long RHS for ordinary '=' stores. On the Z80 target int is 16-bit and long is 32-bit, but the emitter already truncates stores to the destination element width. The AST support gate was stricter than codegen, so valid stores like int_array[i] = long_expr were rejected even though scalar int assignment already worked.

Add VLA regression coverage for:

- explicit 2D pointer-to-array dereference chains
- explicit 3D pointer-to-array dereference chains
- a 10D VLA with a runtime first dimension
- long RHS assignment into int VLA elements

Increase the tvla stack override to cover the expanded regression and update the baseline to 41 checks.

Add a diagnostic regression for declarations with more than 12 array dimensions.

Validated with:

- pwsh ./scripts/build-dcc.ps1
- ./dccmake tests/tvla.c dcc-output=TVLA dcc-peep=true dcc-stack-bytes=8192
- ntvcm build/TVLA.COM compared against tests/baselines/tvla.txt
- clang -std=c99 -I . tests/tvla.c
- direct too-many-array-dimensions diagnostic baseline comparison
- temporary 12D VLA explicit dereference-chain probe under dcc/ntvcm and clang
- temporary long-RHS-to-int-element truncation probe under dcc/ntvcm
- pwsh ./scripts/runall.ps1 -Mode full

Full regression result: 221 passed, 0 failed, 9 skipped.