### PR TITLE
test(dcc): cover VLA deref chains across statement contexts

### DIFF
--- a/src/dcc/dcc_diag_emit.c
+++ b/src/dcc/dcc_diag_emit.c
@@ -75,6 +75,7 @@ const char *dcc_diag_code_for_message(const char *msg)
     if (dcc_msg_has(msg, "type expected")) return "DCC-E0531";
     if (dcc_msg_has(msg, "multiple storage classes in declaration")) return "DCC-E0540";
     if (dcc_msg_has(msg, "variable length arrays are not supported")) return "DCC-E0601";
+    if (dcc_msg_has(msg, "variable inner dimensions in variable-length arrays are not supported")) return "DCC-E0601";
     if (dcc_msg_has(msg, "subscripted value is not an array or pointer")) return "DCC-E0602";
     if (dcc_msg_has(msg, "too many array dimensions")) return "DCC-E0603";
     if (dcc_msg_has(msg, "break statement outside loop or switch")) return "DCC-E0701";

--- a/src/dcc/dcc_expr.c
+++ b/src/dcc/dcc_expr.c
@@ -746,7 +746,7 @@ void parse_array_declarator_dims(int base_type,
                     n = 0;
                 } else {
                     if (asm_suppress_depth == 0)
-                        error_here("variable length arrays are not supported; use malloc and an explicit pointer");
+                        error_here("variable inner dimensions in variable-length arrays are not supported; use malloc and an explicit pointer");
                     skip_array_dim_to_close();
                     n = 0;
                 }

--- a/tests/baselines/tvla.txt
+++ b/tests/baselines/tvla.txt
@@ -1,3 +1,3 @@
 tvla start
-checks=41 failures=0
+checks=45 failures=0
 tvla ok

--- a/tests/diagnostics/baselines/variable-length-array.txt
+++ b/tests/diagnostics/baselines/variable-length-array.txt
@@ -1,4 +1,4 @@
-<source>:3: error DCC-E0601: variable length arrays are not supported; use malloc and an explicit pointer near 'm'
+<source>:3: error DCC-E0601: variable inner dimensions in variable-length arrays are not supported; use malloc and an explicit pointer near 'm'
         int a[n][m];
                  ^
 dcc: 1 error(s)

--- a/tests/tvla.c
+++ b/tests/tvla.c
@@ -412,6 +412,32 @@ static int vla_ptr2d_deref_chain(int rows)
     return s;
 }
 
+static int vla_ptr2d_deref_chain_while(int rows)
+{
+    int grid[rows][3];
+    int (*p)[3] = grid;
+    int i, j, s = 0;
+    i = 0;
+    while (i < rows) {
+        j = 0;
+        while (j < 3) {
+            *(*(p + i) + j) = i * 10 + j;
+            j++;
+        }
+        i++;
+    }
+    i = 0;
+    while (i < rows) {
+        j = 0;
+        while (j < 3) {
+            s += *(*(p + i) + j);
+            j++;
+        }
+        i++;
+    }
+    return s;
+}
+
 /* Three-dimensional pointer-to-array dereference chain: the explicit
  * *(*(*(p + i) + j) + k) desugaring of p[i][j][k], written for both a store
  * and a read, must match the bracket form. */
@@ -429,6 +455,89 @@ static int vla_ptr3d_deref_chain(int rows)
             for (k = 0; k < 3; k++)
                 s += *(*(*(p + i) + j) + k);
     return s;
+}
+
+static int vla_ptr3d_deref_chain_do(int rows)
+{
+    int cube[rows][2][3];
+    int (*p)[2][3] = cube;
+    int i, j, k, s = 0;
+    i = 0;
+    do {
+        j = 0;
+        do {
+            k = 0;
+            do {
+                *(*(*(p + i) + j) + k) = i * 100 + j * 10 + k;
+                k++;
+            } while (k < 3);
+            j++;
+        } while (j < 2);
+        i++;
+    } while (i < rows);
+    i = 0;
+    do {
+        j = 0;
+        do {
+            k = 0;
+            do {
+                s += *(*(*(p + i) + j) + k);
+                k++;
+            } while (k < 3);
+            j++;
+        } while (j < 2);
+        i++;
+    } while (i < rows);
+    return s;
+}
+
+static int vla_ptr2d_deref_chain_return(int rows)
+{
+    int grid[rows][3];
+    int (*p)[3] = grid;
+    *(*(p + 1) + 2) = 77;
+    return *(*(p + 1) + 2);
+}
+
+static int vla_ptr2d_deref_chain_switch(int rows, int (*p)[3])
+{
+    switch (rows) {
+    case 2:
+        *(*(p + 0) + 1) = 20;
+        break;
+    default:
+        *(*(p + 0) + 1) = 99;
+        break;
+    }
+    return *(*(p + 0) + 1);
+}
+
+static int vla_ptr2d_deref_chain_contexts(int rows)
+{
+    int grid[rows][3];
+    int (*p)[3] = grid;
+    int sw;
+
+    if (rows == 2)
+        *(*(p + 0) + 0) = 10;
+
+    sw = vla_ptr2d_deref_chain_switch(rows, p);
+
+    *(*(p + 0) + 2) = 30;
+    {
+        int x = *(*(p + 0) + 2);
+        return *(*(p + 0) + 0) + sw + x +
+               vla_ptr2d_deref_chain_return(rows);
+    }
+}
+
+static int vla_ptr2d_deref_chain_compound(int rows)
+{
+    int grid[rows][3];
+    int (*p)[3] = grid;
+    *(*(p + 1) + 2) = 40;
+    *(*(p + 1) + 2) += 2;
+    return *(*(p + 1) + 2);
 }
 
 /* Storing a long-typed RHS into an int VLA element uses the truncating element
@@ -626,7 +735,11 @@ int main(void)
     check_int("vla_long_bound", vla_long_bound(5), 6);
     check_int("vla_pass2d", vla_pass2d(4), 30);
     check_int("vla_ptr2d_deref_chain", vla_ptr2d_deref_chain(4), 192);
+    check_int("vla_ptr2d_deref_chain_while", vla_ptr2d_deref_chain_while(4), 192);
     check_int("vla_ptr3d_deref_chain", vla_ptr3d_deref_chain(3), 1908);
+    check_int("vla_ptr3d_deref_chain_do", vla_ptr3d_deref_chain_do(3), 1908);
+    check_int("vla_ptr2d_deref_chain_contexts", vla_ptr2d_deref_chain_contexts(2), 137);
+    check_int("vla_ptr2d_deref_chain_compound", vla_ptr2d_deref_chain_compound(2), 42);
     check_int("vla_ptr10d_deref_chain", vla_ptr10d_deref_chain(2), 1024);
     check_int("vla_long_rhs_store", vla_long_rhs_store(5), 5010);
 


### PR DESCRIPTION
@davidly 

Extend the VLA regression suite to verify that explicit pointer-to-array dereference chains work outside the original for-loop coverage.

The underlying expression support should not depend on the enclosing statement form, so add coverage for:

- nested while loops using a 2D VLA deref chain
- nested do-while loops using a 3D VLA deref chain
- if-body stores through a 2D VLA deref chain
- switch-case stores through a pointer-to-VLA parameter
- local initializer reads from a deref chain
- return-expression reads from a deref chain
- compound assignment through a deref-chain lvalue

The switch coverage is deliberately placed in a helper that receives the pointer-to-VLA storage, because dcc intentionally rejects case/default labels inside a VLA-owning scope. This still exercises switch statement lowering without violating the existing VLA scope rule.

Update the tvla baseline from 41 to 45 checks.

Also clarify the diagnostic for unsupported variable inner VLA dimensions. dcc supports local VLAs whose outermost dimension is runtime-sized and whose inner dimensions are constant. A declaration such as:

    int a[n][m];

is rejected because the inner runtime dimension would require runtime row stride modelling, not because all VLAs are unsupported. Change the diagnostic text to say:

    variable inner dimensions in variable-length arrays are not supported

while preserving the existing DCC-E0601 diagnostic code, and update the diagnostic baseline accordingly.

Validated with:

- pwsh ./scripts/build-dcc.ps1
- ./dccmake tests/tvla.c dcc-output=TVLA dcc-peep=true dcc-stack-bytes=8192
- ntvcm build/TVLA.COM compared against tests/baselines/tvla.txt
- clang -std=c99 -I . tests/tvla.c
- direct variable-length-array diagnostic baseline comparison