### PR TITLE
Speed up AST support checks for high-rank VLA recovery

### DIFF
--- a/src/dcc/dcc_ast_gen_internal.h
+++ b/src/dcc/dcc_ast_gen_internal.h
@@ -131,6 +131,7 @@ int ast_struct_copy_assign_supported(const struct AstNode *n);
 int ast_is_const_zero_condition(const struct AstNode *n);
 int ast_is_const_nonzero_condition(const struct AstNode *n);
 int ast_expr_yields_bool01(const struct AstNode *n);
+void ast_support_cache_begin(void);
 int ast_gen_supported(const struct AstNode *n);
 int ast_call_arg_word_supported(const struct AstNode *arg);
 int ast_call_struct_arg_supported(int want_type, const struct AstNode *arg);

--- a/src/dcc/dcc_ast_gen_stmt.c
+++ b/src/dcc/dcc_ast_gen_stmt.c
@@ -690,8 +690,11 @@ int ast_scan_for_stmt(void)
     scan_mode = 1;
 
     n = ast_build_stmt(&g_ast_arena);
-    if (n != NULL && ast_stmt_supported(n))
-        ast_gen_stmt(n);
+    if (n != NULL) {
+        ast_support_cache_begin();
+        if (ast_stmt_supported(n))
+            ast_gen_stmt(n);
+    }
 
     ast_arena_reset(&g_ast_arena);
     scan_mode = s_scan_mode;
@@ -1065,6 +1068,9 @@ int ast_try_emit_statement(void)
     end_line = line_no;
     end_tok_line = tok_line;
     end_tok = tok;
+
+    if (n != NULL)
+        ast_support_cache_begin();
 
     if (n != NULL && ast_stmt_supported(n)) {
         g_for_seq = sv_for_seq;

--- a/src/dcc/dcc_ast_gen_support.c
+++ b/src/dcc/dcc_ast_gen_support.c
@@ -7,6 +7,29 @@
 #include <string.h>
 #include "dcc_ast_gen_internal.h"
 
+#define AST_SUPPORT_CACHE_SIZE 4096
+
+struct AstSupportCacheEntry {
+    const struct AstNode *node;
+    unsigned stamp;
+    int dead;
+    int value;
+};
+
+static struct AstSupportCacheEntry ast_support_cache[AST_SUPPORT_CACHE_SIZE];
+static unsigned ast_support_cache_stamp = 1;
+
+static int ast_gen_supported_uncached(const struct AstNode *n);
+
+void ast_support_cache_begin(void)
+{
+    ast_support_cache_stamp++;
+    if (ast_support_cache_stamp == 0) {
+        memset(ast_support_cache, 0, sizeof(ast_support_cache));
+        ast_support_cache_stamp = 1;
+    }
+}
+
 
 int ast_expr_yields_bool01(const struct AstNode *n)
 {
@@ -44,6 +67,32 @@ static int ast_int_elem_assign_rhs_ok(const struct AstNode *n)
 }
 
 int ast_gen_supported(const struct AstNode *n)
+{
+    unsigned long h;
+    unsigned idx;
+    int dead;
+    int value;
+    struct AstSupportCacheEntry *e;
+
+    if (n == NULL)
+        return 0;
+
+    dead = expr_result_dead ? 1 : 0;
+    h = ((unsigned long)n >> 4) ^ (unsigned long)(n->kind * 131) ^ (unsigned long)dead;
+    idx = (unsigned)(h & (AST_SUPPORT_CACHE_SIZE - 1));
+    e = &ast_support_cache[idx];
+    if (e->stamp == ast_support_cache_stamp && e->node == n && e->dead == dead)
+        return e->value;
+
+    value = ast_gen_supported_uncached(n);
+    e->node = n;
+    e->stamp = ast_support_cache_stamp;
+    e->dead = dead;
+    e->value = value;
+    return value;
+}
+
+static int ast_gen_supported_uncached(const struct AstNode *n)
 {
     if (n == NULL)
         return 0;

--- a/src/dcc/dcc_stmt.c
+++ b/src/dcc/dcc_stmt.c
@@ -74,6 +74,8 @@ void gen_compound(void)
                 struct AstNode *n;
 
                 n = ast_build_stmt(&g_ast_arena);
+                if (n != NULL)
+                    ast_support_cache_begin();
                 if (n == NULL || !ast_stmt_supported(n))
                     fatal("unsupported AST statement");
                 if (ast_stmt_has_reentry_label(n)) {

--- a/tests/diagnostics/baselines/too-many-array-dimensions.txt
+++ b/tests/diagnostics/baselines/too-many-array-dimensions.txt
@@ -1,4 +1,7 @@
 <source>:10: error DCC-E0603: too many array dimensions near ';'
         int a[2][2][2][2][2][2][2][2][2][2][2][2][2];
                                                     ^
-dcc: 1 error(s)
+<source>:11: error DCC-E1002: unsupported for statement near 'for'
+        for (int i0 = 0; i0 < 2; i0++) {
+        ^
+dcc: 2 error(s)

--- a/tests/diagnostics/too-many-array-dimensions.c
+++ b/tests/diagnostics/too-many-array-dimensions.c
@@ -8,5 +8,32 @@
 int f(void)
 {
     int a[2][2][2][2][2][2][2][2][2][2][2][2][2];
+    for (int i0 = 0; i0 < 2; i0++) {
+        for (int i1 = 0; i1 < 2; i1++) {
+            for (int i2 = 0; i2 < 2; i2++) {
+                for (int i3 = 0; i3 < 2; i3++) {
+                    for (int i4 = 0; i4 < 2; i4++) {
+                        for (int i5 = 0; i5 < 2; i5++) {
+                            for (int i6 = 0; i6 < 2; i6++) {
+                                for (int i7 = 0; i7 < 2; i7++) {
+                                    for (int i8 = 0; i8 < 2; i8++) {
+                                        for (int i9 = 0; i9 < 2; i9++) {
+                                            for (int i10 = 0; i10 < 2; i10++) {
+                                                for (int i11 = 0; i11 < 2; i11++) {
+                                                    for (int i12 = 0; i12 < 2; i12++) {
+                                                        a[i0][i1][i2][i3][i4][i5][i6][i7][i8][i9][i10][i11][i12] = 1;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
     return 0;
 }


### PR DESCRIPTION
@davidly 
Add a per-statement cache around ast_gen_supported() so repeated support queries over deeply nested array-index expressions do not explode during frame-size scanning. Reset the cache before each top-level statement gate to avoid stale results across arena reuse and declaration replay.

Extend the too-many-array-dimensions diagnostic fixture with a nested 13D indexing tail, covering the reported dccmake hang: the compiler now reports DCC-E0603 promptly instead of spending unbounded time in AST support gating.

Validation:
- pwsh ./scripts/build-dcc.ps1
- dccmake repro for main.c exits with DCC-E0603/DCC-E1002
- dccmake tests/tvla.c dcc-output=TVLA dcc-peep=true dcc-stack-bytes=2048
- ntvcm build/TVLA.COM
- focused too-many-array-dimensions diagnostic test
- pwsh ./scripts/runall.ps1 -Mode fast