### PR TITLE
Fix emit-time sizeof for nested arrays and supported VLAs

### DIFF
--- a/docs/docs/en/01-c-conformance.md
+++ b/docs/docs/en/01-c-conformance.md
@@ -103,7 +103,7 @@ portability surprises when code is moved from a hosted desktop compiler.
 | `long long` and 64-bit integer types | Not supported |
 | Variable-length arrays with a variable inner dimension (`a[n][m]`) | Not supported; the runtime row stride is not modelled (variable outermost dimension is supported, above) |
 | `goto`/`case` entry into VLA scopes | Not supported; a jump that would bypass a VLA's allocation is rejected. Jumps that *leave* VLA scopes — `break`, `continue`, `return`, and forward or backward `goto` — are fully supported and reclaim the stack correctly |
-| `sizeof` applied to a whole VLA | Not supported; the size is not a compile-time constant, so it is rejected rather than silently miscomputed (`sizeof vla[i]` on a constant-size subobject is fine) |
+| `sizeof` applied to a whole VLA | Supported for DCC's VLA subset; produces the VLA's run-time byte size |
 | `_Complex` and complex arithmetic | Not supported |
 | Full C99 compound literal value semantics | Partly supported only |
 | Flexible array member initialization | Not supported |

--- a/docs/docs/en/03-types-and-conventions.md
+++ b/docs/docs/en/03-types-and-conventions.md
@@ -189,21 +189,22 @@ void f(int n)
 - A **variable inner** dimension, e.g. `int a[n][m]`, because the row stride
   would be a run-time value. Only the outermost dimension may vary. Use an
   explicit index computation or `malloc` for a fully dynamic 2-D array.
-- `sizeof` applied to a **whole** VLA. Its size would be a run-time value; DCC
-  rejects it rather than silently return the wrong value. `sizeof a[0]` and
-  other constant-size subobjects are fine. Track the length yourself:
-
-  ```c
-  int a[n];
-  /* sizeof a;              -> error: not a compile-time size */
-  /* memset(a, 0, sizeof a) -> would be wrong; use the count: */
-  memset(a, 0, (size_t)n * sizeof a[0]);   /* sizeof a[0] is a constant */
-  ```
-
 - Jumping **into** a VLA's scope with `goto`, `case`, or `default` (which would
   bypass the allocation) is rejected, matching a conforming compiler. (Jumping
   *out of* a VLA scope is fine and reclaims the stack — see above.)
 - Variably-modified **types** beyond the array object itself — VLA `typedef`s,
   pointers-to-VLA (`int (*p)[n]`), and run-time-bound VLA function parameters —
   are not modelled.
+
+### `sizeof` on VLAs
+
+`sizeof` applied to a whole VLA produces the array's run-time byte size, matching
+standard C expectations for the supported VLA subset. Constant-size subobjects
+remain compile-time sizes:
+
+```c
+int a[n][3];
+memset(a, 0, sizeof a);        /* run-time value: n * 3 * sizeof(int) */
+sizeof a[0];                  /* compile-time row size: 3 * sizeof(int) */
+```
 

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -246,6 +246,7 @@ struct Sym {
     int *init_sizes;
     int is_array;
     int is_vla;     /* C99 variable-length array: slot holds a runtime pointer */
+    int vla_size_offset; /* frame slot holding the runtime byte size for sizeof */
     int array_len;
     int elem_size; /* stride per first-dimension element */
     int dim_count; /* C array dimensions, e.g. a[2][3] -> 2 */

--- a/src/dcc/dcc_ast.h
+++ b/src/dcc/dcc_ast.h
@@ -183,6 +183,14 @@ int ast_expr_has_side_effects(const struct AstNode *n);
  * deciding whether a multiply subexpression is float-valued for fusion). */
 int ast_expr_type_for_sizeof(const struct AstNode *n);
 
+/* Compute the constant byte size of a `sizeof expr` operand, and (separately)
+ * detect when that operand is a whole variable-length array.  Both resolve
+ * symbols by name, so they must be called at EMIT time - when a nested-block
+ * declaration's span has already run and its symbol is in scope - not at
+ * AST-build time, where such a symbol is not yet in the local table. */
+int ast_sizeof_expr_value(const struct AstNode *n);
+struct Sym *ast_sizeof_whole_vla_sym(const struct AstNode *n);
+
 /* Detects a for-loop whose whole body is one assignment to an array-element
  * lvalue whose address is provably the same on every iteration (see
  * dcc_ast_gen_support.c for the full shape and rationale). Callable from

--- a/src/dcc/dcc_ast_build.c
+++ b/src/dcc/dcc_ast_build.c
@@ -259,7 +259,7 @@ static int ast_expr_is_pointer_assignment_rhs(const struct AstNode *n)
     return 0;
 }
 
-static int ast_sizeof_expr_value(const struct AstNode *n)
+int ast_sizeof_expr_value(const struct AstNode *n)
 {
     struct Sym *s;
     struct FieldDef *fd;
@@ -274,8 +274,6 @@ static int ast_sizeof_expr_value(const struct AstNode *n)
     case AST_IDENT:
         s = find_sym(n->sval);
         if (s != NULL && s->is_array) {
-            if (s->is_vla && asm_suppress_depth == 0)
-                error_here("sizeof applied to a variable-length array is not supported");
             total = sym_array_total_elems(s);
             if (total <= 0)
                 total = 1;
@@ -306,6 +304,18 @@ static int ast_sizeof_expr_value(const struct AstNode *n)
     }
     t = ast_expr_type_for_sizeof(n);
     return type_size(t);
+}
+
+struct Sym *ast_sizeof_whole_vla_sym(const struct AstNode *n)
+{
+    struct Sym *s;
+
+    if (n == NULL || n->kind != AST_IDENT)
+        return NULL;
+    s = find_sym(n->sval);
+    if (s == NULL || !s->is_vla)
+        return NULL;
+    return s;
 }
 
 static void ast_skip_braced_initializer(void)
@@ -526,7 +536,10 @@ static struct AstNode *p_unary(struct AstArena *ar)
             struct AstNode *n = ast_new(ar, AST_SIZEOF_EXPR);
             n->a = p_unary(ar);
             n->type = TYPE_INT;
-            n->ival = ast_sizeof_expr_value(n->a);
+            /* The operand's size is resolved at EMIT time (see
+             * gen_sizeof_expr_ast): a local declared in a nested block only
+             * enters the symbol table when its declaration span is emitted,
+             * which is after this node is built but before it is walked. */
             return n;
         }
     }

--- a/src/dcc/dcc_ast_gen_expr.c
+++ b/src/dcc/dcc_ast_gen_expr.c
@@ -443,6 +443,33 @@ void gen_pointer_cmp_operand_ast(const struct AstNode *n)
     }
 }
 
+static void gen_sizeof_expr_ast(const struct AstNode *n)
+{
+    long val;
+
+    if (n->kind == AST_SIZEOF_EXPR) {
+        /* Resolve the operand at EMIT time.  A local declared in a nested
+         * block only enters the symbol table when its declaration span is
+         * emitted, which happens before this node is walked but after the AST
+         * was built - so a build-time size would resolve the wrong (or no)
+         * symbol.  A whole VLA loads its stored run-time byte size; every
+         * other operand is a compile-time constant. */
+        struct Sym *vsym = ast_sizeof_whole_vla_sym(n->a);
+        if (vsym != NULL && vsym->vla_size_offset != 0) {
+            emit("\tpush ix\n\tpop hl\n");
+            fprintf(outf, "\tld de,%d\n\tadd hl,de\n", vsym->vla_size_offset);
+            emit("\tld a,(hl)\n\tinc hl\n\tld h,(hl)\n\tld l,a\n");
+            g_expr_type = TYPE_INT;
+            return;
+        }
+        val = ast_sizeof_expr_value(n->a);
+    } else {
+        val = n->ival;
+    }
+    fprintf(outf, "\tld hl,%ld\n", val & 0xffffL);
+    g_expr_type = TYPE_INT;
+}
+
 void gen_pointer_cmp_ast(const struct AstNode *n)
 {
     gen_pointer_cmp_operand_ast(n->a);
@@ -3749,8 +3776,7 @@ void ast_gen_expr(const struct AstNode *n)
         break;
     case AST_SIZEOF_EXPR:
     case AST_SIZEOF_TYPE:
-        fprintf(outf, "\tld hl,%ld\n", n->ival & 0xffffL);
-        g_expr_type = TYPE_INT;
+        gen_sizeof_expr_ast(n);
         break;
     case AST_FLOAT_LIT:
         emit_load_float_bits(n->uval);

--- a/src/dcc/dcc_decl.c
+++ b/src/dcc/dcc_decl.c
@@ -947,6 +947,15 @@ static void emit_vla_alloc(struct Sym *s)
     if (s->elem_size > 1)
         emit_mul_hl_const((long)s->elem_size);   /* HL = size in bytes */
 
+    if (s->vla_size_offset != 0) {
+        emit("\tpush hl\n");
+        emit("\tpush ix\n\tpop hl\n");
+        fprintf(outf, "\tld de,%d\n\tadd hl,de\n", s->vla_size_offset);
+        emit("\tpop de\n");
+        emit("\tld (hl),e\n\tinc hl\n\tld (hl),d\n");
+        emit("\tex de,hl\n");
+    }
+
     /* SP -= size; the new SP is the block base, stored into the slot. */
     emit("\tex de,hl\n");
     emit("\tld hl,0\n");
@@ -1113,6 +1122,7 @@ void gen_local_decl_after_type(int base)
                 if (s->elem_size <= 0) s->elem_size = 2;
                 copy_last_array_dims_to_sym(s);
                 if (g_vla_pending) {
+                    struct Sym *size_slot;
                     /* VLA: the frame slot holds a runtime pointer to the
                      * block.  Keep the elem_size set above - the element size
                      * for a[n], or the (constant) row stride for a[n][C] - so
@@ -1121,6 +1131,8 @@ void gen_local_decl_after_type(int base)
                     s->is_vla = 1;
                     s->array_len = 0;
                     if (s->elem_size <= 0) s->elem_size = 1;
+                    size_slot = add_local_alloc("#vlasz", TYPE_INT, 2);
+                    s->vla_size_offset = size_slot->offset;
                     /* Save SP once per scope, before its first VLA, so the
                      * scope's VLAs can be reclaimed at block/loop exit. */
                     {
@@ -1291,7 +1303,7 @@ void gen_local_decl_after_type(int base)
                     }
                 }
             }
-        } else if (freshly_allocated && !local_name_used_ahead(source_name)) {
+        } else if (freshly_allocated && !s->is_vla && !local_name_used_ahead(source_name)) {
             /* No initializer, and never referenced again in this scope:
              * add_local_alloc just appended this Sym as the last local and
              * reserved its frame space, so popping both back off is safe -
@@ -1299,10 +1311,14 @@ void gen_local_decl_after_type(int base)
              * anything above it yet. freshly_allocated (rather than just
              * !s->is_const_value) guards against the redefinition-error
              * recovery case, where s is an unrelated pre-existing symbol and
-             * bytes/nlocals do not describe it. Must match
-             * scan_local_decl_after_type's identical decision exactly, since
-             * that earlier frame-sizing pass already committed to the frame
-             * size this function's prologue was emitted with. */
+             * bytes/nlocals do not describe it. A VLA is never pruned: it has
+             * a side-effecting stack allocation plus hidden #vlasz/#vlasp
+             * slots whose offsets are already baked into emitted save/restore
+             * code, and its `bytes` (2, the pointer slot) does not describe
+             * the whole reservation. scan_local_decl_after_type skips the
+             * prune for the same case via its still-set g_vla_pending guard,
+             * so both passes must agree here (g_vla_pending is already cleared
+             * above in this pass, hence the s->is_vla test instead). */
             nlocals--;
             local_size -= bytes;
         }

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -1666,12 +1666,15 @@ void scan_local_decl_after_type(int base)
                 if (s->elem_size <= 0) s->elem_size = 2;
                 copy_last_array_dims_to_sym(s);
                 if (g_vla_pending) {
+                    struct Sym *size_slot;
                     /* VLA: keep the elem_size set above (element size for
                      * a[n], row stride for a[n][C]); the slot holds a runtime
                      * pointer, mirrored by gen_local_decl_after_type. */
                     s->is_vla = 1;
                     s->array_len = 0;
                     if (s->elem_size <= 0) s->elem_size = 1;
+                    size_slot = add_local_alloc("#vlasz", TYPE_INT, 2);
+                    s->vla_size_offset = size_slot->offset;
                     /* Reserve this scope's SP-save slot (first VLA only) so the
                      * frame matches the codegen pass, which also emits it. */
                     vla_scope_ensure_save_slot();

--- a/tests/baselines/tvla.txt
+++ b/tests/baselines/tvla.txt
@@ -1,3 +1,3 @@
 tvla start
-checks=45 failures=0
+checks=73 failures=0
 tvla ok

--- a/tests/diagnostics/baselines/vla-sizeof.txt
+++ b/tests/diagnostics/baselines/vla-sizeof.txt
@@ -1,4 +1,0 @@
-<source>:4: error DCC-E0001: sizeof applied to a variable-length array is not supported near ';'
-        return (int)sizeof a;
-                            ^
-dcc: 1 error(s)

--- a/tests/diagnostics/vla-sizeof.c
+++ b/tests/diagnostics/vla-sizeof.c
@@ -1,5 +1,0 @@
-int f(int n)
-{
-    int a[n];
-    return (int)sizeof a;
-}

--- a/tests/tc89size.c
+++ b/tests/tc89size.c
@@ -22,6 +22,116 @@ static void chki(const char *name, int got, int expect)
     }
 }
 
+/* Arrays declared in a NESTED scope (a bare block, an if/for body, or several
+ * levels deep) enter the local symbol table only when their declaration is
+ * emitted, not when the enclosing block's AST is built.  sizeof of such an
+ * array must therefore be resolved at emit time.  Regression for a bug where
+ * nested-scope sizeof was computed at AST-build time - before the symbol was
+ * in scope - and silently collapsed to sizeof(int) (so the element-count
+ * idiom returned 1 instead of the true length).  Expectations use element
+ * counts / sizeof(int) so they are int-width independent. */
+static int nb_block_count(void)
+{
+    {
+        int a[10];
+        return (int)(sizeof a / sizeof a[0]);   /* 10 */
+    }
+}
+
+static int nb_block_bytes(void)
+{
+    {
+        int a[10];
+        return (int)sizeof a;                   /* 10 * sizeof(int) */
+    }
+}
+
+static int nb_if_count(int n)
+{
+    if (n > 0) {
+        int a[7];
+        return (int)(sizeof a / sizeof a[0]);   /* 7 */
+    }
+    return -1;
+}
+
+static int nb_loop_count(void)
+{
+    int i;
+    int last = 0;
+    for (i = 0; i < 3; i++) {
+        int a[6];
+        last = (int)(sizeof a / sizeof a[0]);   /* 6 */
+    }
+    return last;
+}
+
+static int nb_deep_count(void)
+{
+    {
+        {
+            {
+                int a[4];
+                return (int)(sizeof a / sizeof a[0]);   /* 4 */
+            }
+        }
+    }
+}
+
+static int nb_2d_rows(void)
+{
+    {
+        int a[5][3];
+        return (int)(sizeof a / sizeof a[0]);   /* 5 rows */
+    }
+}
+
+static int nb_2d_row_bytes(void)
+{
+    {
+        int a[5][3];
+        return (int)sizeof a[0];                /* 3 * sizeof(int) */
+    }
+}
+
+static int nb_char_bytes(void)
+{
+    {
+        char a[9];
+        return (int)sizeof a;                   /* 9 */
+    }
+}
+
+static int nb_between_locals(void)
+{
+    {
+        int guard = 1;
+        int a[8];
+        int tail = 2;
+        int r = (int)(sizeof a / sizeof a[0]);  /* 8 */
+        return r + guard - tail;                /* 8 + 1 - 2 = 7 */
+    }
+}
+
+static int nb_shadow_inner(void)
+{
+    int a[3];
+    {
+        int a[6];
+        return (int)(sizeof a / sizeof a[0]);   /* inner array */
+    }
+}
+
+static int nb_shadow_outer_after(void)
+{
+    int a[5];
+    {
+        int a[2];
+        (void)a;
+    }
+    return (int)(sizeof a / sizeof a[0]);       /* outer array */
+}
+
 int main(void)
 {
     struct SzOne s;
@@ -66,6 +176,19 @@ int main(void)
     chki("sizeof_expr_long", sizeof(ga[0] + 1L), 4);
     chki("sizeof_expr_uint", sizeof(ga[0] + 1U), 2);
     chki("sizeof_compare", sizeof(ga[0] < 1L), 2);
+
+    /* sizeof of arrays declared in nested scopes (resolved at emit time). */
+    chki("nb_block_count", nb_block_count(), 10);
+    chki("nb_block_bytes", nb_block_bytes(), 10 * (int)sizeof(int));
+    chki("nb_if_count", nb_if_count(1), 7);
+    chki("nb_loop_count", nb_loop_count(), 6);
+    chki("nb_deep_count", nb_deep_count(), 4);
+    chki("nb_2d_rows", nb_2d_rows(), 5);
+    chki("nb_2d_row_bytes", nb_2d_row_bytes(), 3 * (int)sizeof(int));
+    chki("nb_char_bytes", nb_char_bytes(), 9);
+    chki("nb_between_locals", nb_between_locals(), 7);
+    chki("nb_shadow_inner", nb_shadow_inner(), 6);
+    chki("nb_shadow_outer_after", nb_shadow_outer_after(), 5);
 
     if (fails) {
         printf("tc89size failed: %d\n", fails);

--- a/tests/tvla.c
+++ b/tests/tvla.c
@@ -7,6 +7,7 @@
  */
 #include <stdio.h>
 #include <setjmp.h>
+#include <string.h>
 
 static int checks = 0;
 static int failures = 0;
@@ -155,6 +156,271 @@ static int fixed_cast_bounds(void)
     int bcount = (int)(sizeof b / sizeof b[0]);
     return (acount == 8) && (bcount == 5);
 }
+
+static int uvp_helper(int x) { return x + 1; }
+
+/* Regression: an UNUSED VLA (its name never referenced again) that is the
+ * first VLA in its scope, followed by a normal local, must NOT let the
+ * dead-local prune drop the VLA's hidden #vlasp/#vlasz slots.  The codegen
+ * pass used to prune the just-allocated VLA (its `bytes` is only the 2-byte
+ * pointer, and g_vla_pending was already cleared), so the following local
+ * aliased the saved-SP slot; the block-exit "ld sp,(#vlasp)" then restored a
+ * garbage SP.  The scan pass never pruned it, so the two passes disagreed.
+ * Fall through the block (so the per-block SP restore runs) and then make a
+ * call, which uses SP - a clobbered SP would corrupt the call. */
+static int unused_vla_prune_fallthrough(int n)
+{
+    int result = 0;
+    {
+        int unused[n];
+        int marker = 22222;
+        result = marker;
+    }
+    result = uvp_helper(result);
+    return result;
+}
+
+/* Same hazard, but with live locals bracketing the block to catch a frame
+ * offset that shifted between the two passes. */
+static int unused_vla_prune_locals(int n)
+{
+    int a = 111;
+    int b = 222;
+    {
+        int unused[n];
+        int c = 333;
+        a = a + c;
+    }
+    b = b + a;
+    return b;
+}
+
+/* Stronger form of the same regression: on the old codegen path, `marker`
+ * reused the hidden #vlasp offset, so block exit restored SP to &result+2.
+ * The following call's argument push then overwrote result itself.  Keep the
+ * address trick DCC-only so the host clang baseline stays well-defined. */
+static int unused_vla_prune_sp_alias(int n)
+{
+#ifdef _DCC_
+    int result = 1234;
+    {
+        int unused[n];
+        int marker = (int)&result + 2;
+        (void)marker;
+    }
+    uvp_helper(0);
+    return result;
+#else
+    (void)n;
+    uvp_helper(0);
+    return 1234;
+#endif
+}
+
+/* Same hidden-slot alias bug, but with the unused VLA and following local in
+ * one declaration statement.  This specifically covers the declaration loop's
+ * comma path after pruning the first declarator. */
+static int unused_vla_prune_same_decl(int n)
+{
+#ifdef _DCC_
+    int result = 4321;
+    {
+        int unused[n], marker = (int)&result + 2;
+        (void)marker;
+    }
+    uvp_helper(0);
+    return result;
+#else
+    (void)n;
+    uvp_helper(0);
+    return 4321;
+#endif
+}
+
+/* ---- sizeof on a VLA (C99 6.5.3.4: the operand is a run-time value) ----
+ *
+ * dcc stores each VLA's run-time byte size in a hidden frame slot when the VLA
+ * is allocated; `sizeof vla` loads that slot.  All expectations below are
+ * written in terms of sizeof(int)/element counts so they are identical on a
+ * 16-bit-int target (dcc) and a 32-bit-int host (the clang baseline). */
+
+/* Whole 1-D VLA: byte size == n elements. */
+static int vla_sizeof_1d(int n)
+{
+    int a[n];
+    return (int)sizeof a;               /* n * sizeof(int) */
+}
+
+/* Whole 2-D VLA with a constant inner dim: n rows * 3 * sizeof(int). */
+static int vla_sizeof_2d(int rows)
+{
+    int a[rows][3];
+    return (int)sizeof a;               /* rows * 3 * sizeof(int) */
+}
+
+/* A constant-size subobject stays a compile-time constant. */
+static int vla_sizeof_element(int n)
+{
+    int a[n];
+    return (int)sizeof a[0];            /* sizeof(int) */
+}
+
+/* The pervasive element-count idiom must yield n regardless of int width. */
+static int vla_sizeof_count(int n)
+{
+    int a[n];
+    return (int)(sizeof a / sizeof a[0]);   /* n */
+}
+
+/* 2-D VLA row count and row size via sizeof. */
+static int vla_sizeof_2d_rows(int rows)
+{
+    int a[rows][3];
+    return (int)(sizeof a / sizeof a[0]);   /* rows */
+}
+
+static int vla_sizeof_2d_row(int rows)
+{
+    int a[rows][3];
+    return (int)sizeof a[0];            /* 3 * sizeof(int) */
+}
+
+/* char VLA: element size is 1 on every target, so byte size == n. */
+static int vla_sizeof_char(int n)
+{
+    char b[n];
+    return (int)sizeof b;               /* n */
+}
+
+/* The VLA bound (with a side effect) is evaluated exactly once; sizeof reads
+ * the stored size afterwards rather than re-evaluating the bound. */
+static int vla_sizeof_saved_once(int n)
+{
+    int calls = n;
+    int a[calls++];
+    /* count is n (calls++ used n); calls is n+1 iff evaluated exactly once. */
+    return (int)(sizeof a / sizeof a[0]) * 1000 + calls;
+}
+
+/* sizeof as the byte count of a memset over the whole VLA. */
+static int vla_memset_sizeof(int n)
+{
+    int a[n];
+    int i;
+    int s = 0;
+    memset(a, 0, sizeof a);
+    for (i = 0; i < n; i++)
+        s += a[i];
+    return s;                           /* 0 */
+}
+
+/* --- sizeof of a VLA declared in a NESTED scope ---
+ * A nested-block declaration only enters the symbol table when its span is
+ * emitted, so sizeof must be resolved at emit time.  These would silently
+ * return the wrong size if sizeof were baked at AST-build time. */
+static int vla_sizeof_nested_block(int n)
+{
+    int r = 0;
+    {
+        int a[n];
+        r = (int)(sizeof a / sizeof a[0]);      /* n */
+    }
+    return r;
+}
+
+static int vla_sizeof_if_body(int n)
+{
+    int r = -1;
+    if (n > 0) {
+        int a[n];
+        r = (int)(sizeof a / sizeof a[0]);      /* n */
+    }
+    return r;
+}
+
+static int vla_sizeof_deep_nested(int n)
+{
+    {
+        {
+            {
+                int a[n];
+                return (int)(sizeof a / sizeof a[0]);   /* n */
+            }
+        }
+    }
+}
+
+/* A VLA re-declared each loop iteration with a changing bound: sizeof must
+ * reflect the current iteration's size, not a stale one. */
+static int vla_sizeof_loop_changes(int n)
+{
+    int i;
+    int acc = 0;
+    for (i = 1; i <= n; i++) {
+        int a[i];
+        acc += (int)(sizeof a / sizeof a[0]);   /* += i */
+    }
+    return acc;                                 /* 1+2+...+n */
+}
+
+/* sizeof of the FIRST VLA taken after a SECOND VLA is declared: exercises the
+ * per-VLA hidden size-slot offsets staying distinct and correct. */
+static int vla_sizeof_first_after_second(int n)
+{
+    int a[n];
+    int b[n + 5];
+    int cb = (int)(sizeof b / sizeof b[0]);     /* n+5 */
+    int ca = (int)(sizeof a / sizeof a[0]);     /* n */
+    return ca * 1000 + cb;
+}
+
+static int vla_sizeof_shadow_inner(int n)
+{
+    int a[3];
+    {
+        int a[n];
+        return (int)(sizeof a / sizeof a[0]);   /* inner VLA */
+    }
+}
+
+static int vla_sizeof_shadow_outer_after(int n)
+{
+    int a[n];
+    {
+        int a[4];
+        (void)a;
+    }
+    return (int)(sizeof a / sizeof a[0]);       /* outer VLA */
+}
+
+/* --- sizeof of a VLA as an operand of arithmetic/bitwise operators ---
+ * A whole-VLA sizeof is a run-time value, so these must NOT be folded as if
+ * sizeof were a compile-time constant (which would read a stale immediate). */
+static int vla_sizeof_op_sub(int n)   { int a[n]; return (int)(sizeof a - 2); }
+static int vla_sizeof_op_add(int n)   { int a[n]; return (int)(sizeof a + 1); }
+static int vla_sizeof_op_and(int n)   { int a[n]; return (int)(sizeof a & 7); }
+static int vla_sizeof_op_mullhs(int n){ int a[n]; return (int)(3 * sizeof a); }
+static int vla_sizeof_op_mulrhs(int n){ int a[n]; return (int)(sizeof a * 3); }
+static int vla_sizeof_op_cmp(int n)   { int a[n]; return sizeof a == (unsigned)(n * sizeof(int)); }
+
+/* sizeof of a VLA used as a subscript index (run-time value). */
+static int vla_sizeof_subscript(int n)
+{
+    static int table[64];
+    int a[n];
+    int i;
+    for (i = 0; i < 64; i++)
+        table[i] = i + 1;
+    return table[sizeof a];             /* table[n*sizeof(int)] = n*sizeof(int)+1 */
+}
+
+/* sizeof of a VLA in ternary / comma / loop-condition contexts. */
+static int vla_sizeof_ternary(int n)
+{
+    int a[n];
+    return (sizeof a > sizeof a[0]) ? (int)(sizeof a / sizeof a[0]) : -1;   /* n for n>1 */
+}
+
 
 /* Three-dimensional VLA: variable outer, constant inner dims. */
 static int vla_3d(int n)
@@ -705,6 +971,47 @@ int main(void)
     check_int("fixed_sizeof_bounds", fixed_sizeof_bounds(123), 1);
     /* A cast of a constant bound is a fixed-size array, not a VLA. */
     check_int("fixed_cast_bounds", fixed_cast_bounds(), 1);
+
+    /* An unused VLA must not be pruned (would clobber the saved SP). */
+    check_int("unused_vla_prune_fallthrough",
+              unused_vla_prune_fallthrough(4), 22223);
+    check_int("unused_vla_prune_locals",
+              unused_vla_prune_locals(4), 666);
+    check_int("unused_vla_prune_sp_alias",
+              unused_vla_prune_sp_alias(4), 1234);
+    check_int("unused_vla_prune_same_decl",
+              unused_vla_prune_same_decl(4), 4321);
+
+    /* sizeof on a whole VLA yields its run-time size; expectations are written
+     * via sizeof(int) so they hold on both a 16-bit and a 32-bit int target. */
+    check_int("vla_sizeof_1d", vla_sizeof_1d(5), 5 * (int)sizeof(int));
+    check_int("vla_sizeof_2d", vla_sizeof_2d(4), 4 * 3 * (int)sizeof(int));
+    check_int("vla_sizeof_element", vla_sizeof_element(9), (int)sizeof(int));
+    check_int("vla_sizeof_count", vla_sizeof_count(7), 7);
+    check_int("vla_sizeof_2d_rows", vla_sizeof_2d_rows(4), 4);
+    check_int("vla_sizeof_2d_row", vla_sizeof_2d_row(4), 3 * (int)sizeof(int));
+    check_int("vla_sizeof_char", vla_sizeof_char(6), 6);
+    check_int("vla_sizeof_saved_once", vla_sizeof_saved_once(5), 5 * 1000 + 6);
+    check_int("vla_memset_sizeof", vla_memset_sizeof(6), 0);
+    /* nested-scope VLA sizeof (resolved at emit time, not AST-build time) */
+    check_int("vla_sizeof_nested_block", vla_sizeof_nested_block(6), 6);
+    check_int("vla_sizeof_if_body", vla_sizeof_if_body(6), 6);
+    check_int("vla_sizeof_deep_nested", vla_sizeof_deep_nested(6), 6);
+    check_int("vla_sizeof_loop_changes", vla_sizeof_loop_changes(5), 15);
+    check_int("vla_sizeof_first_after_second", vla_sizeof_first_after_second(6), 6 * 1000 + 11);
+    check_int("vla_sizeof_shadow_inner", vla_sizeof_shadow_inner(6), 6);
+    check_int("vla_sizeof_shadow_outer_after", vla_sizeof_shadow_outer_after(6), 6);
+    /* sizeof-of-VLA as an operand: must use the run-time value, not a stale
+     * folded immediate. */
+    check_int("vla_sizeof_op_sub", vla_sizeof_op_sub(6), 6 * (int)sizeof(int) - 2);
+    check_int("vla_sizeof_op_add", vla_sizeof_op_add(6), 6 * (int)sizeof(int) + 1);
+    check_int("vla_sizeof_op_and", vla_sizeof_op_and(6), (6 * (int)sizeof(int)) & 7);
+    check_int("vla_sizeof_op_mullhs", vla_sizeof_op_mullhs(6), 3 * 6 * (int)sizeof(int));
+    check_int("vla_sizeof_op_mulrhs", vla_sizeof_op_mulrhs(6), 6 * (int)sizeof(int) * 3);
+    check_int("vla_sizeof_op_cmp", vla_sizeof_op_cmp(6), 1);
+    check_int("vla_sizeof_subscript", vla_sizeof_subscript(6), 6 * (int)sizeof(int) + 1);
+    check_int("vla_sizeof_ternary", vla_sizeof_ternary(6), 6);
+
     /* 3-D VLA (variable outer, constant inner) for n=3 -> 45 */
     check_int("vla_3d", vla_3d(3), 45);
 


### PR DESCRIPTION
@davidly 

Move `sizeof expr` resolution from AST-build time to emit time. Nested-block declarations are represented as AST declaration spans and only enter the local symbol table while that span is emitted, so build-time sizing could bind the wrong symbol or no symbol at all. This fixed an existing bug where `sizeof` of regular arrays declared in nested scopes collapsed to scalar `sizeof(int)`, breaking idioms like `sizeof a / sizeof a[0]`.

Extend the same emit-time path to supported whole-VLA operands. Each VLA now gets a hidden frame slot containing its runtime byte size, stored during VLA allocation and loaded for `sizeof a`. Constant-size subobjects such as `sizeof a[0]` remain compile-time constants, and constant-expression contexts still reject whole-VLA `sizeof`.

Keep scan/codegen frame layout aligned for the new VLA size slots and prevent dead-local pruning from removing unused VLA declarations. An unused VLA still has side-effecting stack allocation plus hidden `#vlasz`/`#vlasp` slots whose offsets are baked into emitted save/restore code.

Add regressions for:
- nested-scope regular array `sizeof`
- whole-VLA `sizeof` in runtime expressions
- VLA `sizeof` in arithmetic, subscript, ternary, memset, and nested scopes
- same-name shadowing across nested scopes
- unused-VLA frame-slot pruning, including same-declaration cases

Update the conformance docs to describe supported whole-VLA `sizeof`, and remove the obsolete diagnostic test that expected normal expression `sizeof` on a VLA to fail.