### PR TITLE
Diagnose missing user includes with file+line instead of generic fatal

### DIFF
--- a/src/dcc/dcc.c
+++ b/src/dcc/dcc.c
@@ -436,6 +436,21 @@ char *preprocess_includes_file(const char *name, int depth, long *out_len)
                     }
                 } else {
                     make_include_path(name, incname, incpath, sizeof(incpath));
+                    {
+                        FILE *probe = fopen(incpath, "rb");
+                        if (!probe) {
+                            /* A quoted user include that cannot be found is a
+                             * hard error.  Report it against the including file
+                             * and line (rather than letting read_file() abort
+                             * with a generic "cannot open input") so the
+                             * diagnostic points at the offending #include. */
+                            char diag[320];
+                            sprintf(diag, "cannot open include file '%s'", incname);
+                            report_include_error(name, src_line, diag);
+                            exit(1);
+                        }
+                        fclose(probe);
+                    }
                     incsrc = preprocess_includes_file(incpath, depth + 1, &inc_len);
                     append_mem(&out, &out_len2, &out_cap, incsrc, inc_len);
                     append_mem(&out, &out_len2, &out_cap, "\n", 1);

--- a/src/dcc/dcc_diag_emit.c
+++ b/src/dcc/dcc_diag_emit.c
@@ -46,6 +46,7 @@ const char *dcc_diag_code_for_message(const char *msg)
     if (dcc_msg_has(msg, "expected \"FILENAME\" or <FILENAME>")) return "DCC-E0301";
     if (dcc_msg_has(msg, "include name too long")) return "DCC-E0302";
     if (dcc_msg_has(msg, "unterminated include name")) return "DCC-E0303";
+    if (dcc_msg_has(msg, "cannot open include file")) return "DCC-E0304";
     if (dcc_msg_has(msg, "not a valid preprocessor directive")) return "DCC-E0310";
     if (dcc_msg_has(msg, "unknown preprocessor directive")) return "DCC-E0310";
     if (dcc_msg_has(msg, "too many nested #if")) return "DCC-E0311";

--- a/tests/diagnostics/baselines/include-missing.txt
+++ b/tests/diagnostics/baselines/include-missing.txt
@@ -1,0 +1,1 @@
+<source>:1: error DCC-E0304: cannot open include file 'definitely_missing_header.h'

--- a/tests/diagnostics/include-missing.c
+++ b/tests/diagnostics/include-missing.c
@@ -1,0 +1,3 @@
+#include "definitely_missing_header.h"
+
+int x;


### PR DESCRIPTION
@davidly 
A missing `#include "user.h"` previously fell through to read_file()'s generic `dcc: fatal: cannot open input: <name>`, which didn't point at the offending #include. Probe the resolved path in preprocess_includes_file() and emit a proper diagnostic against the including file and line via report_include_error(), with new code DCC-E0304.

Missing <system.h> includes remain silently dropped (runtime-provided model) and valid quoted includes still compile.

- src/dcc/dcc.c: probe user include before read_file; report + exit
- src/dcc/dcc_diag_emit.c: map "cannot open include file" -> DCC-E0304
- tests/diagnostics/include-missing.c (+baseline): regression coverage