### PR TITLE
Implement #pragma once include-splicer support

### DIFF
--- a/src/dcc/dcc.c
+++ b/src/dcc/dcc.c
@@ -15,6 +15,10 @@
 #include "dcc.h"
 #include "dcc_ast.h"
 
+#ifdef _WIN32
+#include <direct.h>
+#endif
+
 void append_mem(char **outp, long *lenp, long *capp, const char *s, long n);
 
 long file_size(FILE *f)
@@ -140,9 +144,12 @@ char *read_file(const char *name, long *lenp)
 }
 
 #define MAX_INCLUDE_DEPTH 8
+#define MAX_PRAGMA_ONCE_FILES 256
 
 static const char *include_dirs[MAX_INCLUDE_DIRS];
 static int num_include_dirs;
+static char pragma_once_files[MAX_PRAGMA_ONCE_FILES][512];
+static int num_pragma_once_files;
 
 void add_include_dir(const char *dir)
 {
@@ -300,6 +307,341 @@ int report_include_error(const char *file, int line, const char *msg)
     return -1;
 }
 
+void canonical_include_path(const char *name, char *out, int outsz)
+{
+    char *p;
+
+    /*
+     * Let the platform routine allocate the buffer: realpath() may write up to
+     * PATH_MAX bytes (4096 on Linux), so a fixed on-stack buffer risks an
+     * overflow.  Both realpath(x, NULL) (POSIX.1-2008 / glibc / macOS) and
+     * _fullpath(NULL, x, 0) (MSVC) malloc a right-sized result for us.
+     */
+#ifdef _WIN32
+    p = _fullpath(NULL, name, 0);
+#else
+    p = realpath(name, NULL);
+#endif
+
+    if (!p) {
+        /* Not resolvable (e.g. file does not exist): fall back to the raw
+         * name; read_file() will report the real error later. */
+        if ((int)strlen(name) >= outsz)
+            fatal("include path too long");
+        strcpy(out, name);
+        return;
+    }
+
+    if ((int)strlen(p) >= outsz) {
+        free(p);
+        fatal("include path too long");
+    }
+
+    strcpy(out, p);
+    free(p);
+}
+
+int find_pragma_once_file(const char *path)
+{
+    int i;
+
+    for (i = 0; i < num_pragma_once_files; ++i) {
+        if (!strcmp(pragma_once_files[i], path))
+            return i;
+    }
+    return -1;
+}
+
+void mark_pragma_once_file(const char *path)
+{
+    if (find_pragma_once_file(path) >= 0)
+        return;
+
+    if (num_pragma_once_files >= MAX_PRAGMA_ONCE_FILES)
+        fatal("too many #pragma once files");
+
+    strcpy(pragma_once_files[num_pragma_once_files++], path);
+}
+
+/* Track #if/#ifdef/#ifndef/#elif/#else/#endif nesting during include splicing so
+ * that `#pragma once` (and recursion into #include) can be gated on the active
+ * region.  Returns 1 if the line is a conditional directive - the caller still
+ * emits its verbatim text so the later active-source filter pass sees it - or 0
+ * otherwise. */
+int include_cond_update(const char *line, long n,
+                        int *astk, int *btk, int *selse,
+                        int *spp, int *activep)
+{
+    const char *s = line;
+    const char *e = line + n;
+    char word[16];
+    int wi;
+    int sp = *spp;
+    int active = *activep;
+
+    while (s < e && (*s == ' ' || *s == '\t'))
+        s++;
+    if (s >= e || *s != '#')
+        return 0;
+    s++;
+    while (s < e && (*s == ' ' || *s == '\t'))
+        s++;
+    wi = 0;
+    while (s < e && is_ident_char((unsigned char)*s) && wi < (int)sizeof(word) - 1)
+        word[wi++] = *s++;
+    word[wi] = 0;
+
+    if (!strcmp(word, "ifdef") || !strcmp(word, "ifndef")) {
+        char name[64];
+        int ni;
+        int cond;
+        while (s < e && (*s == ' ' || *s == '\t'))
+            s++;
+        ni = 0;
+        while (s < e && is_ident_char((unsigned char)*s) && ni < (int)sizeof(name) - 1)
+            name[ni++] = *s++;
+        name[ni] = 0;
+        cond = (name[0] && find_define(name) >= 0);
+        if (!strcmp(word, "ifndef"))
+            cond = !cond;
+        if (sp < MAX_IFSTACK) {
+            astk[sp] = active;
+            btk[sp] = (active && cond) ? 1 : 0;
+            selse[sp] = 0;
+            active = active && cond;
+            sp++;
+        }
+    } else if (!strcmp(word, "if")) {
+        char expr[512];
+        int ei = 0;
+        int cond;
+        while (s < e && ei < (int)sizeof(expr) - 1)
+            expr[ei++] = *s++;
+        expr[ei] = 0;
+        strip_macro_replacement_comments(expr);
+        cond = pp_eval_simple_expr(expr);
+        if (sp < MAX_IFSTACK) {
+            astk[sp] = active;
+            btk[sp] = (active && cond) ? 1 : 0;
+            selse[sp] = 0;
+            active = active && cond;
+            sp++;
+        }
+    } else if (!strcmp(word, "elif")) {
+        if (sp > 0) {
+            int i = sp - 1;
+            int parent = astk[i];
+            if (selse[i] || btk[i]) {
+                active = 0;
+            } else {
+                char expr[512];
+                int ei = 0;
+                int cond;
+                while (s < e && ei < (int)sizeof(expr) - 1)
+                    expr[ei++] = *s++;
+                expr[ei] = 0;
+                strip_macro_replacement_comments(expr);
+                cond = pp_eval_simple_expr(expr);
+                active = parent && cond;
+                if (active)
+                    btk[i] = 1;
+            }
+        }
+    } else if (!strcmp(word, "else")) {
+        if (sp > 0) {
+            int i = sp - 1;
+            int parent = astk[i];
+            if (!selse[i]) {
+                active = parent && !btk[i];
+                btk[i] = 1;
+                selse[i] = 1;
+            } else {
+                active = 0;
+            }
+        }
+    } else if (!strcmp(word, "endif")) {
+        if (sp > 0) {
+            sp--;
+            active = astk[sp];
+        }
+    } else {
+        return 0;
+    }
+
+    *spp = sp;
+    *activep = active;
+    return 1;
+}
+
+int include_scan_macro_directive(const char *line, long n, int active)
+{
+    const char *s = line;
+    const char *e = line + n;
+    char word[16];
+    int wi;
+
+    while (s < e && (*s == ' ' || *s == '\t'))
+        s++;
+    if (s >= e || *s != '#')
+        return 0;
+    s++;
+    while (s < e && (*s == ' ' || *s == '\t'))
+        s++;
+
+    wi = 0;
+    while (s < e && is_ident_char((unsigned char)*s) && wi < (int)sizeof(word) - 1)
+        word[wi++] = *s++;
+    word[wi] = 0;
+
+    if (!strcmp(word, "undef")) {
+        char name[64];
+        int ni;
+
+        if (!active)
+            return 1;
+        while (s < e && (*s == ' ' || *s == '\t'))
+            s++;
+        ni = 0;
+        while (s < e && is_ident_char((unsigned char)*s) && ni < (int)sizeof(name) - 1)
+            name[ni++] = *s++;
+        name[ni] = 0;
+        if (name[0])
+            remove_define(name);
+        return 1;
+    }
+
+    if (!strcmp(word, "define")) {
+        char name[64];
+        char val[MAX_MACRO_TEXT];
+        char params[8][32];
+        int nargs;
+        int ni;
+        int vi;
+
+        if (!active)
+            return 1;
+        while (s < e && (*s == ' ' || *s == '\t'))
+            s++;
+        ni = 0;
+        while (s < e && is_ident_char((unsigned char)*s) && ni < (int)sizeof(name) - 1)
+            name[ni++] = *s++;
+        name[ni] = 0;
+        if (!name[0])
+            return 1;
+
+        memset(params, 0, sizeof(params));
+        nargs = 0;
+        if (s < e && *s == '(') {
+            s++;
+            while (s < e && *s != ')') {
+                char pname[32];
+                int pi;
+                while (s < e && (*s == ' ' || *s == '\t'))
+                    s++;
+                if (s >= e || *s == ')')
+                    break;
+
+                if (s + 2 < e && s[0] == '.' && s[1] == '.' && s[2] == '.') {
+                    s += 3;
+                    if (nargs < 8) {
+                        strcpy(params[nargs], "__VA_ARGS__");
+                        nargs++;
+                    }
+                    while (s < e && (*s == ' ' || *s == '\t'))
+                        s++;
+                    if (s < e && *s == ',')
+                        s++;
+                    continue;
+                }
+
+                pi = 0;
+                while (s < e && is_ident_char((unsigned char)*s) && pi < 31)
+                    pname[pi++] = *s++;
+                pname[pi] = 0;
+                if (pname[0] && nargs < 8) {
+                    strcpy(params[nargs], pname);
+                    nargs++;
+                }
+                while (s < e && (*s == ' ' || *s == '\t'))
+                    s++;
+                if (s < e && *s == ',') {
+                    s++;
+                } else if (s < e && *s != ')') {
+                    s++;
+                }
+            }
+            if (s < e && *s == ')')
+                s++;
+            while (s < e && (*s == ' ' || *s == '\t'))
+                s++;
+            vi = 0;
+            while (s < e && vi < (int)sizeof(val) - 1)
+                val[vi++] = *s++;
+            while (vi > 0 && (val[vi - 1] == ' ' || val[vi - 1] == '\t' || val[vi - 1] == '\r'))
+                vi--;
+            val[vi] = 0;
+            strip_macro_replacement_comments(val);
+            add_define_ex(name, val[0] ? val : "1", 1, nargs, params);
+        } else {
+            while (s < e && (*s == ' ' || *s == '\t'))
+                s++;
+            vi = 0;
+            while (s < e && vi < (int)sizeof(val) - 1)
+                val[vi++] = *s++;
+            while (vi > 0 && (val[vi - 1] == ' ' || val[vi - 1] == '\t' || val[vi - 1] == '\r'))
+                vi--;
+            val[vi] = 0;
+            strip_macro_replacement_comments(val);
+            add_define(name, val[0] ? val : "1");
+        }
+        return 1;
+    }
+
+    return 0;
+}
+
+int try_parse_pragma_once(const char *line, long n)
+{
+    long i;
+
+    i = 0;
+    while (i < n && (line[i] == ' ' || line[i] == '\t'))
+        i++;
+
+    if (i >= n || line[i] != '#')
+        return 0;
+    i++;
+
+    while (i < n && (line[i] == ' ' || line[i] == '\t'))
+        i++;
+
+    if (i + 6 > n || memcmp(line + i, "pragma", 6) != 0)
+        return 0;
+    i += 6;
+
+    if (i >= n || (line[i] != ' ' && line[i] != '\t'))
+        return 0;
+
+    while (i < n && (line[i] == ' ' || line[i] == '\t'))
+        i++;
+
+    if (i + 4 > n || memcmp(line + i, "once", 4) != 0)
+        return 0;
+    i += 4;
+
+    while (i < n && (line[i] == ' ' || line[i] == '\t' || line[i] == '\r'))
+        i++;
+
+    if (i == n)
+        return 1;
+
+    /* Tolerate a trailing comment after the directive (line or block form). */
+    if (i + 1 < n && line[i] == '/' && (line[i + 1] == '/' || line[i + 1] == '*'))
+        return 1;
+
+    return 0;
+}
+
 int try_parse_include(const char *line, long n, const char *file, int src_line,
                               char *name, int namesz, int *is_system)
 {
@@ -380,9 +722,23 @@ char *preprocess_includes_file(const char *name, int depth, long *out_len)
     long line_start;
     long line_end;
     int src_line;
+    char once_path[512];
+    int if_active[MAX_IFSTACK];
+    int if_taken[MAX_IFSTACK];
+    int if_seen_else[MAX_IFSTACK];
+    int if_sp;
+    int active;
 
     if (depth > MAX_INCLUDE_DEPTH)
         fatal("too many nested includes");
+
+    canonical_include_path(name, once_path, sizeof(once_path));
+    if (find_pragma_once_file(once_path) >= 0) {
+        out = (char *)xmalloc(1);
+        out[0] = 0;
+        out_len[0] = 0;
+        return out;
+    }
 
     raw = read_file(name, &raw_len);
 
@@ -390,6 +746,8 @@ char *preprocess_includes_file(const char *name, int depth, long *out_len)
     out_len2 = 0;
     out_cap = 0;
     src_line = 1;
+    if_sp = 0;
+    active = 1;
 
     append_line_directive(&out, &out_len2, &out_cap, 1, name);
 
@@ -407,13 +765,42 @@ char *preprocess_includes_file(const char *name, int depth, long *out_len)
         {
             int is_system = 0;
             int include_status;
-            include_status = try_parse_include(raw + line_start,
-                                               line_end - line_start,
-                                               name,
-                                               src_line,
-                                               incname,
-                                               sizeof(incname),
-                                               &is_system);
+            if (include_cond_update(raw + line_start, line_end - line_start,
+                                    if_active, if_taken, if_seen_else,
+                                    &if_sp, &active)) {
+                /* Conditional directive: keep it verbatim so the later
+                 * active-source filter pass still balances #if/#endif. */
+                include_status = 0;
+            } else if (include_scan_macro_directive(raw + line_start,
+                                                    line_end - line_start,
+                                                    active)) {
+                /* Keep the directive in the stream; this mutation is only for
+                 * include-splice conditionals and is restored before filtering. */
+                include_status = 0;
+            } else if (try_parse_pragma_once(raw + line_start, line_end - line_start)) {
+                if (active) {
+                    mark_pragma_once_file(once_path);
+                    include_status = -1;
+                } else {
+                    /* Dead-code pragma (e.g. inside #if 0): do not honor it;
+                     * leave the line for the filter pass to drop. */
+                    include_status = 0;
+                }
+            } else {
+                include_status = try_parse_include(raw + line_start,
+                                                   line_end - line_start,
+                                                   name,
+                                                   src_line,
+                                                   incname,
+                                                   sizeof(incname),
+                                                   &is_system);
+                if (include_status > 0 && !active) {
+                    /* #include inside an inactive block: drop it instead of
+                     * recursively expanding the header (which would also mark
+                     * its #pragma once) from dead code. */
+                    include_status = -1;
+                }
+            }
             if (include_status > 0) {
                 if (is_system) {
                     /* For system includes (<foo.h>), try the local directory
@@ -1139,7 +1526,24 @@ int main(int argc, char **argv)
     strncpy(current_file_name, input_name, sizeof(current_file_name) - 1);
     current_file_name[sizeof(current_file_name) - 1] = 0;
 
-    src = preprocess_includes_file(input_name, 0, &src_len);
+    {
+        int saved_ndefs;
+        struct Def *saved_defs;
+
+        /* Include splicing tracks active #define/#undef directives so that
+         * #pragma once under #if/#ifdef sees source-order macro state. Restore
+         * the table afterward: the expanded source still contains those
+         * directives, and the active-source filter must replay them normally. */
+        saved_defs = (struct Def *)xmalloc(sizeof(defs));
+        saved_ndefs = ndefs;
+        memcpy(saved_defs, defs, sizeof(defs));
+
+        src = preprocess_includes_file(input_name, 0, &src_len);
+
+        ndefs = saved_ndefs;
+        memcpy(defs, saved_defs, sizeof(defs));
+        free(saved_defs);
+    }
     {
         char *filtered_src;
         long filtered_len;

--- a/src/dcc/dcc_global_scan.c
+++ b/src/dcc/dcc_global_scan.c
@@ -166,6 +166,15 @@ void scan_global_write_info(void)
     memcpy(saved_src, src, (size_t)src_len + 1);
     saved_src_len = src_len;
 
+    /* This scan tokenises the whole file purely for its write/addr-taken
+     * bookkeeping; the real pass re-tokenises the same source afterward. Any
+     * lexer/preprocessor diagnostic here (over-long string literal, function-
+     * like macro arg-count mismatch, ...) would therefore be emitted twice, so
+     * suppress diagnostics for the duration - the real pass is the one that
+     * surfaces them to the user. This also keeps the scan from tripping the
+     * errors>40 fatal before real compilation begins. */
+    asm_suppress_depth++;
+
     posi = 0;
     tok_start_pos = 0;
     line_no = 1;
@@ -244,6 +253,8 @@ void scan_global_write_info(void)
         (void)prev_text;
         next_token();
     }
+
+    asm_suppress_depth--;
 
     ndefs = saved_ndefs;
     memcpy(defs, saved_defs, sizeof(defs));

--- a/tests/baselines/tponce.txt
+++ b/tests/baselines/tponce.txt
@@ -1,0 +1,2 @@
+tponce start
+tponce completed with great success

--- a/tests/diagnostics/baselines/pragma-once-conditional-edges.txt
+++ b/tests/diagnostics/baselines/pragma-once-conditional-edges.txt
@@ -1,0 +1,4 @@
+<source>:21: error DCC-E0312: #error conditional pragma once edges were handled correctly
+    #error conditional pragma once edges were handled correctly
+    ^
+dcc: 1 error(s)

--- a/tests/diagnostics/baselines/pragma-once-dead-code.txt
+++ b/tests/diagnostics/baselines/pragma-once-dead-code.txt
@@ -1,0 +1,4 @@
+<source>:16: error DCC-E0312: #error dead-code pragma once was correctly ignored
+    #error dead-code pragma once was correctly ignored
+    ^
+dcc: 1 error(s)

--- a/tests/diagnostics/baselines/pragma-once-macro-conditions.txt
+++ b/tests/diagnostics/baselines/pragma-once-macro-conditions.txt
@@ -1,0 +1,4 @@
+<source>:22: error DCC-E0312: #error macro-controlled pragma once conditions were handled correctly
+    #error macro-controlled pragma once conditions were handled correctly
+    ^
+dcc: 1 error(s)

--- a/tests/diagnostics/pragma-once-conditional-edges.c
+++ b/tests/diagnostics/pragma-once-conditional-edges.c
@@ -1,0 +1,27 @@
+/*
+ * Regression guard (compile-fail): conditional tracking in the include splicer
+ * must match preprocessing closely enough for #pragma once.
+ *
+ * - pragma-once-ifdef-dead.h puts #pragma once under an inactive #ifdef; it
+ *   must be ignored, so including the header twice makes PODC_IFDEF_VAL == 2.
+ * - pragma-once-else-live.h puts #pragma once under the live #else branch after
+ *   an undefined #if; it must be honored, so including the header twice leaves
+ *   PODC_ELSE_VAL == 1.
+ *
+ * Correct behavior fires the #error below. A regression in either edge case
+ * makes the expression false, dcc exits 0, and the diagnostics harness reports
+ * "expected compile failure, got success".
+ */
+#include "pragma-once-ifdef-dead.h"
+#include "pragma-once-ifdef-dead.h"
+#include "pragma-once-else-live.h"
+#include "pragma-once-else-live.h"
+
+#if PODC_IFDEF_VAL == 2 && PODC_ELSE_VAL == 1
+#error conditional pragma once edges were handled correctly
+#endif
+
+int main(void)
+{
+    return 0;
+}

--- a/tests/diagnostics/pragma-once-dead-code.c
+++ b/tests/diagnostics/pragma-once-dead-code.c
@@ -1,0 +1,22 @@
+/*
+ * Regression guard (compile-fail): a #pragma once inside #if 0 is dead code and
+ * must be IGNORED, so pragma-once-dead.h is expanded on both includes and
+ * PODC_VAL becomes 2.  The #error below then fires - that diagnostic is the
+ * expected result recorded in the baseline.
+ *
+ * If a regression makes dcc honor the dead #pragma once, the second include is
+ * skipped, PODC_VAL stays 1, the #error does not fire, dcc compiles cleanly and
+ * exits 0, and the diagnostics harness reports "expected compile failure, got
+ * success".
+ */
+#include "pragma-once-dead.h"
+#include "pragma-once-dead.h"
+
+#if PODC_VAL == 2
+#error dead-code pragma once was correctly ignored
+#endif
+
+int main(void)
+{
+    return 0;
+}

--- a/tests/diagnostics/pragma-once-dead.h
+++ b/tests/diagnostics/pragma-once-dead.h
@@ -1,0 +1,16 @@
+/* Dead-code #pragma once helper for pragma-once-dead-code.c.
+ *
+ * The #pragma once below is inside #if 0 (dead code) and must be ignored, so
+ * this header is expanded on every include.  It only toggles macros, so it is
+ * safe to include more than once.  Each expansion advances PODC_VAL 1 -> 2. */
+#if 0
+#pragma once
+#endif
+
+#ifdef PODC_SEEN
+#undef PODC_VAL
+#define PODC_VAL 2
+#else
+#define PODC_SEEN
+#define PODC_VAL 1
+#endif

--- a/tests/diagnostics/pragma-once-else-live.h
+++ b/tests/diagnostics/pragma-once-else-live.h
@@ -1,0 +1,13 @@
+/* #pragma once under the live #else branch of an undefined #if must be honored. */
+#if PODC_NOT_DEFINED
+#else
+#pragma once
+#endif
+
+#ifdef PODC_ELSE_SEEN
+#undef PODC_ELSE_VAL
+#define PODC_ELSE_VAL 2
+#else
+#define PODC_ELSE_SEEN
+#define PODC_ELSE_VAL 1
+#endif

--- a/tests/diagnostics/pragma-once-ifdef-dead.h
+++ b/tests/diagnostics/pragma-once-ifdef-dead.h
@@ -1,0 +1,12 @@
+/* #pragma once under an inactive #ifdef must be ignored. */
+#ifdef PODC_NOT_DEFINED
+#pragma once
+#endif
+
+#ifdef PODC_IFDEF_SEEN
+#undef PODC_IFDEF_VAL
+#define PODC_IFDEF_VAL 2
+#else
+#define PODC_IFDEF_SEEN
+#define PODC_IFDEF_VAL 1
+#endif

--- a/tests/diagnostics/pragma-once-macro-conditions.c
+++ b/tests/diagnostics/pragma-once-macro-conditions.c
@@ -1,0 +1,28 @@
+/*
+ * Regression guard (compile-fail): include-splicer #pragma once conditionals
+ * must see active #define/#undef directives encountered earlier in the same
+ * source/header stream.
+ *
+ * Correct outcomes after each header is included twice:
+ * - macro-on:      #define POM_ON 1 -> #if POM_ON is live -> pragma honored -> 1
+ * - macro-off:     #define POM_OFF 0 -> #if POM_OFF is dead -> pragma ignored -> 2
+ * - macro-undef:   #undef before #if -> condition false -> pragma ignored -> 2
+ * - macro-defined: #if defined(POM_DEFINED) is live -> pragma honored -> 1
+ */
+#include "pragma-once-macro-on.h"
+#include "pragma-once-macro-on.h"
+#include "pragma-once-macro-off.h"
+#include "pragma-once-macro-off.h"
+#include "pragma-once-macro-undef.h"
+#include "pragma-once-macro-undef.h"
+#include "pragma-once-macro-defined.h"
+#include "pragma-once-macro-defined.h"
+
+#if POM_ON_VAL == 1 && POM_OFF_VAL == 2 && POM_UNDEF_VAL == 2 && POM_DEFINED_VAL == 1
+#error macro-controlled pragma once conditions were handled correctly
+#endif
+
+int main(void)
+{
+    return 0;
+}

--- a/tests/diagnostics/pragma-once-macro-defined.h
+++ b/tests/diagnostics/pragma-once-macro-defined.h
@@ -1,0 +1,13 @@
+/* defined(NAME) after an active #define: #pragma once must be honored. */
+#define POM_DEFINED 1
+#if defined(POM_DEFINED)
+#pragma once
+#endif
+
+#ifdef POM_DEFINED_SEEN
+#undef POM_DEFINED_VAL
+#define POM_DEFINED_VAL 2
+#else
+#define POM_DEFINED_SEEN
+#define POM_DEFINED_VAL 1
+#endif

--- a/tests/diagnostics/pragma-once-macro-off.h
+++ b/tests/diagnostics/pragma-once-macro-off.h
@@ -1,0 +1,13 @@
+/* Macro-defined false condition: #pragma once must be ignored. */
+#define POM_OFF 0
+#if POM_OFF
+#pragma once
+#endif
+
+#ifdef POM_OFF_SEEN
+#undef POM_OFF_VAL
+#define POM_OFF_VAL 2
+#else
+#define POM_OFF_SEEN
+#define POM_OFF_VAL 1
+#endif

--- a/tests/diagnostics/pragma-once-macro-on.h
+++ b/tests/diagnostics/pragma-once-macro-on.h
@@ -1,0 +1,13 @@
+/* Macro-defined true condition: #pragma once must be honored. */
+#define POM_ON 1
+#if POM_ON
+#pragma once
+#endif
+
+#ifdef POM_ON_SEEN
+#undef POM_ON_VAL
+#define POM_ON_VAL 2
+#else
+#define POM_ON_SEEN
+#define POM_ON_VAL 1
+#endif

--- a/tests/diagnostics/pragma-once-macro-undef.h
+++ b/tests/diagnostics/pragma-once-macro-undef.h
@@ -1,0 +1,14 @@
+/* Macro undefined before the condition: #pragma once must be ignored. */
+#define POM_UNDEF 1
+#undef POM_UNDEF
+#if POM_UNDEF
+#pragma once
+#endif
+
+#ifdef POM_UNDEF_SEEN
+#undef POM_UNDEF_VAL
+#define POM_UNDEF_VAL 2
+#else
+#define POM_UNDEF_SEEN
+#define POM_UNDEF_VAL 1
+#endif

--- a/tests/ponce_a.h
+++ b/tests/ponce_a.h
@@ -1,0 +1,6 @@
+#include "ponce_shared.h"
+
+int aval(void)
+{
+    return shval() + 5;
+}

--- a/tests/ponce_b.h
+++ b/tests/ponce_b.h
@@ -1,0 +1,6 @@
+#include "./ponce_shared.h"
+
+int bval(void)
+{
+    return shval() + PONCE_SHARED_MACRO;
+}

--- a/tests/ponce_c.h
+++ b/tests/ponce_c.h
@@ -1,0 +1,6 @@
+#pragma once /* trailing block comment after pragma once */
+
+int cval(void)
+{
+    return 12;
+}

--- a/tests/ponce_g.h
+++ b/tests/ponce_g.h
@@ -1,0 +1,10 @@
+#ifndef PONCE_G_H
+#define PONCE_G_H
+#pragma once
+
+int gval(void)
+{
+    return 15;
+}
+
+#endif

--- a/tests/ponce_shared.h
+++ b/tests/ponce_shared.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#define PONCE_SHARED_MACRO 7
+
+int shval(void)
+{
+    return 41;
+}

--- a/tests/tponce.c
+++ b/tests/tponce.c
@@ -1,0 +1,39 @@
+/* tponce.c - #pragma once include-splicing regression test */
+#include <stdio.h>
+#include "ponce_a.h"
+#include "ponce_b.h"
+#include "ponce_shared.h"
+#include "./ponce_shared.h"
+#include "ponce_c.h"
+#include "ponce_c.h"
+#include "ponce_g.h"
+#include "ponce_g.h"
+
+static int fails;
+
+static void ckpi(const char *name, int got, int exp)
+{
+    if (got != exp) {
+        printf("FAIL %s got %d expected %d\n", name, got, exp);
+        fails++;
+    }
+}
+
+int main(void)
+{
+    printf("tponce start\n");
+    fails = 0;
+    ckpi("shared", shval(), 41);
+    ckpi("a", aval(), 46);
+    ckpi("b", bval(), 48);
+    ckpi("macro", PONCE_SHARED_MACRO, 7);
+    ckpi("cmt", cval(), 12);
+    ckpi("guard", gval(), 15);
+
+    if (fails) {
+        printf("tponce failed: %d\n", fails);
+        return 1;
+    }
+    printf("tponce completed with great success\n");
+    return 0;
+}


### PR DESCRIPTION
@davidly 
Add host-side #pragma once handling during include expansion, with canonical path tracking so repeated includes and path aliases are deduplicated before the later preprocessor pass. Teach the include splicer to respect conditional state, active #define/#undef directives, trailing comments, and macro-controlled #if/defined(...) cases while restoring macro state before normal filtering/parsing.

Add runtime and diagnostic coverage for live pragma-once behavior, dead-code pragmas, conditional branches, and macro-controlled pragma conditions.

Also suppress diagnostics during the global write-info lexical pre-scan so recoverable lexer/preprocessor diagnostics are emitted only by the real compile pass, fixing duplicate diagnostic output in the diagnostics suite.