### PR TITLE
Add source-level stack-check pragma

### DIFF
--- a/docs/docs/en/02-build-and-link.md
+++ b/docs/docs/en/02-build-and-link.md
@@ -336,7 +336,10 @@ Common options:
   return code `0FFh` instead of silently corrupting memory. The guard costs a
   few bytes and one call per function, so it is **off by default**; turn it on
     while developing or for deeply recursive code. The `stacksize` utility
-  (below) uses this guard to measure the minimum `-stack` reserve an app needs.
+    (below) uses this guard to measure the minimum `-stack` reserve an app needs.
+    This option sets the initial state for the translation unit; source can then
+    use [`#pragma stack_check(on)` / `#pragma stack_check(off)`](03-types-and-conventions.md#supported-pragmas)
+    to control guard emission in source order.
 - **`-Dname[=value]`** — predefine a macro. `_DCC_=1` is always defined.
 
 ### Measuring the stack an app needs

--- a/docs/docs/en/03-types-and-conventions.md
+++ b/docs/docs/en/03-types-and-conventions.md
@@ -143,6 +143,33 @@ int main(void)
   final application's synthetic BSS range. The zeroing guarantee above describes
   the normal final app translation unit linked with `DCCRTL.MAC` / `RTLMIN.MAC`.
 
+## Supported pragmas
+
+DCC accepts `#pragma` directives for source compatibility. Unknown pragmas are
+ignored, so headers shared with other compilers can usually keep vendor-specific
+directives in place. The pragmas below have DCC-specific behavior:
+
+| Pragma | Effect |
+| --- | --- |
+| `#pragma once` | Marks the current source or header file as include-once. Later includes of the same canonical host path are skipped. The directive is honored only when it appears in an active preprocessor branch. |
+| `#pragma stack_check(on)` | Enables stack-overflow guard emission from this point forward in the translation unit. |
+| `#pragma stack_check(off)` | Disables stack-overflow guard emission from this point forward in the translation unit. |
+| `#pragma push_macro("NAME")` | Saves the current definition state of macro `NAME` on DCC's macro stack. |
+| `#pragma pop_macro("NAME")` | Restores the most recently pushed definition state for macro `NAME`; if the macro was not defined at push time, it is undefined. |
+
+`#pragma once` is handled during include splicing, before normal tokenization, so
+it works through relative-path aliases such as `"foo.h"` and `"./foo.h"` when
+they resolve to the same host file. It also follows DCC's active conditional
+state: a pragma inside `#if 0` is ignored, while a pragma made active by `#else`,
+`#elif`, `#ifdef`, `#ifndef`, or earlier active `#define` / `#undef` directives
+is honored.
+
+[`-fstack-check`](02-build-and-link.md#options-that-affect-the-runtime) sets
+the initial stack-check state for the translation unit. `#pragma stack_check(on)`
+and `#pragma stack_check(off)` then control guard emission in source order. The
+pragma affects function prologues and VLA allocations emitted after the directive;
+it does not retroactively change code already emitted.
+
 ## Variable-length arrays
 
 DCC supports a practical subset of C99 variable-length arrays (VLAs):

--- a/scripts/runall.ps1
+++ b/scripts/runall.ps1
@@ -9,7 +9,9 @@ Builds all *.c files in tests/ folder using dccmake, executes each under the
 emulator, and compares output against per-app baselines in tests/baselines/
 (one <app>.txt per test). Comparison is keyed by app name, so test discovery
 order does not matter. Uses tests/_test_overrides.json for test-specific arguments and
-stack sizes.
+stack sizes. After the app suite, also runs the compile-fail diagnostics suite
+via scripts/run-diagnostics.ps1 and fails the run if any diagnostic baseline
+mismatches.
 
 Pass -Extended to also run scripts/runall-extended.ps1 after the main app suite,
 verifying the imported c-testsuite single-exec corpus as part of the same run.
@@ -1070,6 +1072,18 @@ if ($Extended) {
     }
 }
 
+$diagnosticsPassed = $null
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Cyan
+Write-Host "RUNNING DIAGNOSTICS SUITE" -ForegroundColor Cyan
+Write-Host "========================================" -ForegroundColor Cyan
+& pwsh (Join-Path $PSScriptRoot "run-diagnostics.ps1") -Dcc (Join-Path $script:RepoRoot "dcc")
+$diagnosticsExitCode = $LASTEXITCODE
+$diagnosticsPassed = ($diagnosticsExitCode -eq 0)
+if (-not $diagnosticsPassed) {
+    $failed++
+}
+
 Write-Host ""
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host "TEST SUITE SUMMARY" -ForegroundColor Cyan
@@ -1088,6 +1102,7 @@ Write-Host "  Skipped:      $skipped"
 if ($Extended) {
     Write-Host "  Extended:     $(if ($extendedPassed) { 'passed' } else { 'failed' })" -ForegroundColor $(if ($extendedPassed) { "Green" } else { "Red" })
 }
+Write-Host "  Diagnostics:  $(if ($diagnosticsPassed) { 'passed' } else { 'failed' })" -ForegroundColor $(if ($diagnosticsPassed) { "Green" } else { "Red" })
 Write-Host "  Total time:   $suiteElapsedStr"
 Write-Host "  Optimisation: $optimisationSummary"
 
@@ -1101,6 +1116,10 @@ if ($failedApps.Count -gt 0) {
 if ($Extended -and -not $extendedPassed) {
     Write-Host ""
     Write-Host "Extended c-testsuite failed" -ForegroundColor Red
+}
+if (-not $diagnosticsPassed) {
+    Write-Host ""
+    Write-Host "Diagnostics suite failed" -ForegroundColor Red
 }
 
 if ($Report) {

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -269,6 +269,7 @@ struct Sym {
                                * elimination - both a static inline's fallback body
                                * and a plain (non-inline) static function's only body */
     int deferred_body_needed;
+    int stack_check_enabled;
     int has_proto;
     int proto_nargs;
     int proto_variadic;

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -3131,6 +3131,8 @@ static int try_speculative_noix_function_body(const char *name, int type,
 {
     FILE *scratch;
     FILE *saved_outf_ptr;
+    int saved_stack_check;
+    int generated_stack_check;
     int implicit_zero_return;
     int c;
 
@@ -3142,7 +3144,9 @@ static int try_speculative_noix_function_body(const char *name, int type,
         fatal("cannot create speculative no-ix-frame temp file");
 
     saved_outf_ptr = outf;
+    saved_stack_check = opt_stack_check;
     outf = scratch;
+    opt_stack_check = s->stack_check_enabled;
     /* emit_runtime_extrn_if_needed (dcc_symbols.c) caches which runtime-
      * helper EXTRNs have already been emitted in a *persistent*,
      * compilation-wide table, so a helper's declaration is normally only
@@ -3175,6 +3179,8 @@ static int try_speculative_noix_function_body(const char *name, int type,
     gen_compound();
     emit_function_epilogue(implicit_zero_return);
     g_inline_body_buffering--;
+    generated_stack_check = opt_stack_check;
+    opt_stack_check = saved_stack_check;
     outf = saved_outf_ptr;
 
     /* check_undefined_user_labels() is deliberately not called above: if
@@ -3193,6 +3199,7 @@ static int try_speculative_noix_function_body(const char *name, int type,
         while ((c = fgetc(scratch)) != EOF)
             fputc(c, outf);
         fclose(scratch);
+        opt_stack_check = generated_stack_check;
         return 1;
     }
 
@@ -3250,6 +3257,7 @@ void parse_function_or_global(int base_type)
         int saved_param_offset;
         int saved_nenum_consts;
         int saved_nulabels;
+        int saved_stack_check;
 
         int base_is_func_typedef;
         int is_funcret_funcptr_decl;
@@ -3341,10 +3349,26 @@ void parse_function_or_global(int base_type)
                 strncpy(g_current_compiling_func, name, sizeof(g_current_compiling_func) - 1);
                 g_current_compiling_func[sizeof(g_current_compiling_func) - 1] = 0;
 
+                /* Capture the stack-check state in effect at the function's
+                 * opening brace.  This is the value baked into THIS function's
+                 * prologue and VLA guards (stored in s->stack_check_enabled
+                 * below and re-applied before the real codegen pass).
+                 *
+                 * Every body-inspection helper and frame-sizing scan below
+                 * tokenizes past the body, which processes any later
+                 * `#pragma stack_check(...)` and mutates the global
+                 * opt_stack_check as a side effect.  None of them READ
+                 * opt_stack_check (runtime-call emission is a no-op while
+                 * scanning - see emit_runtime_call's scan_mode guard), so a
+                 * single restore after the group re-synchronizes the flag with
+                 * the rewound source position; the two rewind blocks further
+                 * below each restore it again alongside posi/tok/nlocals. */
+                saved_stack_check = opt_stack_check;
                 record_inline_function_if_simple(s);
                 record_narrow_return_expr_if_simple(s);
                 if (function_body_mentions_multiuse_inline_call())
                     reserve_inline_temp_locals();
+                opt_stack_check = saved_stack_check;
 
                 saved_pos = posi;
                 saved_tok_start = tok_start_pos;
@@ -3381,6 +3405,7 @@ void parse_function_or_global(int base_type)
                 local_size = saved_local_size;
                 param_offset = saved_param_offset;
                 nenum_consts = saved_nenum_consts;
+                opt_stack_check = saved_stack_check;
                 /* ast_scan_for_stmt (called by scan_function_body via the AST
                  * builder/emitter for for-loops) can now reach a labeled
                  * statement inside a loop body and call define_user_label,
@@ -3402,9 +3427,11 @@ void parse_function_or_global(int base_type)
                 tok_line = saved_tok_line;
                 tok = saved_tok;
                 nenum_consts = saved_nenum_consts;
+                opt_stack_check = saved_stack_check;
 
                 s->is_defined = 1;
                 s->needs_extrn = 0;
+                s->stack_check_enabled = saved_stack_check;
 
                 nulabels = 0;
                 current_return_label = new_label();
@@ -3427,6 +3454,7 @@ void parse_function_or_global(int base_type)
                 g_static_local_seq = 0;
                 g_compound_literal_seq = 0;
                 g_licm_seq = 0;
+                opt_stack_check = s->stack_check_enabled;
                 if (static_inline_body_can_be_buffered(s)) {
                     FILE *saved_outf;
 

--- a/src/dcc/dcc_global_scan.c
+++ b/src/dcc/dcc_global_scan.c
@@ -130,6 +130,7 @@ void scan_global_write_info(void)
     int saved_line;
     int saved_tok_line;
     struct Token saved_tok;
+    int saved_stack_check;
     struct Def *saved_defs;
     int saved_ndefs;
     char *saved_src;
@@ -146,6 +147,7 @@ void scan_global_write_info(void)
     saved_line = line_no;
     saved_tok_line = tok_line;
     saved_tok = tok;
+    saved_stack_check = opt_stack_check;
 
     saved_defs = (struct Def *)xmalloc(sizeof(defs));
     saved_ndefs = ndefs;
@@ -279,6 +281,7 @@ void scan_global_write_info(void)
     line_no = saved_line;
     tok_line = saved_tok_line;
     tok = saved_tok;
+    opt_stack_check = saved_stack_check;
 }
 
 /* Total number of textual write-context occurrences of `name` anywhere in

--- a/src/dcc/dcc_preproc.c
+++ b/src/dcc/dcc_preproc.c
@@ -603,6 +603,39 @@ static int parse_pragma_macro_name(const char *line, const char *op, char *name,
     return name[0] && *line == ')';
 }
 
+static int parse_pragma_stack_check(const char *line, int *enabled)
+{
+    const char *op;
+
+    while (*line && isspace((unsigned char)*line))
+        line++;
+    op = "stack_check";
+    while (*op) {
+        if (*line++ != *op++)
+            return 0;
+    }
+    while (*line && isspace((unsigned char)*line))
+        line++;
+    if (*line++ != '(')
+        return 0;
+    while (*line && isspace((unsigned char)*line))
+        line++;
+
+    if (!strncmp(line, "on", 2) && !is_ident_char((unsigned char)line[2])) {
+        line += 2;
+        *enabled = 1;
+    } else if (!strncmp(line, "off", 3) && !is_ident_char((unsigned char)line[3])) {
+        line += 3;
+        *enabled = 0;
+    } else {
+        return 0;
+    }
+
+    while (*line && isspace((unsigned char)*line))
+        line++;
+    return *line == ')';
+}
+
 static void pp_push_macro(const char *name)
 {
     int di;
@@ -663,6 +696,7 @@ static void pp_pop_macro(const char *name)
 static void handle_pragma_line(const char *line)
 {
     char name[64];
+    int stack_check_enabled;
 
     if (parse_pragma_macro_name(line, "push_macro", name, sizeof(name))) {
         pp_push_macro(name);
@@ -670,6 +704,10 @@ static void handle_pragma_line(const char *line)
     }
     if (parse_pragma_macro_name(line, "pop_macro", name, sizeof(name))) {
         pp_pop_macro(name);
+        return;
+    }
+    if (parse_pragma_stack_check(line, &stack_check_enabled)) {
+        opt_stack_check = stack_check_enabled;
         return;
     }
 }

--- a/tests/baselines/tpragstk.txt
+++ b/tests/baselines/tpragstk.txt
@@ -1,0 +1,3 @@
+tpragstk start 7
+
+?stack overflow: exceeded by 0x{{HEX4}} limit 0x{{HEX4}}

--- a/tests/diagnostics/baselines/pragma-stack-check.txt
+++ b/tests/diagnostics/baselines/pragma-stack-check.txt
@@ -1,0 +1,4 @@
+<source>:14: error DCC-E0312: #error stack_check pragma diagnostics smoke test
+    #error stack_check pragma diagnostics smoke test
+    ^
+dcc: 1 error(s)

--- a/tests/diagnostics/pragma-stack-check.c
+++ b/tests/diagnostics/pragma-stack-check.c
@@ -1,0 +1,19 @@
+/*
+ * Compile-fail guard: stack_check pragmas, including malformed variants, must
+ * not emit their own diagnostics.  The only expected diagnostic is the #error
+ * below, so this catches accidental warning/error behavior for pragma parsing.
+ */
+#pragma stack_check(on)
+#pragma stack_check ( off )
+#pragma stack_check(auto)
+
+#if 0
+#pragma stack_check(on)
+#endif
+
+#error stack_check pragma diagnostics smoke test
+
+int main(void)
+{
+    return 0;
+}

--- a/tests/tpragstk.c
+++ b/tests/tpragstk.c
@@ -1,0 +1,37 @@
+/* tpragstk.c - source-level stack-check pragma regression. */
+#include <stdio.h>
+
+#pragma stack_check(off)
+
+int sink;
+
+int unguarded_leaf(void)
+{
+    int local[4];
+
+    local[0] = 7;
+    sink = local[0];
+    return sink;
+}
+
+#pragma stack_check ( on )
+
+int guarded_descend(int depth)
+{
+    int local[8];
+    int i;
+
+    for (i = 0; i < 8; ++i)
+        local[i] = depth + i;
+
+    sink = local[depth & 7];
+    return guarded_descend(depth + 1) + local[0];
+}
+
+int main(void)
+{
+    printf("tpragstk start %d\n", unguarded_leaf());
+    sink = guarded_descend(1);
+    printf("tpragstk should not reach here %d\n", sink);
+    return 0;
+}


### PR DESCRIPTION
@davidly 
Implement `#pragma stack_check(on)` and `#pragma stack_check(off)` as source-level controls for DCC's lightweight stack-overflow guard.

The existing `-fstack-check` option now defines the initial stack-check state for a translation unit, while the new pragma can enable or disable guard emission in source order. This allows code to opt individual regions into or out of prologue and VLA stack checks without requiring separate compiler invocations.

Key implementation details:

- Add lexer-level pragma parsing for:
  - `#pragma stack_check(on)`
  - `#pragma stack_check(off)`
  - whitespace-tolerant forms such as `#pragma stack_check ( on )`

- Keep unknown or malformed pragma forms silently ignored, matching existing DCC pragma behavior.

- Capture stack-check state per function definition in `Sym.stack_check_enabled`. This is needed because DCC may scan, buffer, defer, or speculatively emit function bodies; the guard decision must reflect the pragma state at the function's opening brace, not the later state when buffered output is flushed.

- Preserve `opt_stack_check` across whole-file lexical scanning and function frame-sizing/body-inspection passes so those speculative tokenization passes do not consume source-order pragma state.

- Preserve pragma state correctly through the speculative no-IX body path, while still allowing accepted speculative generation to carry forward any pragma state changes seen inside the function body.

- Add runtime coverage with `tests/tpragstk.c`, proving a default-off compile can enable the guard from source and reach the runtime stack-overflow path.

- Add diagnostics coverage for accepted and malformed `stack_check` pragmas, ensuring pragma parsing does not introduce unexpected diagnostics.

- Document supported pragmas in the MkDocs Types and conventions page, including `once`, `push_macro`, `pop_macro`, and `stack_check(on/off)`, and cross-link the `-fstack-check` option to the pragma reference.

- Run compile-fail diagnostics automatically at the end of `scripts/runall.ps1`, include their result in the final summary, and fail the run if diagnostics do not match their baselines.

Validation:

- `pwsh ./scripts/build-dcc.ps1`
- direct `.MAC` inspection confirmed:
  - `#pragma stack_check(on)` emits `__stchk` after the directive
  - `#pragma stack_check(off)` suppresses `__stchk`
  - source `off` overrides command-line `-fstack-check`
- `unset DCC_FORCE_STACK_CHECK && ./dccmake tests/tpragstk.c dcc-output=TPRAGSTK dcc-peep=true && ntvcm -s:0 build/TPRAGSTK.COM`
- `pwsh ./scripts/run-diagnostics.ps1`
- `cd docs/docs && ../../.venv/bin/python -m mkdocs build --strict`
- `pwsh ./scripts/runall.ps1 -Mode fast`

Final fast-suite result:

- Apps: 224 passed, 0 failed, 9 skipped
- Diagnostics: 87 passed