### PR TITLE
Fix live-result wide assignment codegen and support gates

### DIFF
--- a/.github/skills/dcc-cpm-z80/SKILL.md
+++ b/.github/skills/dcc-cpm-z80/SKILL.md
@@ -85,6 +85,19 @@ you see that error.
 `"..."` header is fatal. If standard calls compile but misbehave, check that
 `-I` actually resolves the dcc headers.
 
+**`#pragma` support is selective.** Unknown pragmas are ignored for source
+compatibility, so vendor-specific directives usually do not block a build. dcc
+does give these pragmas target-specific behavior:
+
+- `#pragma once` marks the current source/header as include-once. It is honored
+  only in an active preprocessor branch, and later includes of the same
+  canonical host path are skipped.
+- `#pragma stack_check(on)` / `#pragma stack_check(off)` toggle stack-overflow
+  guard emission from that point forward in the translation unit. They affect
+  later function prologues and VLA allocations, not code already emitted.
+- `#pragma push_macro("NAME")` / `#pragma pop_macro("NAME")` save and restore a
+  macro definition state on dcc's macro stack.
+
 ## C99/C11 front-end compatibility dcc accepts (beyond C89)
 
 These behave as standard C99: `for`-init declarations with loop scope, `//` line
@@ -234,8 +247,8 @@ Notes: M80 needs CRLF (`dccmake` handles this). `RTLMIN.MAC` is generated per-ap
 
 The deviations above are the pitfalls. For worked examples (the `float` decimal
 parser, `%f`/`-ffloatio`, 16-bit overflow, signed `char`, CP/M 8.3 names, the
-stack/heap collision), the full inlining rules, and the function inventory and
-`printf`/`scanf` conversion tables, see
+stack/heap collision, and supported pragmas), the full inlining rules, and the
+function inventory and `printf`/`scanf` conversion tables, see
 [references/library.md](./references/library.md).
 
 ## Workflow
@@ -243,12 +256,15 @@ stack/heap collision), the full inlining rules, and the function inventory and
 1. **Plan for the deviations.** Floating point → single precision (no `double`);
   decimal parsing → dcc's `float`-returning `atof`, or a small parser if you
   need different semantics; `time`/`signal`/`locale` → don't exist.
-2. **Check the library** in [references/library.md](./references/library.md)
+2. **Keep pragma assumptions narrow.** `#pragma once`, `#pragma stack_check`,
+  and `#pragma push_macro`/`#pragma pop_macro` are supported; unknown pragmas
+  are ignored, not diagnosed.
+3. **Check the library** in [references/library.md](./references/library.md)
    before calling anything unverified — a missing function is a link error,
    not a compile error.
-3. **Match repo conventions.** Read a nearby working program first. In the dcc
+4. **Match repo conventions.** Read a nearby working program first. In the dcc
    repo, the exhaustive reference is
    [dcc-c89-reference-guide.md](dcc-c89-reference-guide.md) at the repo root.
-4. **Build and run**: `dccmake app.c dcc-output=APP dcc-peep=true && ntvcm build/APP.COM`
+5. **Build and run**: `dccmake app.c dcc-output=APP dcc-peep=true && ntvcm build/APP.COM`
   (set `dcc-floatio=true` if you use `%f`); redirect stdin for interactive apps
   and compare against expected output.

--- a/.github/skills/dcc-cpm-z80/references/library.md
+++ b/.github/skills/dcc-cpm-z80/references/library.md
@@ -65,6 +65,7 @@ Standard C89 `malloc`/`free`/`qsort`/`bsearch`/`atoi`/`strtol`/… are present;
 (size with `-stack`; keep big buffers `static`/global).
 
 **dcc extensions** (declared in `<stdlib.h>`, not C89):
+
 - `inp(port)`/`outp(port,val)` — direct Z80 8-bit port I/O. `inp` runs
   `IN A,(port)` and returns the byte zero-extended to `int` (0..255); `outp` runs
   `OUT (port),A` with the low byte of `val`. Only the low 8 bits of `port` are
@@ -137,7 +138,6 @@ digits**), and `sin`/`cos`/`tan` range-reduction via `fmodf` degrades for very
 large arguments. There is **no** `double`, `long double`, or `HUGE_VAL`, and
 printing a float (`%f`) requires `-ffloatio`.
 
-
 ## setjmp.h / stdarg.h / stddef.h
 
 Standard C89. dcc specifics: `jmp_buf` is 8 bytes (return address, SP, IX);
@@ -177,6 +177,21 @@ prototype. See `tbdos.c`, `crc.c` in the dcc repo.
 
 `<locale.h>`, `<signal.h>`, `<time.h>`. (`<stdbool.h>`/`<stdint.h>` are present
 as C99-style conveniences but are not C89.)
+
+## `#pragma` support
+
+dcc accepts `#pragma` lines for source compatibility. Unknown pragmas are
+ignored, so headers shared with other compilers can usually leave
+vendor-specific pragmas in place. The pragmas with dcc-specific behavior are:
+
+- `#pragma once`: marks the current source/header as include-once; later
+  includes of the same canonical host path are skipped. It is honored only in
+  an active preprocessor branch, so a pragma inside `#if 0` is ignored.
+- `#pragma stack_check(on)` / `#pragma stack_check(off)`: toggle stack-overflow
+  guard emission from that point forward in the translation unit. They affect
+  later function prologues and VLA allocations, not already-emitted code.
+- `#pragma push_macro("NAME")` / `#pragma pop_macro("NAME")`: save and restore
+  the definition state of macro `NAME` on dcc's macro stack.
 
 ## Pitfalls and worked examples
 

--- a/src/dcc/dcc_ast_gen_expr.c
+++ b/src/dcc/dcc_ast_gen_expr.c
@@ -1774,6 +1774,11 @@ void gen_assign_ast(const struct AstNode *n)
                     emit_extend_to_long_typed(g_expr_type);
                 }
                 emit_store_de_to_addr_hl(val_type);  /* pops address itself */
+                /* emit_store_de_to_addr_hl leaves the stored 32-bit value as
+                 * DE=low word, BC=high word; rebuild DE:HL=value for a live
+                 * result (e.g. `x = (p->f = v)`). */
+                if (!want_dead)
+                    emit("\tex de,hl\n\tld d,b\n\tld e,c\n");
                 g_long_from16 = 0;
                 return;
             }
@@ -1837,6 +1842,10 @@ void gen_assign_ast(const struct AstNode *n)
             if (type_is_float(val_type)) {
                 emit_float_compound_rhs(n, saved_dead);
                 emit_store_de_to_addr_hl(val_type);
+                /* Rebuild DE:HL=value from the store's DE=low/BC=high leftovers
+                 * so a live result (`x = (p->f += v)`) is correct. */
+                if (!want_dead)
+                    emit("\tex de,hl\n\tld d,b\n\tld e,c\n");
                 g_expr_type = val_type;
                 g_long_from16 = 0;
                 return;
@@ -1867,6 +1876,10 @@ void gen_assign_ast(const struct AstNode *n)
             emit_cast_16_to_common(g_expr_type, common_type);
             gen_binop32_typed(binop, common_type);
             emit_store_de_to_addr_hl(val_type);
+            /* Rebuild DE:HL=value from the store's DE=low/BC=high leftovers so a
+             * live result (`x = (p->lf += v)`) is correct. */
+            if (!want_dead)
+                emit("\tex de,hl\n\tld d,b\n\tld e,c\n");
             g_expr_type = val_type;
             g_long_from16 = 0;
             return;
@@ -1950,8 +1963,7 @@ void gen_assign_ast(const struct AstNode *n)
         return;
     }
 
-    if (n->op == '=' && type_is_float(s->type) && !sym_can_ix_direct(s) &&
-        expr_result_dead) {
+    if (n->op == '=' && type_is_float(s->type) && !sym_can_ix_direct(s)) {
         saved_dead = expr_result_dead;
         emit_load_sym_addr(s);
         emit("\tpush hl\n");
@@ -1961,6 +1973,8 @@ void gen_assign_ast(const struct AstNode *n)
         if (!type_is_float(g_expr_type))
             emit_convert_int_to_float(g_expr_type);
         emit_store_de_to_addr_hl(s->type);
+        if (!saved_dead)
+            emit("\tex de,hl\n\tld d,b\n\tld e,c\n");
         g_expr_type = s->type;
         g_long_from16 = 0;
         return;
@@ -1981,7 +1995,7 @@ void gen_assign_ast(const struct AstNode *n)
 
     if ((n->op == TOK_ADDEQ || n->op == TOK_SUBEQ ||
          n->op == TOK_MULEQ || n->op == TOK_DIVEQ) &&
-        type_is_float(s->type) && !sym_can_ix_direct(s) && expr_result_dead) {
+        type_is_float(s->type) && !sym_can_ix_direct(s)) {
         saved_dead = expr_result_dead;
         emit_load_sym_addr(s);
         emit("\tpush hl\n");
@@ -1989,13 +2003,14 @@ void gen_assign_ast(const struct AstNode *n)
         emit("\tpush de\n\tpush hl\n");
         emit_float_compound_rhs(n, saved_dead);
         emit_store_de_to_addr_hl(s->type);
+        if (!saved_dead)
+            emit("\tex de,hl\n\tld d,b\n\tld e,c\n");
         g_expr_type = s->type;
         g_long_from16 = 0;
         return;
     }
 
-    if (n->op == '=' && type_is_long(s->type) && !sym_can_ix_direct(s) &&
-        expr_result_dead) {
+    if (n->op == '=' && type_is_long(s->type) && !sym_can_ix_direct(s)) {
         saved_dead = expr_result_dead;
         emit_load_sym_addr(s);
         emit("\tpush hl\n");
@@ -2007,6 +2022,8 @@ void gen_assign_ast(const struct AstNode *n)
         else if (!type_is_long(g_expr_type))
             emit_extend_to_long_typed(g_expr_type);
         emit_store_de_to_addr_hl(s->type);
+        if (!saved_dead)
+            emit("\tex de,hl\n\tld d,b\n\tld e,c\n");
         g_expr_type = s->type;
         g_long_from16 = 0;
         return;
@@ -2080,7 +2097,7 @@ void gen_assign_ast(const struct AstNode *n)
     if ((n->op == TOK_ADDEQ || n->op == TOK_SUBEQ ||
          n->op == TOK_MULEQ || n->op == TOK_DIVEQ || n->op == TOK_MODEQ ||
          n->op == TOK_ANDEQ || n->op == TOK_OREQ  || n->op == TOK_XOREQ) &&
-        type_is_long(s->type) && !sym_can_ix_direct(s) && expr_result_dead) {
+        type_is_long(s->type) && !sym_can_ix_direct(s)) {
         int b32;
         saved_dead = expr_result_dead;
         emit_load_sym_addr(s);
@@ -2104,13 +2121,15 @@ void gen_assign_ast(const struct AstNode *n)
         }
         gen_binop32(b32, s->type);
         emit_store_de_to_addr_hl(s->type);
+        if (!saved_dead)
+            emit("\tex de,hl\n\tld d,b\n\tld e,c\n");
         g_expr_type = s->type;
         g_long_from16 = 0;
         return;
     }
 
     if ((n->op == TOK_SHLEQ || n->op == TOK_SHREQ) &&
-        type_is_long(s->type) && !sym_can_ix_direct(s) && expr_result_dead) {
+        type_is_long(s->type) && !sym_can_ix_direct(s)) {
         saved_dead = expr_result_dead;
         emit_load_sym_addr(s);
         emit("\tpush hl\n");
@@ -2132,6 +2151,8 @@ void gen_assign_ast(const struct AstNode *n)
         emit("\tpop de\n");
         emit("\tex de,hl\n");
         emit("\tld (hl),e\n\tinc hl\n\tld (hl),d\n\tinc hl\n\tld (hl),c\n\tinc hl\n\tld (hl),b\n");
+        if (!saved_dead)
+            emit("\tex de,hl\n\tld d,b\n\tld e,c\n");
         g_expr_type = s->type;
         g_long_from16 = 0;
         return;

--- a/src/dcc/dcc_ast_gen_support.c
+++ b/src/dcc/dcc_ast_gen_support.c
@@ -319,6 +319,30 @@ static int ast_gen_supported_uncached(const struct AstNode *n)
             struct Sym *base;
             int decayed;
             int elem;
+            if (ast_index_lvalue_elem_type(n->a, &elem)) {
+                if (type_is_long(elem)) {
+                    if (n->op == '=')
+                        return ast_value_is_long_word(n->b) || ast_value_is_plain_int(n->b) ||
+                               ast_value_is_float_word(n->b);
+                    if (n->op == TOK_SHLEQ || n->op == TOK_SHREQ)
+                        return ast_value_is_plain_int(n->b) || ast_value_is_long_word(n->b);
+                    if (n->op == TOK_ADDEQ || n->op == TOK_SUBEQ ||
+                        n->op == TOK_MULEQ || n->op == TOK_DIVEQ || n->op == TOK_MODEQ ||
+                        n->op == TOK_ANDEQ || n->op == TOK_OREQ  || n->op == TOK_XOREQ)
+                        return ast_value_is_long_word(n->b) || ast_value_is_plain_int(n->b);
+                    return 0;
+                }
+                if (type_is_float(elem)) {
+                    if (n->op == '=')
+                        return ast_value_is_float_word(n->b) || ast_value_is_plain_int(n->b) ||
+                               ast_value_is_long_word(n->b);
+                    if (n->op == TOK_ADDEQ || n->op == TOK_SUBEQ ||
+                        n->op == TOK_MULEQ || n->op == TOK_DIVEQ)
+                        return ast_value_is_float_word(n->b) || ast_value_is_plain_int(n->b) ||
+                               ast_value_is_long_word(n->b);
+                    return 0;
+                }
+            }
             if (ast_index_symbol_nd_elem_type(n->a, &elem)) {
                 if (type_is_long(elem))
                     return (n->op == '=' || (is_compound && expr_result_dead)) &&
@@ -515,10 +539,9 @@ static int ast_gen_supported_uncached(const struct AstNode *n)
             }
             return 1;
         }
-        /* Member lvalue store: s.f = rhs / p->f OP= rhs.  Restricted to an INT
-         * (size 2) plain scalar field so the general store lowering is used
-         * with no byte-field fast path intervening (the global struct byte-field
-         * fast path needs a size-1 field). */
+        /* Member lvalue store: s.f = rhs / p->f OP= rhs.  Plain int fields use
+         * the general store lowering; long and float fields also use the
+         * wide-value tail for the supported arithmetic compound operators. */
         if (n->a->kind == AST_MEMBER) {
             int field_type;
             if (ast_member_bitfield_lvalue_type(n->a, &field_type))
@@ -527,16 +550,25 @@ static int ast_gen_supported_uncached(const struct AstNode *n)
                 return 0;
             if (type_is_long(field_type)) {
                 if (n->op == '=')
-                    return ast_value_is_long_word(n->b) || ast_value_is_plain_int(n->b);
+                    return ast_value_is_long_word(n->b) || ast_value_is_plain_int(n->b) ||
+                           ast_value_is_float_word(n->b);
+                if (n->op == TOK_SHLEQ || n->op == TOK_SHREQ)
+                    return ast_value_is_plain_int(n->b) || ast_value_is_long_word(n->b);
                 if (n->op == TOK_ADDEQ || n->op == TOK_SUBEQ ||
                     n->op == TOK_MULEQ || n->op == TOK_DIVEQ || n->op == TOK_MODEQ ||
                     n->op == TOK_ANDEQ || n->op == TOK_OREQ  || n->op == TOK_XOREQ)
                     return ast_value_is_long_word(n->b) || ast_value_is_plain_int(n->b);
                 return 0;
             }
-            if (type_is_float(field_type))
-                return n->op == '=' &&
-                       (ast_value_is_float_word(n->b) || ast_value_is_plain_int(n->b));
+            if (type_is_float(field_type)) {
+                if (n->op == '=')
+                    return ast_value_is_float_word(n->b) || ast_value_is_plain_int(n->b) ||
+                           ast_value_is_long_word(n->b);
+                  return (n->op == TOK_ADDEQ || n->op == TOK_SUBEQ ||
+                        n->op == TOK_MULEQ || n->op == TOK_DIVEQ) &&
+                       (ast_value_is_float_word(n->b) || ast_value_is_plain_int(n->b) ||
+                        ast_value_is_long_word(n->b));
+            }
             if (type_is_bool(field_type))
                 return n->op == '=' &&
                        (ast_value_is_plain_int(n->b) || ast_value_is_long_word(n->b) || ast_value_is_float_word(n->b));
@@ -574,7 +606,7 @@ static int ast_gen_supported_uncached(const struct AstNode *n)
                 if (type_is_long(deref_type) &&
                     (n->op == TOK_SHLEQ || n->op == TOK_SHREQ))
                     return ast_value_is_plain_int(n->b) || ast_value_is_long_word(n->b);
-                if (type_is_long(deref_type) && expr_result_dead &&
+                if (type_is_long(deref_type) &&
                     (n->op == TOK_ADDEQ || n->op == TOK_SUBEQ ||
                      n->op == TOK_MULEQ || n->op == TOK_DIVEQ ||
                      n->op == TOK_MODEQ || n->op == TOK_ANDEQ ||
@@ -583,12 +615,15 @@ static int ast_gen_supported_uncached(const struct AstNode *n)
                 return type_is_float(deref_type) &&
                        (n->op == TOK_ADDEQ || n->op == TOK_SUBEQ ||
                         n->op == TOK_MULEQ || n->op == TOK_DIVEQ) &&
-                       (ast_value_is_float_word(n->b) || ast_value_is_plain_int(n->b));
+                       (ast_value_is_float_word(n->b) || ast_value_is_plain_int(n->b) ||
+                        ast_value_is_long_word(n->b));
             }
             if (type_is_long(deref_type))
-                return ast_value_is_long_word(n->b) || ast_value_is_plain_int(n->b);
+                return ast_value_is_long_word(n->b) || ast_value_is_plain_int(n->b) ||
+                       ast_value_is_float_word(n->b);
             if (type_is_float(deref_type))
-                return ast_value_is_float_word(n->b) || ast_value_is_plain_int(n->b);
+                return ast_value_is_float_word(n->b) || ast_value_is_plain_int(n->b) ||
+                       ast_value_is_long_word(n->b);
             if (type_ptr_depth(deref_type) > 0)
                 return type_size(deref_type) == 2 && ast_pointer_assign_rhs_supported(n->b);
             return 0;
@@ -605,15 +640,8 @@ static int ast_gen_supported_uncached(const struct AstNode *n)
                    ast_struct_return_call_assign_supported(s->type, n->b);
         if (type_is_float(s->type)) {
             if (n->op == '=')
-                return (sym_can_ix_direct(s) || expr_result_dead) &&
-                       (ast_value_is_float_word(n->b) || ast_value_is_plain_int(n->b) ||
-                        ast_value_is_long_word(n->b));
-            if (!sym_can_ix_direct(s))
-                return expr_result_dead &&
-                       (n->op == TOK_ADDEQ || n->op == TOK_SUBEQ ||
-                        n->op == TOK_MULEQ || n->op == TOK_DIVEQ) &&
-                       (ast_value_is_float_word(n->b) || ast_value_is_plain_int(n->b) ||
-                        ast_value_is_long_word(n->b));
+                return ast_value_is_float_word(n->b) || ast_value_is_plain_int(n->b) ||
+                       ast_value_is_long_word(n->b);
             if (n->op == TOK_ADDEQ || n->op == TOK_SUBEQ ||
                 n->op == TOK_MULEQ || n->op == TOK_DIVEQ)
                 return ast_value_is_float_word(n->b) || ast_value_is_plain_int(n->b) ||
@@ -622,25 +650,14 @@ static int ast_gen_supported_uncached(const struct AstNode *n)
         }
         if (type_is_long(s->type)) {
             if (n->op == '=')
-                return (sym_can_ix_direct(s) || expr_result_dead) &&
-                       (ast_value_is_long_word(n->b) || ast_value_is_plain_int(n->b) ||
-                        ast_value_is_float_word(n->b));
-            if ((n->op == TOK_SHLEQ || n->op == TOK_SHREQ) &&
-                !sym_can_ix_direct(s) && expr_result_dead)
+                return ast_value_is_long_word(n->b) || ast_value_is_plain_int(n->b) ||
+                       ast_value_is_float_word(n->b);
+            if (n->op == TOK_SHLEQ || n->op == TOK_SHREQ)
                 return ast_value_is_plain_int(n->b) || ast_value_is_long_word(n->b);
-            if ((n->op == TOK_ADDEQ || n->op == TOK_SUBEQ ||
-                 n->op == TOK_MULEQ || n->op == TOK_DIVEQ || n->op == TOK_MODEQ ||
-                 n->op == TOK_ANDEQ || n->op == TOK_OREQ  || n->op == TOK_XOREQ) &&
-                !sym_can_ix_direct(s) && expr_result_dead)
-                return ast_value_is_long_word(n->b) || ast_value_is_plain_int(n->b);
-            if (!sym_can_ix_direct(s))
-                return 0;
             if (n->op == TOK_ADDEQ || n->op == TOK_SUBEQ ||
                 n->op == TOK_MULEQ || n->op == TOK_DIVEQ || n->op == TOK_MODEQ ||
                 n->op == TOK_ANDEQ || n->op == TOK_OREQ  || n->op == TOK_XOREQ)
                 return ast_value_is_long_word(n->b) || ast_value_is_plain_int(n->b);
-            if (n->op == TOK_SHLEQ || n->op == TOK_SHREQ)
-                return ast_value_is_plain_int(n->b) || ast_value_is_long_word(n->b);
             return 0;
         }
         if (!sym_can_ix_direct(s) && !is_global_word_sym(s) &&
@@ -1133,9 +1150,7 @@ int ast_value_is_long_word(const struct AstNode *arg)
             ast_deref_lvalue_type(arg->a, &lhs_type))
             return type_is_long(lhs_type);
         if (arg->a->kind == AST_INDEX &&
-            (ast_index_symbol_nd_elem_type(arg->a, &lhs_type) ||
-             ast_index_pointer_expr_elem_type(arg->a, &lhs_type) ||
-             ast_index_2d_array_elem_type(arg->a, &lhs_type)))
+            ast_index_lvalue_elem_type(arg->a, &lhs_type))
             return type_is_long(lhs_type);
         if (arg->a->kind == AST_MEMBER && ast_member_lvalue_type(arg->a, &lhs_type))
             return type_is_long(lhs_type);
@@ -1393,10 +1408,21 @@ int ast_value_is_float_word(const struct AstNode *arg)
     }
     if (arg->kind == AST_CAST && type_is_float(arg->type))
         return ast_gen_supported(arg);
-    if (arg->kind == AST_ASSIGN && arg->a != NULL && arg->a->kind == AST_IDENT) {
-        s = find_sym(arg->a->sval);
-        return s != NULL && !s->is_const_value && s->storage != SC_FUNC &&
-               !s->is_array && type_is_float(s->type);
+    if (arg->kind == AST_ASSIGN && arg->a != NULL) {
+        int lhs_type;
+        if (arg->a->kind == AST_IDENT) {
+            s = find_sym(arg->a->sval);
+            return s != NULL && !s->is_const_value && s->storage != SC_FUNC &&
+                   !s->is_array && type_is_float(s->type);
+        }
+        if (arg->a->kind == AST_UNARY && arg->a->op == '*' &&
+            ast_deref_lvalue_type(arg->a, &lhs_type))
+            return type_is_float(lhs_type);
+        if (arg->a->kind == AST_INDEX &&
+            ast_index_lvalue_elem_type(arg->a, &lhs_type))
+            return type_is_float(lhs_type);
+        if (arg->a->kind == AST_MEMBER && ast_member_lvalue_type(arg->a, &lhs_type))
+            return type_is_float(lhs_type);
     }
     if (arg->kind == AST_COND)
         return ast_cond_result_is_float(arg);

--- a/tests/tc89flta.c
+++ b/tests/tc89flta.c
@@ -22,6 +22,7 @@ static void chk4(const char *name, float *pf, unsigned char b0, unsigned char b1
 }
 
 struct Sflt { int tag; float f; };
+struct Core { float flux; float reserve; };
 
 static float gf;
 static float gg;
@@ -42,6 +43,21 @@ static void f_st(float x)
     gg = x;
 }
 
+static void core_rebalance(struct Core *core)
+{
+    core->reserve += core->flux * 0.125f;
+}
+
+static float core_rebalance_live(struct Core *core)
+{
+    return core->reserve += core->flux * 0.125f;
+}
+
+static float deref_add_live(float *p)
+{
+    return *p += 1.5f;
+}
+
 int main(void)
 {
     float lf;
@@ -49,6 +65,9 @@ int main(void)
     float lh;
     float la[2];
     struct Sflt s;
+    struct Core core;
+    float lc;
+    float ld;
 
     fails = 0;
     printf("tc89flta start\n");
@@ -77,6 +96,44 @@ int main(void)
 
     s.f = 1.0f;
     chk4("sf", &s.f, 0, 0, 128, 63);
+
+    core.flux = 3.5f;
+    core.reserve = 0.25f;
+    core_rebalance(&core);
+    chk4("core", &core.reserve, 0, 0, 48, 63);
+
+    core.flux = 3.5f;
+    core.reserve = 0.25f;
+    ld = core_rebalance_live(&core);
+    chk4("corelf", &core.reserve, 0, 0, 48, 63);
+    chk4("corelr", &ld, 0, 0, 48, 63);
+
+    gf = 2.0f;
+    ld = f_id(gf += 1.5f);
+    chk4("gfadd_f", &gf, 0, 0, 96, 64);
+    chk4("gfadd_r", &ld, 0, 0, 96, 64);
+
+    lc = 2.0f;
+    ld = deref_add_live(&lc);
+    chk4("dadd_f", &lc, 0, 0, 96, 64);
+    chk4("dadd_r", &ld, 0, 0, 96, 64);
+
+    ga[1] = 2.0f;
+    ld = f_id(ga[1] += 1.5f);
+    chk4("gaadd_f", &ga[1], 0, 0, 96, 64);
+    chk4("gaadd_r", &ld, 0, 0, 96, 64);
+    ga[1] = -3.0f;
+
+    /* local float assignment used as a live value (ix-direct store path) */
+    lc = 2.0f;
+    ld = (lc += 1.5f);            /* lc=3.5, ld=3.5 */
+    chk4("lcadd_f", &lc, 0, 0, 96, 64);
+    chk4("lcadd_r", &ld, 0, 0, 96, 64);
+
+    lc = 2.0f;
+    ld = (lc = 5.0f);            /* lc=5.0, ld=5.0 */
+    chk4("lcset_f", &lc, 0, 0, 160, 64);
+    chk4("lcset_r", &ld, 0, 0, 160, 64);
 
     lh = f_id(la[1]);
     chk4("fid", &lh, 0, 0, 0, 64);

--- a/tests/tlongopt.c
+++ b/tests/tlongopt.c
@@ -1,6 +1,12 @@
 #include <stdio.h>
+#include <stdint.h>
 
 static int fails;
+
+struct LongBox { int32_t l; int32_t a[2]; };
+
+static int32_t glive;
+static int32_t glarr[2];
 
 static void chk(long got, long want, char *name)
 {
@@ -36,6 +42,10 @@ static int br_lt65535(int x) { if (x < 65535) return 1; return 0; }
 static int br_lt_hex_u(int x) { if (x < 0xffff) return 1; return 0; }
 static int br_ult_hex_u(unsigned int x) { if (x < 0xffff) return 1; return 0; }
 static int clamp_int_min(long a) { if (a < -32768L) return -32768; return (int)a; }
+static int32_t id32(int32_t value) { return value; }
+static int32_t ret_global_live_add(void) { return glive += 5L; }
+static int32_t ret_deref_live_add(int32_t *p) { return *p += 7L; }
+static int32_t ret_member_live_shr(struct LongBox *p) { return p->l >>= 2; }
 
 /* Compound long expressions that peek_simple_unary_type cannot predict: the
  * first term is 16-bit but the whole RHS is long.  The operator must still
@@ -395,6 +405,69 @@ static void test_compound_long_ops(void)
     chk(cb_ge(5, 30000, 60000L), 0L, "cb_ge 5>=90000");
 }
 
+/* A long assignment used as a live value must produce BOTH the stored lvalue and
+ * the propagated result correctly.  int32_t keeps the width identical on the
+ * clang host (32-bit int) and dcc (32-bit long). */
+static void test_local_long_assign_value(void)
+{
+    struct LongBox box;
+    int32_t a;
+    int32_t arr[2];
+    int32_t b;
+    int32_t *p;
+
+    a = 0L;
+    b = (a = 100000L);              /* chained plain = */
+    chk(a, 100000L, "chain= field");
+    chk(b, 100000L, "chain= result");
+
+    a = 100000L;
+    b = (a += 50000L);             /* compound += live */
+    chk(a, 150000L, "chain+= field");
+    chk(b, 150000L, "chain+= result");
+
+    a = 4L;
+    b = (a *= 100000L);            /* compound *= live */
+    chk(a, 400000L, "chain*= field");
+    chk(b, 400000L, "chain*= result");
+
+    a = 900000L;
+    b = (a -= 100000L);            /* compound -= live */
+    chk(a, 800000L, "chain-= field");
+    chk(b, 800000L, "chain-= result");
+
+    glive = 10L;
+    b = ret_global_live_add();
+    chk(glive, 15L, "global+= field");
+    chk(b, 15L, "global+= result");
+
+    a = 20L;
+    p = &a;
+    b = ret_deref_live_add(p);
+    chk(a, 27L, "deref+= field");
+    chk(b, 27L, "deref+= result");
+
+    box.l = 0x80L;
+    b = ret_member_live_shr(&box);
+    chk(box.l, 0x20L, "member>>= field");
+    chk(b, 0x20L, "member>>= result");
+
+    arr[1] = 9L;
+    b = id32(arr[1] *= 5L);
+    chk(arr[1], 45L, "index*= field");
+    chk(b, 45L, "index*= result");
+
+    glarr[1] = 100L;
+    b = id32(glarr[1] -= 58L);
+    chk(glarr[1], 42L, "gindex-= field");
+    chk(b, 42L, "gindex-= result");
+
+    box.a[1] = 0x10L;
+    b = id32(box.a[1] <<= 2);
+    chk(box.a[1], 0x40L, "mindex<<= field");
+    chk(b, 0x40L, "mindex<<= result");
+}
+
 int main(void)
 {
     test_widen_mul_edges();
@@ -404,6 +477,7 @@ int main(void)
     test_shift_edges();
     test_long_const_compare_edges();
     test_compound_long_ops();
+    test_local_long_assign_value();
 
     if (fails == 0)
         printf("tlongopt passed with great success\n");


### PR DESCRIPTION
dcc could compile or accept some 32-bit long/float assignments only when the assignment expression result was unused. When the result was live, forms such as chained assignment, return expressions, or call arguments could either propagate a corrupted DE:HL value or be rejected by the AST support gate even though the emitter could now lower them.

After 4-byte address stores, emit_store_de_to_addr_hl does not preserve DE:HL. It leaves the stored value split as DE=low word and BC=high word, so rebuild the live expression result with:

    ex de,hl
    ld d,b
    ld e,c

Apply that reload to global, member, deref, and index long/float assignment paths where the expression value is live. Also remove stale expr_result_dead and sym_can_ix_direct restrictions from AST support checks so the gate matches the fixed emitter.

This fixes cases including:

    core->reserve += core->flux * 0.125f;
    x = (p->field = value);
    x = (p->field += value);
    return *p += 5L;
    return p->f += 1.5f;
    sink(global_long += 5L);
    sink(array[i] *= 5L);

Add regressions for:
- float member/global/deref/index live-result compound assignments
- long local/global/deref/member/index live-result assignments
- shift and arithmetic compound forms that previously risked rejection or bad result propagation

Validated with focused peep/nopeep runs for tc89flta and tlongopt, plus the full regression suite:

    224 passed, 0 failed, 9 skipped
    diagnostics: all 87 passed