### PR TITLE
Fix nested address-taken compound literals

### DIFF
--- a/src/dcc/dcc_ast_gen_expr.c
+++ b/src/dcc/dcc_ast_gen_expr.c
@@ -704,6 +704,15 @@ static void gen_compound_literal_ast(const struct AstNode *n)
     int sv_line = line_no;
     int sv_tok_line = tok_line;
     struct Token sv_tok = tok;
+    /* Capture the fields we still need after the initializer is emitted.
+     * `n` itself lives in g_ast_init_arena, and emitting a non-constant field
+     * (e.g. .p = &(T){...}) re-enters ast_emit_init_expr, which builds into and
+     * then resets that same arena - overwriting this node with the last nested
+     * initializer. Reading n->sym/n->type afterwards would then yield the wrong
+     * (last nested) compound literal, so snapshot them now. The Sym pointer
+     * itself targets the stable locals[] table, so it stays valid. */
+    struct Sym *clit_sym = n->sym;
+    int clit_type = n->type;
 
     posi = sp->posi;
     tok_start_pos = sp->tok_start_pos;
@@ -711,15 +720,15 @@ static void gen_compound_literal_ast(const struct AstNode *n)
     tok_line = sp->tok_line;
     tok = sp->tok;
 
-    if ((n->type & TYPE_STRUCT) && type_ptr_depth(n->type) == 0) {
-        emit_init_auto_struct_from_list(n->sym);
+    if ((clit_type & TYPE_STRUCT) && type_ptr_depth(clit_type) == 0) {
+        emit_init_auto_struct_from_list(clit_sym);
     } else if (accept('{')) {
-        emit_init_auto_struct_scalar(n->sym, 0, n->type);
+        emit_init_auto_struct_scalar(clit_sym, 0, clit_type);
         if (tok.kind == ',')
             next_token();
         expect('}');
     } else {
-        emit_init_auto_struct_scalar(n->sym, 0, n->type);
+        emit_init_auto_struct_scalar(clit_sym, 0, clit_type);
     }
 
     posi = sv_posi;
@@ -728,8 +737,8 @@ static void gen_compound_literal_ast(const struct AstNode *n)
     tok_line = sv_tok_line;
     tok = sv_tok;
 
-    emit_load_sym_addr(n->sym);
-    g_expr_type = type_add_ptr(n->type);
+    emit_load_sym_addr(clit_sym);
+    g_expr_type = type_add_ptr(clit_type);
 }
 
 void gen_pointer_cmp_operand_ast(const struct AstNode *n)

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -1131,10 +1131,22 @@ static int scan_compound_literal_if_present(void)
 
     add_compound_literal_local(type);
 
+    /* Walk the braced initializer, recursing into nested compound literals so
+     * each reserves its own frame slot in source order. The codegen pass
+     * re-parses this same initializer at emit time and allocates one frame
+     * slot per nested compound literal (add_compound_literal_local, reached
+     * through ast_emit_init_expr for each non-constant field). Emit consumes
+     * the initializer tokens in source order, so a source-order recursive walk
+     * here reserves exactly the same slots at the same offsets. Skipping the
+     * body (the old behavior) under-reserved the frame: the prologue is sized
+     * from this scan, so the nested literals then landed below SP where an
+     * intervening push/call clobbers them. */
     depth = 0;
     do {
         if (tok.kind == TOK_EOF)
             break;
+        if (depth >= 1 && tok.kind == '(' && scan_compound_literal_if_present())
+            continue;
         if (tok.kind == '{')
             depth++;
         else if (tok.kind == '}')

--- a/tests/tclit.c
+++ b/tests/tclit.c
@@ -59,9 +59,55 @@ static void check_block_literals(void)
     check_int(*ip, 1235, "scalar literal");
 }
 
+/* Nested, address-taken compound literals used to build a small tree inline,
+ * then walked recursively. A field initialized to the address of another
+ * compound literal (.left = &(struct Node){...}) re-enters the initializer
+ * emitter, so this exercises both the root-address capture and the frame
+ * reservation for every nested literal. */
+struct Node {
+    long v;
+    const struct Node *left;
+    const struct Node *right;
+};
+
+static long sum_tree(const struct Node *n)
+{
+    if (n == NULL)
+        return 0;
+    return n->v + sum_tree(n->left) + sum_tree(n->right);
+}
+
+static void check_nested_literals(void)
+{
+    const struct Node *tree = &(struct Node){
+        .v = 1L,
+        .left = &(struct Node){ .v = 20L },
+        .right = &(struct Node){ .v = 300L }
+    };
+    /* Same shape, but the nested literals are designated out of source order:
+     * the root must still resolve to the outer literal, not the last-built
+     * nested one. */
+    const struct Node *reordered = &(struct Node){
+        .v = 7L,
+        .right = &(struct Node){ .v = 500L },
+        .left = &(struct Node){ .v = 40L }
+    };
+
+    check_int((int)tree->v, 1, "tree.v");
+    check_int((int)tree->left->v, 20, "tree.left.v");
+    check_int((int)tree->right->v, 300, "tree.right.v");
+    check_int((int)sum_tree(tree), 321, "sum_tree");
+
+    check_int((int)reordered->v, 7, "reordered.v");
+    check_int((int)reordered->left->v, 40, "reordered.left.v");
+    check_int((int)reordered->right->v, 500, "reordered.right.v");
+    check_int((int)sum_tree(reordered), 547, "sum_tree reordered");
+}
+
 int main(void)
 {
     check_block_literals();
+    check_nested_literals();
     if (failures == 0)
         printf("test tclit completed with great success\n");
     return failures;


### PR DESCRIPTION
@davidly 
Nested compound literals exposed two related codegen bugs.

First, gen_compound_literal_ast kept reading n->sym and n->type after emitting the literal initializer. That is unsafe for initializer expressions, because the outer compound-literal AST node lives in g_ast_init_arena. Emitting a non-constant field such as:

    .left = &(struct Node){ .v = 20L }

re-enters ast_emit_init_expr, which builds into and resets that same arena. As a result, the outer n could be overwritten by the last nested initializer node. The generated code would initialize the outer literal correctly, but then return the address of the last nested literal instead of the address of the outer object.

Fix this by snapshotting the compound literal's Sym * and type before emitting the initializer, and using those captured values for the final address load and result type.

Second, the function-body frame-sizing scan only reserved storage for the outer compound literal, then skipped the braced initializer body. Codegen later re-parsed that initializer and allocated additional stack slots for nested address-taken compound literals. Because the prologue frame size came from the scan pass, those nested slots could land below SP and be clobbered by later pushes or calls.

Fix this by making scan_compound_literal_if_present recurse through compound-literal initializer bodies and reserve nested literal slots in source order. This matches the order used by emit-time initializer parsing, keeping scan-time frame layout and codegen-time offsets aligned.

Add regression coverage to tclit for a recursive tree built from nested address-taken compound literals. The test checks both the normal source-order case and a reordered-designator case, which catches the old "root address becomes the last nested literal" failure mode.