### PR TITLE
fix(parser): accept function returning pointer-to-array and related a…

### DIFF
--- a/src/dcc/dcc_decl.c
+++ b/src/dcc/dcc_decl.c
@@ -1184,7 +1184,7 @@ void gen_local_decl_after_type(int base)
                 emit_init_auto_struct_array_from_list(s);
             } else if (!s->is_array && tok.kind == '{' && (type & TYPE_STRUCT) && type_ptr_depth(type) == 0) {
                 emit_init_auto_struct_from_list(s);
-            } else if (s->is_array && tok.kind == '{' && !(type & TYPE_STRUCT)) {
+            } else if (s->is_array && tok.kind == '{' && (!(type & TYPE_STRUCT) || type_ptr_depth(type) > 0)) {
                 emit_init_auto_array_from_list(s, type);
             } else if (!s->is_array && tok.kind == '{') {
                 /* Same ix-direct fast path as the plain (no-braces) scalar

--- a/src/dcc/dcc_expr.c
+++ b/src/dcc/dcc_expr.c
@@ -199,6 +199,46 @@ void gen_expr_no_comma(void);
 void gen_unary(void);
 void gen_snippet_lvalue_addr(const char *snippet, int *ptype);
 void gen_statement(void);
+
+static void parse_pointer_array_suffixes(int base_type)
+{
+    int dims[MAX_ARRAY_DIMS];
+    int ndims;
+    int i;
+    int n;
+    int elem_bytes;
+    int total;
+
+    ndims = 0;
+    memset(dims, 0, sizeof(dims));
+    while (accept('[')) {
+        if (tok.kind == ']') {
+            n = 0;
+            next_token();
+        } else {
+            n = parse_const_int_expr();
+            expect(']');
+        }
+        if (n < 0) n = 0;
+        if (ndims < MAX_ARRAY_DIMS) dims[ndims++] = n;
+    }
+
+    elem_bytes = type_size(base_type);
+    if (elem_bytes <= 0) elem_bytes = 2;
+    total = 1;
+    for (i = 0; i < ndims; ++i) {
+        if (dims[i] <= 0) {
+            total = 0;
+            break;
+        }
+        total *= dims[i];
+    }
+    g_ptr_array_dim_count = ndims;
+    g_ptr_array_elem_size = total > 0 ? total * elem_bytes : elem_bytes;
+    for (i = 0; i < ndims && i < MAX_ARRAY_DIMS; ++i)
+        g_ptr_array_dims[i] = dims[i];
+}
+
 int parse_funcptr_declarator(int *ptype, char *name, int namesz)
 {
     int type;
@@ -349,6 +389,8 @@ int parse_funcptr_declarator(int *ptype, char *name, int namesz)
                     else if (tok.kind == ')') depth--;
                     next_token();
                 }
+            } else if (tok.kind == '[') {
+                parse_pointer_array_suffixes(ptype[0]);
             }
             type = type_add_ptr(ptype[0]);
             ptype[0] = type;
@@ -375,41 +417,7 @@ int parse_funcptr_declarator(int *ptype, char *name, int namesz)
             next_token();
         expect(')');
     } else if (tok.kind == '[') {
-        int dims[MAX_ARRAY_DIMS];
-        int ndims;
-        int i;
-        int n;
-        int elem_bytes;
-        int total;
-
-        ndims = 0;
-        memset(dims, 0, sizeof(dims));
-        while (accept('[')) {
-            if (tok.kind == ']') {
-                n = 0;
-                next_token();
-            } else {
-                n = parse_const_int_expr();
-                expect(']');
-            }
-            if (n < 0) n = 0;
-            if (ndims < MAX_ARRAY_DIMS) dims[ndims++] = n;
-        }
-
-        elem_bytes = type_size(ptype[0]);
-        if (elem_bytes <= 0) elem_bytes = 2;
-        total = 1;
-        for (i = 0; i < ndims; ++i) {
-            if (dims[i] <= 0) {
-                total = 0;
-                break;
-            }
-            total *= dims[i];
-        }
-        g_ptr_array_dim_count = ndims;
-        g_ptr_array_elem_size = total > 0 ? total * elem_bytes : elem_bytes;
-        for (i = 0; i < ndims && i < MAX_ARRAY_DIMS; ++i)
-            g_ptr_array_dims[i] = dims[i];
+        parse_pointer_array_suffixes(ptype[0]);
     }
 
     ptype[0] = type;

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -1776,6 +1776,8 @@ void scan_static_local_decl_after_type(int base)
         bytes = type_size(type);
         if (arrlen > 0)
             bytes = object_array_size(type, arrlen);
+        else if (g_last_array_dim_count > 0)
+            bytes = 0;
         else if (arrlen < 0)
             bytes = 0;
 
@@ -1793,7 +1795,7 @@ void scan_static_local_decl_after_type(int base)
         g->needs_extrn = 0;
         g->is_static = 1;
         g->size = bytes;
-        if (arrlen != 0) {
+        if (arrlen != 0 || g_last_array_dim_count > 0) {
             g->is_array = 1;
             g->array_len = arrlen > 0 ? arrlen : 0;
             g->elem_size = current_field_array_elem_size ? current_field_array_elem_size : type_size(type);
@@ -1805,7 +1807,7 @@ void scan_static_local_decl_after_type(int base)
             l = add_local_known(name, type, SC_GLOBAL, 0, bytes);
             strncpy(l->link_name, backing_name, sizeof(l->link_name) - 1);
             l->link_name[sizeof(l->link_name) - 1] = 0;
-            if (arrlen != 0) {
+            if (arrlen != 0 || g_last_array_dim_count > 0) {
                 l->is_array = 1;
                 l->array_len = arrlen > 0 ? arrlen : 0;
                 l->elem_size = g->elem_size;
@@ -3333,6 +3335,15 @@ void parse_function_or_global(int base_type)
             s = add_global(name, type, SC_FUNC);
             s->is_inline |= decl_is_inline;
             parse_function_return_type = type;
+            if (g_ptr_array_dim_count > 0) {
+                int pi;
+                s->elem_size = g_ptr_array_elem_size;
+                s->dim_count = g_ptr_array_dim_count;
+                for (pi = 0; pi < MAX_ARRAY_DIMS; ++pi)
+                    s->dims[pi] = (pi < g_ptr_array_dim_count) ? g_ptr_array_dims[pi] : 0;
+                g_ptr_array_dim_count = 0;
+                g_ptr_array_elem_size = 0;
+            }
             if (decl_is_static) {
                 s->is_static = 1;
                 s->needs_extrn = 0;

--- a/tests/tc99init.c
+++ b/tests/tc99init.c
@@ -52,6 +52,10 @@ static void check_local_designators(void)
     struct Pair local_pair = { .b = 22, .a = 21 };
     struct Pair local_pairs[2] = { [1] = { .b = 42, .a = 41 }, [0] = { 39, 40 } };
     int local_values[4] = { [2] = 32, [0] = 30, 31, [3] = 33 };
+    static const struct Pair static_pairs[] = {
+        { .b = 52, .a = 51 },
+        { .b = 54, .a = 53 }
+    };
 
     check_int(local_pair.a, 21, "local_pair.a");
     check_int(local_pair.b, 22, "local_pair.b");
@@ -63,6 +67,10 @@ static void check_local_designators(void)
     check_int(local_values[1], 31, "local_values[1]");
     check_int(local_values[2], 32, "local_values[2]");
     check_int(local_values[3], 33, "local_values[3]");
+    check_int(static_pairs[0].a, 51, "static_pairs[0].a");
+    check_int(static_pairs[0].b, 52, "static_pairs[0].b");
+    check_int(static_pairs[1].a, 53, "static_pairs[1].a");
+    check_int(static_pairs[1].b, 54, "static_pairs[1].b");
 }
 
 int main(void)

--- a/tests/tdecl.c
+++ b/tests/tdecl.c
@@ -43,6 +43,33 @@ int sum_row(int (*rp)[3], int row)
     return rp[row][0] + rp[row][1] + rp[row][2];
 }
 
+struct PickNode {
+    int value;
+};
+
+static struct PickNode pick_node = { 101 };
+typedef const struct PickNode *(*pick_node_fn)(const struct PickNode *node, int seed);
+
+static const struct PickNode *pick_same_node(const struct PickNode *node, int seed)
+{
+    (void) seed;
+    return node;
+}
+
+static const struct PickNode *pick_global_node(const struct PickNode *node, int seed)
+{
+    (void) node;
+    (void) seed;
+    return &pick_node;
+}
+
+static int local_structptr_fnptr_array(void)
+{
+    pick_node_fn pickers[2] = { pick_same_node, pick_global_node };
+    (void) pickers;
+    return 202;
+}
+
 static int lpa(void)
 {
     int local[2][3];
@@ -63,9 +90,21 @@ static int lpa(void)
     return 1;
 }
 
+static unsigned char (*glyph_matrix(void))[4]
+{
+    static unsigned char matrix[3][4] = {
+        { 'N', 'E', 'S', 'W' },
+        { 'R', 'I', 'N', 'G' },
+        { 'Z', '8', '0', '!' }
+    };
+
+    return matrix;
+}
+
 int main(void)
 {
     int r;
+    unsigned char (*glyph_rows)[4];
 
     fp = add;
     ops[0] = add;
@@ -91,6 +130,12 @@ int main(void)
 
     r = lpa();
     vri(r, 1, "local-pointer-to-array");
+    vri(local_structptr_fnptr_array(), 202, "local-structptr-fnptr-array");
+
+    glyph_rows = glyph_matrix();
+    vri(glyph_rows[0][0], 'N', "func-return-ptr-array-first");
+    vri(glyph_rows[1][2], 'N', "func-return-ptr-array-stride");
+    vri(glyph_rows[2][3], '!', "func-return-ptr-array-last");
 
     if (g_failed) {
         printf("declaration syntax test failed: %d\n", g_failed);


### PR DESCRIPTION
@davidly 

…ggregate initializers

Fix three related front-end gaps that prevented dcc from compiling valid C that Clang accepts. All were surfaced by a single test program that combines a function-returning-pointer-to-array declarator with static and automatic aggregate initializers.

1. Function returning pointer to array: `T (*f(void))[N]`

   parse_funcptr_declarator() reduced the parenthesized function
   declarator `(*name(params))` but then bailed at a trailing array
   suffix, so a return type of "pointer to array of N" was rejected with
   DCC-E1102/E1101. The existing pointer-to-array suffix reader (dims,
   stride, element size into g_ptr_array_*) is now factored into
   parse_pointer_array_suffixes() and also invoked after the nested
   function declarator closes, so `(*f(void))[N]` parses like the
   already-supported abstract form `T (*)[N]`.

   parse_function_or_global() consumes the resulting g_ptr_array_*
   metadata when it creates the SC_FUNC symbol and clears the globals so
   the pointer-to-array dimensions cannot leak into the next declaration.

2. Static local arrays with an omitted first dimension: `static const T table[] = { ... }`

   scan_static_local_decl_after_type() only marked the backing global as an array when the parsed length was non-zero, so an omitted-size static local (arrlen == 0) was registered as a single object. The designated struct-array initializer that followed then failed with DCC-E0902/E1103. The scan now also treats g_last_array_dim_count > 0 as an array, sizes it as 0 for later inference, and mirrors dim_count/dims onto both the backing global and the local alias, matching file-scope behavior. The initializer parser infers the true element count as before.

3. Automatic arrays whose element type is a pointer carrying TYPE_STRUCT: `fnptr_t table[N] = { a, b, ... }`

   gen_local_decl_after_type() routed any braced initializer whose type had TYPE_STRUCT set through the struct-array path, which is wrong for a pointer element such as a function-pointer typedef returning `const struct *`. Such an initializer is a list of scalar pointers and was rejected with DCC-E1003. The array-initializer branch now also accepts TYPE_STRUCT element types when type_ptr_depth(type) > 0, so arrays of pointers-to-struct (including function pointers) use the scalar array path. Plain struct-value arrays are unaffected because the struct-array branch above still requires ptr_depth == 0.

Tests:
- tests/tdecl.c: function returning pointer to array (assigned to a local `unsigned char (*)[4]` and indexed), plus a local array of function-pointer typedefs returning `const struct *`.
- tests/tc99init.c: static local omitted-size struct array with designated initializers.

Both tests are clang-baselined (unchanged pass-only output) and pass under dcc/ntvcm. Full regression suite passes in full mode (fast + nopeep): 224 apps, 87 diagnostics, 0 failures.

Known limitation (pre-existing, out of scope): direct indexing of the call result, `f()[i][j]`, is still unsupported (DCC-E1002); assign the result to a pointer-to-array local first. The declarator itself now parses correctly.