### PR TITLE
Fix pointer-to-array subscript stores

### DIFF
--- a/src/dcc/dcc_ast_gen.c
+++ b/src/dcc/dcc_ast_gen.c
@@ -494,6 +494,14 @@ int ast_index_struct_object_type(const struct AstNode *n, int *out_type)
         return 0;
     if (n->a == NULL)
         return 0;
+    if (ast_index_deref_pointer_array_collect(n, &s, NULL, NULL, NULL,
+                                              &elem_type)) {
+        if (!type_is_struct_object(elem_type))
+            return 0;
+        if (out_type)
+            *out_type = elem_type;
+        return 1;
+    }
     if (ast_index_symbol_nd_elem_type(n, &elem_type)) {
         if (!type_is_struct_object(elem_type))
             return 0;

--- a/src/dcc/dcc_ast_gen_support.c
+++ b/src/dcc/dcc_ast_gen_support.c
@@ -343,6 +343,22 @@ static int ast_gen_supported_uncached(const struct AstNode *n)
                     return 0;
                 }
             }
+            /* Deref-of-pointer-to-array subscript store `(*p)[i] = rhs` (p a
+             * pointer-to-array local/param, e.g. `int (*p)[4]`).  Long and
+             * float element stores are already accepted by the
+             * ast_index_lvalue_elem_type block above; add the plain-int and
+             * pointer element cases so `(*p)[i]` matches the address machine
+             * that gen_index_addr_ast already emits for this shape (via
+             * ast_index_deref_pointer_array_collect). */
+            if (n->op == '=' &&
+                ast_index_deref_pointer_array_collect(n->a, &base, NULL, NULL,
+                                                      NULL, &elem)) {
+                if (type_ptr_depth(elem) > 0)
+                    return type_size(elem) == 2 && ast_pointer_assign_rhs_supported(n->b);
+                if (ast_is_plain_int_type(elem))
+                    return (type_size(elem) == 1 || type_size(elem) == 2) &&
+                           ast_int_elem_assign_rhs_ok(n);
+            }
             if (ast_index_symbol_nd_elem_type(n->a, &elem)) {
                 if (type_is_long(elem))
                     return (n->op == '=' || (is_compound && expr_result_dead)) &&

--- a/tests/tptrlhs.c
+++ b/tests/tptrlhs.c
@@ -93,6 +93,23 @@ long exp;
     }
 }
 
+static struct Leaf make_leaf(seed)
+int seed;
+{
+    struct Leaf leaf;
+    int i;
+
+    leaf.v = seed;
+    leaf.cv = (char)(seed + 1);
+    leaf.lv = (long)seed * 1000L;
+    for (i = 0; i < 4; ++i) {
+        leaf.a[i] = seed + i;
+        leaf.ca[i] = (char)(seed + 10 + i);
+        leaf.la[i] = (long)seed * 1000L + (long)i;
+    }
+    return leaf;
+}
+
 static void init_all()
 {
     int i, j, k;
@@ -597,6 +614,47 @@ static void touch_alias_mix()
     check_long("alias loa glmat end", glmat[2][3], -400007L);
 }
 
+static void touch_ptr_to_array_deref()
+{
+    int irow[4];
+    char crow[4];
+    int *prow[3];
+    struct Leaf leafrow[3];
+    int (*ip)[4];
+    char (*cp)[4];
+    int *(*pp)[3];
+    struct Leaf (*lp)[3];
+    int i;
+    int ix;
+
+    for (i = 0; i < 4; ++i) {
+        irow[i] = 0;
+        crow[i] = 0;
+    }
+    for (i = 0; i < 3; ++i) {
+        prow[i] = 0;
+        leafrow[i] = make_leaf(0);
+    }
+
+    ip = &irow;
+    cp = &crow;
+    pp = &prow;
+    lp = &leafrow;
+    ix = 2;
+
+    (*ip)[ix] = 501;
+    (*cp)[ix + 1] = 71;
+    (*pp)[1] = &gint[14];
+    (*lp)[ix] = make_leaf(70);
+
+    check_int("ptr-array int store", irow[2], 501);
+    check_char("ptr-array char store", crow[3], 71);
+    check_int("ptr-array pointer store", *prow[1], gint[14]);
+    check_int("ptr-array struct v", leafrow[2].v, 70);
+    check_char("ptr-array struct cv", leafrow[2].cv, 71);
+    check_long("ptr-array struct la", leafrow[2].la[3], 70003L);
+}
+
 int main()
 {
     struct Wrapper *wp;
@@ -621,6 +679,7 @@ int main()
     touch_params(&wp, &np, &lp, &ip, &cp, &longp);
 
     touch_alias_mix();
+    touch_ptr_to_array_deref();
 
     if (fails == 0) {
         printf("PASS\n");


### PR DESCRIPTION
@davidly 

Accept assignments through dereferenced pointer-to-array subscripts such as (*p)[i] = rhs. The address emitter already handled this shape via ast_index_deref_pointer_array_collect, but the AST support gates rejected plain-int, pointer, and struct element stores before codegen.

Add support-gate recognition for scalar/pointer element stores and for struct object element types so these lvalues route through the existing index-address and struct assignment emitters.

Validated with the original main.c reproducer and the fast regression suite: 224/224 apps passed, 87/87 diagnostics passed.