### PR TITLE
Fix bit-field RMW and initializer edge cases

### DIFF
--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -832,6 +832,7 @@ void emit_cleanup_stack_bytes(int bytes);
 void emit_call_hl_from_stack_offset(int off);
 void emit_extract_bitfield(void);
 void emit_store_bitfield_from_hl(void);
+void emit_store_bitfield_de_to_addr_hl(int keep_result);
 int paren_starts_cast(void);
 void emit_incdec_value_in_dehl(int type, int op);
 void emit_pre_incdec_lvalue(int type, int op);

--- a/src/dcc/dcc_ast.h
+++ b/src/dcc/dcc_ast.h
@@ -267,6 +267,7 @@ void ast_support_cache_begin(void);
 /* Pure-AST emission of a declaration initializer's assignment-expression.
  * Builds into the isolated g_ast_init_arena; fatal on unsupported constructs. */
 void ast_emit_init_expr(void);
+void ast_emit_struct_init_expr_assign(struct Sym *s);
 
 /* Statement hook.  Called from gen_statement to build the next statement from
  * the token stream and emit it from the AST.  Returns 0 only in scanner/debug

--- a/src/dcc/dcc_ast_gen.c
+++ b/src/dcc/dcc_ast_gen.c
@@ -2023,7 +2023,8 @@ int ast_preincdec_plain_int(const struct AstNode *n)
         return sz == 1 || sz == 2;
     }
     if (n->a->kind == AST_MEMBER) {
-        if (!ast_member_lvalue_type(n->a, &val_type))
+        if (!ast_member_bitfield_lvalue_type(n->a, &val_type) &&
+            !ast_member_lvalue_type(n->a, &val_type))
             return 0;
         if (type_is_long(val_type))
             return 1;
@@ -2148,7 +2149,8 @@ int ast_postfix_plain_int(const struct AstNode *n)
         return sz == 1 || sz == 2;
     }
     if (n->a->kind == AST_MEMBER) {
-        if (!ast_member_lvalue_type(n->a, &val_type))
+        if (!ast_member_bitfield_lvalue_type(n->a, &val_type) &&
+            !ast_member_lvalue_type(n->a, &val_type))
             return 0;
         if (!ast_is_plain_int_type(val_type))
             return 0;

--- a/src/dcc/dcc_ast_gen_cond.c
+++ b/src/dcc/dcc_ast_gen_cond.c
@@ -1031,7 +1031,8 @@ int ast_deadincdec_member_ok(const struct AstNode *e)
     int t;
     if (e->a == NULL || e->a->kind != AST_MEMBER)
         return 0;
-    if (!ast_member_lvalue_type(e->a, &t))
+    if (!ast_member_bitfield_lvalue_type(e->a, &t) &&
+        !ast_member_lvalue_type(e->a, &t))
         return 0;
     if (type_ptr_depth(t) > 0)
         return type_index_elem_size(t) == 1;
@@ -1112,7 +1113,8 @@ int ast_deadincdec_addr_lvalue_type(const struct AstNode *e, int *out_type)
         t = s->type;
         break;
     case AST_MEMBER:
-        if (!ast_member_lvalue_type(lv, &t))
+        if (!ast_member_bitfield_lvalue_type(lv, &t) &&
+            !ast_member_lvalue_type(lv, &t))
             return 0;
         break;
     case AST_UNARY:

--- a/src/dcc/dcc_ast_gen_expr.c
+++ b/src/dcc/dcc_ast_gen_expr.c
@@ -1494,6 +1494,75 @@ void ast_emit_init_expr(void)
     emit("\tld hl,0\n");
 }
 
+void ast_emit_struct_init_expr_assign(struct Sym *s)
+{
+    struct AstNode *rhs;
+    struct AstNode *lhs;
+    long sv_pos;
+    long sv_tok_start;
+    int sv_line;
+    int sv_tok_line;
+    struct Token sv_tok;
+    long end_pos;
+    long end_tok_start;
+    int end_line;
+    int end_tok_line;
+    struct Token end_tok;
+
+    sv_pos = posi;
+    sv_tok_start = tok_start_pos;
+    sv_line = line_no;
+    sv_tok_line = tok_line;
+    sv_tok = tok;
+
+    rhs = ast_build_assign_expr(&g_ast_init_arena);
+
+    end_pos = posi;
+    end_tok_start = tok_start_pos;
+    end_line = line_no;
+    end_tok_line = tok_line;
+    end_tok = tok;
+
+    lhs = ast_new(&g_ast_init_arena, AST_IDENT);
+    lhs->sval = ast_arena_strdup(&g_ast_init_arena, s->name);
+    lhs->sym = s;
+    lhs->type = s->type;
+
+    if (rhs != NULL && ast_struct_return_call_assign_supported(s->type, rhs)) {
+        gen_struct_return_call_assign_ast(lhs, rhs);
+        ast_arena_reset(&g_ast_init_arena);
+        return;
+    }
+
+    if (getenv("DCC_AST_REPORT") != NULL) {
+        if (rhs == NULL)
+            fprintf(stderr, "; AST-unsupported struct init build token=%d text='%s' line=%d\n",
+                    tok.kind, tok.text, tok_line);
+        else
+            fprintf(stderr, "; AST-unsupported struct init gate kind=%s line=%d\n",
+                    ast_kind_name(rhs->kind), tok_line);
+    }
+    ast_arena_reset(&g_ast_init_arena);
+
+    tok = sv_tok;
+    tok_line = sv_tok_line;
+    line_no = sv_line;
+    posi = sv_pos;
+    tok_start_pos = sv_tok_start;
+    error_here(rhs == NULL ? "malformed initializer expression" : "unsupported struct initializer expression");
+
+    if (rhs != NULL) {
+        posi = end_pos;
+        tok_start_pos = end_tok_start;
+        line_no = end_line;
+        tok_line = end_tok_line;
+        tok = end_tok;
+    } else {
+        while (tok.kind != TOK_EOF && tok.kind != ',' && tok.kind != ';' && tok.kind != '}')
+            next_token();
+    }
+}
+
 static int ast_bool_bitand_const_rhs(const struct AstNode *n,
                                      const struct AstNode **out_value,
                                      unsigned int *out_mask)
@@ -1911,6 +1980,13 @@ void gen_assign_ast(const struct AstNode *n)
 
         emit("\tpush hl\n");                    /* save lvalue address */
         emit_load_from_hl(val_type);            /* HL = current value */
+        if (bf_width > 0) {
+            current_field_bit_width = bf_width;
+            current_field_bit_shift = bf_shift;
+            current_field_bit_mask = bf_mask;
+            g_expr_type = val_type;
+            emit_extract_bitfield();
+        }
         emit("\tpush hl\n");                    /* save current value */
 
         saved_dead = expr_result_dead;
@@ -1922,9 +1998,17 @@ void gen_assign_ast(const struct AstNode *n)
             emit("\tld b,l\n\tpop hl\n");
             emit_shift_loop(n->op, val_type);
             emit("\tex de,hl\n\tpop hl\n");
-            emit_store_de_to_addr_hl(val_type);
-            if (!want_dead)
-                emit("\tex de,hl\n");
+            if (bf_width > 0) {
+                current_field_bit_width = bf_width;
+                current_field_bit_shift = bf_shift;
+                current_field_bit_mask = bf_mask;
+                g_expr_type = val_type;   /* field type -> correct extract sign */
+                emit_store_bitfield_de_to_addr_hl(!want_dead);
+            } else {
+                emit_store_de_to_addr_hl(val_type);
+                if (!want_dead)
+                    emit("\tex de,hl\n");
+            }
             g_long_from16 = 0;
             return;
         }
@@ -1933,9 +2017,17 @@ void gen_assign_ast(const struct AstNode *n)
         common_type = common_arith_type(val_type, g_expr_type);
         gen_binop_typed(binop, common_type);    /* HL = result */
         emit("\tex de,hl\n\tpop hl\n");         /* DE = result, HL = address */
-        emit_store_de_to_addr_hl(val_type);
-        if (!want_dead)
-            emit("\tex de,hl\n");
+        if (bf_width > 0) {
+            current_field_bit_width = bf_width;
+            current_field_bit_shift = bf_shift;
+            current_field_bit_mask = bf_mask;
+            g_expr_type = val_type;   /* field type -> correct extract sign */
+            emit_store_bitfield_de_to_addr_hl(!want_dead);
+        } else {
+            emit_store_de_to_addr_hl(val_type);
+            if (!want_dead)
+                emit("\tex de,hl\n");
+        }
         g_long_from16 = 0;
         return;
     }

--- a/src/dcc/dcc_ast_gen_stmt.c
+++ b/src/dcc/dcc_ast_gen_stmt.c
@@ -638,7 +638,10 @@ void ast_gen_for_stmt(const struct AstNode *n)
             } else {
                 int vt;
                 gen_deadincdec_addr_lvalue_ast(n->c, &vt);
-                emit_incdec_addr(vt, n->c->op);
+                if (current_field_bit_width > 0)
+                    emit_pre_incdec_lvalue(vt, n->c->op);
+                else
+                    emit_incdec_addr(vt, n->c->op);
             }
         } else {
             ast_gen_expr(n->c);
@@ -790,7 +793,10 @@ void ast_gen_stmt(const struct AstNode *n)
             } else {
                 int vt;
                 gen_deadincdec_addr_lvalue_ast(n->a, &vt);
-                emit_incdec_addr(vt, n->a->op);
+                if (current_field_bit_width > 0)
+                    emit_pre_incdec_lvalue(vt, n->a->op);
+                else
+                    emit_incdec_addr(vt, n->a->op);
             }
         } else if (ast_is_local_self_add_stmt(n->a)) {
             ast_emit_local_self_add_stmt(n->a);

--- a/src/dcc/dcc_ast_gen_support.c
+++ b/src/dcc/dcc_ast_gen_support.c
@@ -561,7 +561,7 @@ static int ast_gen_supported_uncached(const struct AstNode *n)
         if (n->a->kind == AST_MEMBER) {
             int field_type;
             if (ast_member_bitfield_lvalue_type(n->a, &field_type))
-                return n->op == '=' && ast_value_is_plain_int(n->b);
+                return ast_value_is_plain_int(n->b);
             if (!ast_member_lvalue_type(n->a, &field_type))
                 return 0;
             if (type_is_long(field_type)) {

--- a/src/dcc/dcc_decl.c
+++ b/src/dcc/dcc_decl.c
@@ -471,6 +471,90 @@ void emit_init_auto_char_array_at_offset_from_string(struct Sym *s, int baseoff,
 void emit_init_auto_struct_type(struct Sym *s, int baseoff, int type);
 void skip_initializer_or_decl_tail(void);
 
+int emit_init_auto_struct_chained_designator(struct Sym *s, int baseoff, struct FieldDef *fd)
+{
+    int off;
+    int type;
+    int elem_size;
+    int is_array;
+    int count;
+
+    off = baseoff + fd->offset;
+    type = fd->is_array ? fd->elem_type : fd->type;
+    elem_size = fd->elem_size ? fd->elem_size : type_size(type);
+    if (elem_size <= 0) elem_size = 2;
+    is_array = fd->is_array;
+    count = fd->array_len;
+
+    if (tok.kind != '[' && tok.kind != '.')
+        return 0;
+
+    for (;;) {
+        if (tok.kind == '[') {
+            int idx;
+            if (!is_array) {
+                error_here("subscripted initializer designator is not an array");
+                skip_initializer_or_decl_tail();
+                return 1;
+            }
+            next_token();
+            idx = parse_const_int_expr();
+            expect(']');
+            if (idx < 0) {
+                error_here("negative array initializer designator");
+                idx = 0;
+            } else if (count > 0 && idx >= count) {
+                error_here("array initializer designator out of range");
+                idx = 0;
+            }
+            off += idx * elem_size;
+            is_array = 0;
+        } else if (tok.kind == '.') {
+            struct FieldDef *sub;
+            int sid;
+            if (!((type & TYPE_STRUCT) && type_ptr_depth(type) == 0)) {
+                error_here("field initializer designator is not a struct");
+                skip_initializer_or_decl_tail();
+                return 1;
+            }
+            next_token();
+            if (tok.kind != TOK_ID) {
+                error_here("expected a field designator, such as '.field = value'");
+                skip_initializer_or_decl_tail();
+                return 1;
+            }
+            sid = type_struct_id(type);
+            sub = find_field_def(sid, tok.text);
+            if (sub == NULL) {
+                error_here("unknown field initializer designator");
+                skip_initializer_or_decl_tail();
+                return 1;
+            }
+            off += sub->offset;
+            type = sub->is_array ? sub->elem_type : sub->type;
+            elem_size = sub->elem_size ? sub->elem_size : type_size(type);
+            if (elem_size <= 0) elem_size = 2;
+            is_array = sub->is_array;
+            count = sub->array_len;
+            fd = sub;
+            next_token();
+        } else {
+            break;
+        }
+    }
+
+    expect('=');
+    if (is_array)
+        emit_init_auto_struct_array(s, off, type, count, elem_size);
+    else if ((type & TYPE_STRUCT) && type_ptr_depth(type) == 0)
+        emit_init_auto_struct_type(s, off, type);
+    else if (fd->bit_width > 0)
+        error_here("bitfield chained initializer designator unsupported");
+    else
+        emit_init_auto_struct_scalar(s, off, type);
+    return 1;
+}
+
 void emit_init_auto_struct_scalar(struct Sym *s, int off, int type)
 {
     long v;
@@ -673,7 +757,11 @@ void emit_init_auto_struct_type(struct Sym *s, int baseoff, int type)
             }
             i = (int)(fd - field_defs);
             next_token();
-            expect('=');
+            if (tok.kind == '=') {
+                next_token();
+            } else if (tok.kind != '[' && tok.kind != '.') {
+                expect('=');
+            }
         } else {
             fd = &field_defs[i];
             if (fd->parent_struct_id != sid || fd->is_promoted)
@@ -682,6 +770,19 @@ void emit_init_auto_struct_type(struct Sym *s, int baseoff, int type)
 
         if (fd->offset > used)
             emit_zero_local_bytes(s, baseoff + used, fd->offset - used);
+
+        if (tok.kind == '[' || tok.kind == '.') {
+            if (used <= fd->offset)
+                emit_zero_local_bytes(s, baseoff + fd->offset, fd->size);
+            if (emit_init_auto_struct_chained_designator(s, baseoff, fd)) {
+                end_used = fd->offset + fd->size;
+                if (end_used > used) used = end_used;
+                if (!accept(',')) break;
+                if (tok.kind == '}') break;
+                if (tok.kind == '.') i = -1;
+                continue;
+            }
+        }
 
         if (fd->bit_width > 0) {
             int unit_off;
@@ -1181,8 +1282,7 @@ void gen_local_decl_after_type(int base)
             }
         } else if (accept('=')) {
             if ((type & TYPE_STRUCT) && type_ptr_depth(type) == 0 && tok.kind != '{') {
-                error_here("struct initializer list expected");
-                skip_initializer_or_decl_tail();
+                ast_emit_struct_init_expr_assign(s);
             } else if (s->is_array && (type & 15) == TYPE_CHAR && type_ptr_depth(type) == 0 && tok.kind == TOK_STR) {
                 char *lit;
                 int is_wide;

--- a/src/dcc/dcc_expr.c
+++ b/src/dcc/dcc_expr.c
@@ -1108,6 +1108,10 @@ void gen_post_update_symbol_addr_value(struct Sym *s, int op)
 
 void gen_post_update_from_addr(int type, int op)
 {
+    int bf_width;
+    int bf_shift;
+    unsigned int bf_mask;
+
     if (type_is_long(type)) {
         if (expr_result_dead) {
             /* Statement context: just increment in place, no old value needed */
@@ -1145,6 +1149,37 @@ void gen_post_update_from_addr(int type, int op)
         emit("\tpop hl\n");              /* HL = low16_old  (return value low) */
         emit("\tpop de\n");              /* DE = high16_old (return value high) */
         g_expr_type = type;
+        return;
+    }
+
+    bf_width = current_field_bit_width;
+    bf_shift = current_field_bit_shift;
+    bf_mask = current_field_bit_mask;
+
+    if (bf_width > 0) {
+        emit("\tld b,h\n\tld c,l\n");
+        emit_load_from_hl(type);
+        current_field_bit_width = bf_width;
+        current_field_bit_shift = bf_shift;
+        current_field_bit_mask = bf_mask;
+        g_expr_type = type;
+        emit_extract_bitfield();
+        if (!expr_result_dead)
+            emit("\tpush hl\n");
+        if (op == TOK_INC)
+            emit("\tinc hl\n");
+        else
+            emit("\tdec hl\n");
+        emit("\tex de,hl\n");
+        emit("\tld h,b\n\tld l,c\n");
+        current_field_bit_width = bf_width;
+        current_field_bit_shift = bf_shift;
+        current_field_bit_mask = bf_mask;
+        emit_store_bitfield_de_to_addr_hl(0);
+        if (!expr_result_dead)
+            emit("\tpop hl\n");
+        g_expr_type = type;
+        g_long_from16 = 0;
         return;
     }
 
@@ -1371,6 +1406,51 @@ void emit_store_bitfield_from_hl(void)
     emit_store_de_to_addr_hl(TYPE_INT);
 }
 
+void emit_store_bitfield_de_to_addr_hl(int keep_result)
+{
+    int i;
+    unsigned int clear_mask;
+    unsigned int mask;
+
+    mask = current_field_bit_mask & 0xffffU;
+    clear_mask = (~mask) & 0xffffU;
+
+    /* keep_result: save the FIELD ADDRESS (not the raw value) so the live
+     * result can be read back from the stored field.  Returning the raw
+     * pre-store value would skip the field's width truncation / sign
+     * extension, e.g. `x = (s.bf3 += 5)` must yield the stored 3-bit value,
+     * not the untruncated sum.  g_expr_type must hold the field type at entry
+     * so emit_extract_bitfield sign- vs zero-extends correctly. */
+    if (keep_result)
+        emit("\tpush hl\n");
+    emit("\tpush hl\n");
+    emit("\tpush de\n");
+    emit_load_from_hl(TYPE_INT);
+
+    fprintf(outf, "\tld de,%u\n", clear_mask);
+    emit("\tld a,l\n\tand e\n\tld l,a\n");
+    emit("\tld a,h\n\tand d\n\tld h,a\n");
+
+    emit("\tpop de\n");
+    for (i = 0; i < current_field_bit_shift; ++i)
+        emit("\tsla e\n\trl d\n");
+
+    fprintf(outf, "\tld bc,%u\n", mask);
+    emit("\tld a,e\n\tand c\n\tld e,a\n");
+    emit("\tld a,d\n\tand b\n\tld d,a\n");
+    emit("\tld a,l\n\tor e\n\tld l,a\n");
+    emit("\tld a,h\n\tor d\n\tld h,a\n");
+
+    emit("\tex de,hl\n");
+    emit("\tpop hl\n");
+    emit_store_de_to_addr_hl(TYPE_INT);
+    if (keep_result) {
+        emit("\tpop hl\n");           /* HL = field address */
+        emit_load_from_hl(TYPE_INT);  /* HL = stored storage unit */
+        emit_extract_bitfield();      /* mask/shift/sign-extend to field value */
+    }
+}
+
 void emit_load_float_bits(unsigned long bits);
 void emit_load_const_sym_value(struct Sym *s);
 void emit_float_compare_call(int op);
@@ -1473,12 +1553,36 @@ void emit_pre_incdec_lvalue(int type, int op)
         emit("\tld a,e\n\tld (bc),a\n\tinc bc\n");
         emit("\tld a,d\n\tld (bc),a\n");
     } else {
-        emit("\tpush hl\n");
+        int bf_width = current_field_bit_width;
+        int bf_shift = current_field_bit_shift;
+        unsigned int bf_mask = current_field_bit_mask;
+
+        if (bf_width > 0)
+            emit("\tld b,h\n\tld c,l\n");
+        else
+            emit("\tpush hl\n");
         emit_load_from_hl(type);
+        if (bf_width > 0) {
+            current_field_bit_width = bf_width;
+            current_field_bit_shift = bf_shift;
+            current_field_bit_mask = bf_mask;
+            g_expr_type = type;
+            emit_extract_bitfield();
+        }
         emit_incdec_value_in_dehl(type, op);
-        emit("\tex de,hl\n\tpop hl\n");
-        emit_store_de_to_addr_hl(type);
         emit("\tex de,hl\n");
+        if (bf_width > 0) {
+            emit("\tld h,b\n\tld l,c\n");
+            current_field_bit_width = bf_width;
+            current_field_bit_shift = bf_shift;
+            current_field_bit_mask = bf_mask;
+            g_expr_type = type;   /* field type -> correct extract signedness */
+            emit_store_bitfield_de_to_addr_hl(1);
+        } else {
+            emit("\tpop hl\n");
+            emit_store_de_to_addr_hl(type);
+            emit("\tex de,hl\n");
+        }
     }
     g_expr_type = type;
 }

--- a/tests/baselines/tbitfld.txt
+++ b/tests/baselines/tbitfld.txt
@@ -2,6 +2,9 @@ global 5 17 200 1234 1456
 local 3 7 99 456 565
 return 6 31 255 1000 1292
 assign 2 4 8 16 30
+rmw 5 2 15 4 4
+rmw-live 0 0 19 19
+rmw-live-signed -8 -7 -7
 signed-global -3 12 77 86
 signed-local -2 5 20 23
 signed-return -4 15 30 41

--- a/tests/baselines/tstructv.txt
+++ b/tests/baselines/tstructv.txt
@@ -1,5 +1,6 @@
 assign/arg 3 1000 7 1010
 return 4 2000 8 2012
+init-return 8 600 14 622
 array/multi 5 3000 9 5026
 nested 5 3000 9 11 12 3037
 return-as-arg 4136

--- a/tests/tbitfld.c
+++ b/tests/tbitfld.c
@@ -51,6 +51,8 @@ int main(void)
     struct Bits m;
     struct SignedBits ls = { -2, 5, 20 };
     struct SignedBits ms;
+    int post;
+    int pre;
 
     printf("global %u %u %u %d %d\n", g.a, g.b, g.c, g.d, sum_bits(g));
     printf("local %u %u %u %d %d\n", l.a, l.b, l.c, l.d, sum_bits(l));
@@ -60,6 +62,27 @@ int main(void)
 
     m.a = 2; m.b = 4; m.c = 8; m.d = 16;
     printf("assign %u %u %u %d %d\n", m.a, m.b, m.c, m.d, sum_bits(m));
+
+    m.a = 1; m.b = 3; m.c = 4; m.d = 0;
+    m.a += 3;
+    m.c <<= 2;
+    post = m.a++;
+    pre = ++m.b;
+    --m.c;
+    m.b -= 2;
+    printf("rmw %u %u %u %d %d\n", m.a, m.b, m.c, post, pre);
+
+    /* Live-result read-modify-write that overflows the field width: the
+     * returned value must be the stored (truncated / sign-extended) field
+     * value, not the raw arithmetic result. */
+    m.a = 7; m.b = 7; m.c = 200; m.d = 0;
+    pre = ++m.a;                 /* a(3) -> 0, pre -> 0 */
+    post = (m.b += 300);         /* b(5) wraps, post == stored b */
+    printf("rmw-live %u %d %d %d\n", m.a, pre, m.b, post);
+    ms.a = 5; ms.b = 0; ms.c = 0;
+    pre = (ms.a += 4);           /* a(4 signed) -> 9 -> -7 */
+    post = ms.a--;               /* post -> -7, a -> -8 */
+    printf("rmw-live-signed %d %d %d\n", ms.a, pre, post);
 
     printf("signed-global %d %u %d %d\n", gs.a, gs.b, gs.c, sum_signed(gs));
     printf("signed-local %d %u %d %d\n", ls.a, ls.b, ls.c, sum_signed(ls));

--- a/tests/tc99init.c
+++ b/tests/tc99init.c
@@ -6,6 +6,16 @@ struct Pair {
     int b;
 };
 
+struct Rect {
+    int w;
+    int h;
+};
+
+struct Grid {
+    int n;
+    struct Rect cells[3];
+};
+
 struct Holder {
     struct Pair pair;
     struct Pair *ptr;
@@ -52,6 +62,11 @@ static void check_local_designators(void)
     struct Pair local_pair = { .b = 22, .a = 21 };
     struct Pair local_pairs[2] = { [1] = { .b = 42, .a = 41 }, [0] = { 39, 40 } };
     int local_values[4] = { [2] = 32, [0] = 30, 31, [3] = 33 };
+    struct Grid local_grid = {
+        .n = 3,
+        .cells[1] = { 2, 9 },
+        .cells[0].w = 1
+    };
     static const struct Pair static_pairs[] = {
         { .b = 52, .a = 51 },
         { .b = 54, .a = 53 }
@@ -67,6 +82,12 @@ static void check_local_designators(void)
     check_int(local_values[1], 31, "local_values[1]");
     check_int(local_values[2], 32, "local_values[2]");
     check_int(local_values[3], 33, "local_values[3]");
+    check_int(local_grid.n, 3, "local_grid.n");
+    check_int(local_grid.cells[0].w, 1, "local_grid.cells[0].w");
+    check_int(local_grid.cells[0].h, 0, "local_grid.cells[0].h");
+    check_int(local_grid.cells[1].w, 2, "local_grid.cells[1].w");
+    check_int(local_grid.cells[1].h, 9, "local_grid.cells[1].h");
+    check_int(local_grid.cells[2].w, 0, "local_grid.cells[2].w");
     check_int(static_pairs[0].a, 51, "static_pairs[0].a");
     check_int(static_pairs[0].b, 52, "static_pairs[0].b");
     check_int(static_pairs[1].a, 53, "static_pairs[1].a");

--- a/tests/tstructv.c
+++ b/tests/tstructv.c
@@ -146,6 +146,7 @@ int main(int argc, char **argv)
     struct Big bigarr[2];
     struct Big b;
     struct Big c;
+    struct Pair init_decl = proto_make_pair(8, 600, 14);
     int s;
 
     x.a = 3;
@@ -159,6 +160,8 @@ int main(int argc, char **argv)
     y = proto_make_pair(4, 2000, 8);
     s = proto_sum_pair(y);
     printf("return %d %d %d %d\n", y.a, y.b, y.c, s);
+
+    printf("init-return %d %d %d %d\n", init_decl.a, init_decl.b, init_decl.c, proto_sum_pair(init_decl));
 
     arr[0] = proto_make_pair(5, 3000, 9);
     arr[1] = y;


### PR DESCRIPTION
@davidly 

Allow bit-field read-modify-write expressions through the AST supported-codegen paths, including compound assignment and prefix/postfix increment/decrement. Store bit-field RMW results through the masked storage unit and reload/extract live expression values so overflowed unsigned fields and signed bit-fields return the stored, sign-correct value.

Support struct-returning calls as local struct declaration initializers by reusing the existing struct-return assignment codegen path.

Support chained local auto struct designators such as `.cells[1]` and `.cells[0].w` by resolving nested field/array offsets before emitting the initializer.

Add regression coverage for bit-field RMW live results, struct-return initializers, and chained designated initializers.