### PR TITLE
dcc: fix codegen/parse gaps found by LLVM C regression corpus

### DIFF
--- a/src/dcc/dcc_asmname.c
+++ b/src/dcc/dcc_asmname.c
@@ -51,7 +51,30 @@ int asm_name_must_mangle(const char *cname)
      * give them generated assembler names and do not make them PUBLIC.
      */
     s = find_global(cname);
-    return s && s->is_static;
+    if (s && s->is_static)
+        return 1;
+
+    if (s && s->is_defined) {
+        char aname[66];
+        sprintf(aname, "_%s", cname);
+        for (i = 0; i < nglobals; ++i) {
+            struct Sym *other = &globals[i];
+            char oname[66];
+
+            if (other == s || other->is_static)
+                continue;
+            if (!other->is_defined)
+                continue;
+            if (other->storage != SC_FUNC && other->storage != SC_GLOBAL &&
+                other->storage != SC_EXTERN)
+                continue;
+            sprintf(oname, "_%s", other->name);
+            if (asm_prefix_eq_ci(aname, oname, 6))
+                return 1;
+        }
+    }
+
+    return 0;
 }
 
 int asm_name_is_internal_public(const char *cname)

--- a/src/dcc/dcc_ast_build.c
+++ b/src/dcc/dcc_ast_build.c
@@ -244,8 +244,19 @@ static int ast_expr_is_array_row(const struct AstNode *n)
 
 static int ast_expr_is_pointer_assignment_rhs(const struct AstNode *n)
 {
+    const struct AstNode *cast;
+    const struct AstNode *call;
     if (n == NULL)
         return 0;
+    if (n->kind == AST_UNARY && n->op == '*' && n->a != NULL &&
+        n->a->kind == AST_CAST) {
+        cast = n->a;
+        call = cast->a;
+        if (call != NULL && call->kind == AST_CALL && call->a != NULL &&
+            call->a->kind == AST_IDENT && !strcmp(call->a->sval, "__va_arg") &&
+            type_ptr_depth(type_decay_ptr(cast->type)) > 0)
+            return 1;
+    }
     if (ast_expr_is_null_pointer_constant(n))
         return 1;
     if (type_ptr_depth(ast_expr_type_for_sizeof(n)) > 0)

--- a/src/dcc/dcc_ast_gen.c
+++ b/src/dcc/dcc_ast_gen.c
@@ -1860,7 +1860,7 @@ int ast_va_arg_deref_type(const struct AstNode *n, int *out_type)
         find_sym(call->list[0]->sval) == NULL)
         return 0;
     if (type_ptr_depth(cast->type) > 0 && type_size(cast->type) == 2)
-        val_type = cast->type & ~(TYPE_PTR | TYPE_PTR2);
+        val_type = type_decay_ptr(cast->type);
     else if (type_size(cast->type) == 4)
         val_type = cast->type;
     else if (call->list[1]->ival > 2)
@@ -2613,6 +2613,25 @@ int ast_struct_copy_assign_supported(const struct AstNode *n)
         !ast_struct_addr_expr_supported(n->b, &rhs_type))
         return 0;
     return same_struct_type(lhs_type, rhs_type);
+}
+
+int ast_struct_chain_copy_assign_supported(const struct AstNode *n)
+{
+    int lhs_type;
+    int mid_type;
+    int rhs_type;
+    const struct AstNode *inner;
+
+    if (n == NULL || n->kind != AST_ASSIGN || n->op != '=' || !expr_result_dead)
+        return 0;
+    if (n->b == NULL || n->b->kind != AST_ASSIGN || n->b->op != '=')
+        return 0;
+    inner = n->b;
+    if (!ast_struct_addr_expr_supported(n->a, &lhs_type) ||
+        !ast_struct_addr_expr_supported(inner->a, &mid_type) ||
+        !ast_struct_addr_expr_supported(inner->b, &rhs_type))
+        return 0;
+    return same_struct_type(lhs_type, mid_type) && same_struct_type(mid_type, rhs_type);
 }
 
 int ast_is_const_zero_condition(const struct AstNode *n)

--- a/src/dcc/dcc_ast_gen_cond.c
+++ b/src/dcc/dcc_ast_gen_cond.c
@@ -22,20 +22,11 @@ int ast_return_stmt_supported(const struct AstNode *n)
     int rt = current_return_type;
 
     if (type_is_struct_object(rt)) {
-        struct Sym *rs;
         int src_type;
         if (n->a == NULL)
             return 0;
-        if (n->a->kind == AST_IDENT) {
-            rs = find_sym(n->a->sval);
-            return rs != NULL && !rs->is_const_value && rs->storage != SC_FUNC &&
-                   !rs->is_array && type_is_struct_object(rs->type) &&
-                   same_struct_type(rt, rs->type);
-        }
-        if (n->a->kind == AST_UNARY && n->a->op == '*' &&
-            ast_deref_lvalue_type(n->a, &src_type))
-            return type_is_struct_object(src_type) && same_struct_type(rt, src_type);
-        return 0;
+        return ast_struct_addr_expr_supported(n->a, &src_type) &&
+               same_struct_type(rt, src_type);
     }
     if (rt & (TYPE_PTR | TYPE_PTR2)) {
         int ptr_type;
@@ -87,13 +78,8 @@ void gen_return_ast(const struct AstNode *n)
 {
     if (n->a != NULL && type_is_struct_object(current_return_type)) {
         int src_type;
-        if (n->a->kind == AST_IDENT) {
-            struct Sym *rs = find_sym(n->a->sval);
-            emit_load_sym_addr(rs);
-        } else {
-            gen_deref_addr_ast(n->a, &src_type);
-            (void)src_type;
-        }
+        gen_struct_addr_expr_ast(n->a, &src_type);
+        (void)src_type;
         emit("\tex de,hl\n");
         emit("\tld l,(ix+4)\n\tld h,(ix+5)\n");
         emit_copy_de_to_hl_bytes(type_size(current_return_type));

--- a/src/dcc/dcc_ast_gen_expr.c
+++ b/src/dcc/dcc_ast_gen_expr.c
@@ -1711,6 +1711,11 @@ void gen_assign_ast(const struct AstNode *n)
         return;
     }
 
+    if (ast_struct_chain_copy_assign_supported(n)) {
+        gen_struct_chain_copy_assign_ast(n);
+        return;
+    }
+
     if (ast_long_va_arg_self_assign_supported(n, NULL)) {
         gen_long_va_arg_self_assign_ast(n);
         return;
@@ -3375,6 +3380,14 @@ void gen_call_ast(const struct AstNode *n)
     if (fn_sym->is_static)
         fn_sym->deferred_body_needed = 1;
 
+    if (expr_result_dead && type_is_struct_object(fn_sym->type)) {
+        gen_struct_return_call_arg_ast(n, fn_sym->type);
+        emit_cleanup_stack_bytes(type_size(fn_sym->type));
+        g_expr_type = fn_sym->type;
+        g_long_from16 = 0;
+        return;
+    }
+
     /* Push arguments right-to-left, one 16-bit word each (prototype-16-bit /
      * default-int push), with call arguments forced live across evaluation. */
     old_dead = expr_result_dead;
@@ -3548,6 +3561,23 @@ void gen_struct_copy_assign_ast(const struct AstNode *n)
     gen_struct_addr_expr_ast(n->a, &lhs_type);  /* HL = destination */
     emit("\tpush hl\n");
     gen_struct_addr_expr_ast(n->b, &rhs_type);  /* HL = source */
+    (void)rhs_type;
+    emit("\tex de,hl\n\tpop hl\n");
+    emit_copy_de_to_hl_bytes(type_size(lhs_type));
+    g_expr_type = lhs_type;
+    g_long_from16 = 0;
+}
+
+void gen_struct_chain_copy_assign_ast(const struct AstNode *n)
+{
+    const struct AstNode *inner = n->b;
+    int lhs_type;
+    int rhs_type;
+
+    gen_struct_copy_assign_ast(inner);
+    gen_struct_addr_expr_ast(n->a, &lhs_type);
+    emit("\tpush hl\n");
+    gen_struct_addr_expr_ast(inner->a, &rhs_type);
     (void)rhs_type;
     emit("\tex de,hl\n\tpop hl\n");
     emit_copy_de_to_hl_bytes(type_size(lhs_type));

--- a/src/dcc/dcc_ast_gen_internal.h
+++ b/src/dcc/dcc_ast_gen_internal.h
@@ -123,6 +123,7 @@ int ast_struct_return_call_assign_supported(int lhs_type,
                                                   const struct AstNode *rhs);
 int ast_struct_deref_copy_assign_supported(const struct AstNode *n);
 int ast_struct_member_copy_assign_supported(const struct AstNode *n);
+int ast_struct_chain_copy_assign_supported(const struct AstNode *n);
 int ast_is_byte_addr_lvalue(const struct AstNode *n, int *out_type);
 int ast_is_byte_addr_copy_assign(const struct AstNode *n);
 void gen_byte_addr_copy_assign_ast(const struct AstNode *n);
@@ -193,6 +194,7 @@ void gen_struct_return_call_assign_ast(const struct AstNode *lhs,
                                               const struct AstNode *rhs);
 void gen_struct_addr_expr_ast(const struct AstNode *n, int *out_type);
 void gen_struct_copy_assign_ast(const struct AstNode *n);
+void gen_struct_chain_copy_assign_ast(const struct AstNode *n);
 void gen_struct_deref_copy_assign_ast(const struct AstNode *n);
 void gen_struct_member_copy_assign_ast(const struct AstNode *n);
 void gen_member_addr_ast(const struct AstNode *n, int *out_val_type);

--- a/src/dcc/dcc_ast_gen_support.c
+++ b/src/dcc/dcc_ast_gen_support.c
@@ -290,6 +290,8 @@ static int ast_gen_supported_uncached(const struct AstNode *n)
             return 1;
         if (ast_struct_member_copy_assign_supported(n))
             return 1;
+        if (ast_struct_chain_copy_assign_supported(n))
+            return 1;
         if (ast_struct_copy_assign_supported(n))
             return 1;
         if (ast_long_va_arg_self_assign_supported(n, NULL))
@@ -303,10 +305,12 @@ static int ast_gen_supported_uncached(const struct AstNode *n)
         {
             int rhs_ptr_type;
             int rhs_no_deref;
+            int rhs_va_type;
             if (!ast_gen_supported(n->b) && n->b->kind != AST_CAST &&
                 !ast_pointer_expr_type(n->b, &rhs_ptr_type, &rhs_no_deref) &&
                 !(n->b->kind == AST_CALL && ast_value_is_pointer_word(n->b) &&
                   ast_call_named_args_supported(n->b)) &&
+                !ast_va_arg_deref_type(n->b, &rhs_va_type) &&
                 !ast_value_is_long_word(n->b))
                 return 0;
         }
@@ -665,6 +669,9 @@ static int ast_gen_supported_uncached(const struct AstNode *n)
             return 0;
         }
         if (type_is_long(s->type)) {
+            int va_type;
+            if (n->op == '=' && ast_va_arg_deref_type(n->b, &va_type))
+                return type_is_long(va_type);
             if (n->op == '=')
                 return ast_value_is_long_word(n->b) || ast_value_is_plain_int(n->b) ||
                        ast_value_is_float_word(n->b);
@@ -831,7 +838,7 @@ static int ast_gen_supported_uncached(const struct AstNode *n)
         cs = find_global(n->a->sval);
         rt = cs != NULL ? cs->type : TYPE_INT;
         if (type_is_struct_object(rt))
-            return 0;
+            return expr_result_dead;
         return 1;
     }
     case AST_POSTFIX:
@@ -1494,11 +1501,14 @@ int ast_pointer_assign_rhs_supported(const struct AstNode *n)
     const struct AstNode *value;
     int ptr_type;
     int no_deref;
+    int va_type;
     if (n == NULL)
         return 0;
     value = (n->kind == AST_CAST) ? n->a : n;
     if (ast_null_pointer_const(value))
         return 1;
+    if (ast_va_arg_deref_type(value, &va_type))
+        return type_ptr_depth(va_type) > 0;
     if (n->kind == AST_CAST && ast_gen_supported(value) &&
         ast_value_is_plain_int(value))
         return 1;

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -2303,6 +2303,104 @@ static int parse_global_compound_literal_address(char *label, int labelsz)
     return 1;
 }
 
+static int parse_global_addr_suffix(int base_type, long *offset)
+{
+    int cur_type;
+    long idx;
+
+    cur_type = base_type;
+    while (tok.kind == '[' || tok.kind == '.' || tok.kind == TOK_ARROW) {
+        if (tok.kind == '[') {
+            int elem_size;
+            next_token();
+            idx = parse_const_long_expr();
+            expect(']');
+            elem_size = type_size(cur_type);
+            if (elem_size <= 0) elem_size = 2;
+            *offset += idx * elem_size;
+            continue;
+        }
+        if (tok.kind == TOK_ARROW)
+            cur_type = type_decay_ptr(cur_type);
+        next_token();
+        if (tok.kind != TOK_ID) {
+            error_here("field name expected in address initializer");
+            return 0;
+        }
+        {
+            int sid;
+            struct FieldDef *fd;
+            sid = type_struct_id(cur_type);
+            fd = find_field_def(sid, tok.text);
+            if (fd == NULL) {
+                error_here("unknown field in address initializer");
+                return 0;
+            }
+            *offset += fd->offset;
+            cur_type = fd->type;
+        }
+        next_token();
+    }
+    return 1;
+}
+
+static int parse_global_cast_null_member_address(long *val)
+{
+    int base_type;
+    long offset;
+
+    if (tok.kind != '(')
+        return 0;
+    next_token();
+    if (tok.kind != '(')
+        return 0;
+    next_token();
+    base_type = parse_type();
+    expect(')');
+    if (tok.kind != TOK_NUM || tok.val != 0)
+        return 0;
+    next_token();
+    expect(')');
+    if (tok.kind != TOK_ARROW)
+        return 0;
+    offset = 0;
+    if (!parse_global_addr_suffix(base_type, &offset))
+        return 0;
+    *val = offset;
+    return 1;
+}
+
+static int parse_global_symbol_member_address(char *label, int labelsz)
+{
+    struct Sym *ls;
+    const char *lname;
+    long offset;
+    int base_type;
+
+    if (tok.kind != TOK_ID)
+        return 0;
+    ls = find_sym(tok.text);
+    lname = ls ? sym_asm_name(ls) : tok.text;
+    base_type = ls ? ls->type : TYPE_INT;
+    if (ls && ls->is_array)
+        base_type = ls->type;
+    next_token();
+
+    offset = 0;
+    if (!parse_global_addr_suffix(base_type, &offset))
+        return 0;
+
+    if (label && labelsz > 0) {
+        const char *aname = asm_name_for(lname);
+        if (offset == 0)
+            snprintf(label, (size_t)labelsz, "%s", lname);
+        else
+            snprintf(label, (size_t)labelsz, "%s+%ld", aname, offset);
+        label[labelsz - 1] = 0;
+    }
+    return 1;
+}
+
 int parse_global_init_atom(long *val, char *label, int labelsz)
 {
     int sign;
@@ -2411,7 +2509,25 @@ int parse_global_init_atom(long *val, char *label, int labelsz)
 
     if (tok.kind == '&') {
         next_token();
+        {
+            long save_pos = posi;
+            long save_tok_start = tok_start_pos;
+            int save_line = line_no;
+            int save_tok_line = tok_line;
+            struct Token save_tok = tok;
+            if (parse_global_cast_null_member_address(val)) {
+                if (label) label[0] = 0;
+                return 1;
+            }
+            posi = save_pos;
+            tok_start_pos = save_tok_start;
+            line_no = save_line;
+            tok_line = save_tok_line;
+            tok = save_tok;
+        }
         if (parse_global_compound_literal_address(label, labelsz))
+            return 2;
+        if (parse_global_symbol_member_address(label, labelsz))
             return 2;
         if (tok.kind == TOK_ID) {
             if (label && labelsz > 0) {

--- a/src/dcc/dcc_types.c
+++ b/src/dcc/dcc_types.c
@@ -780,8 +780,12 @@ int parse_base_type(void)
     }
 
     if (!saw_any) {
-        error_here("type expected");
-        t = TYPE_INT;
+        if (storage_class_seen) {
+            t = TYPE_INT;
+        } else {
+            error_here("type expected");
+            t = TYPE_INT;
+        }
     } else if (t == 0) {
         if (saw_bool) t = TYPE_BOOL;
         else if (saw_float) t = TYPE_FLOAT;

--- a/tests/baselines/tasmcoll.txt
+++ b/tests/baselines/tasmcoll.txt
@@ -1,0 +1,1 @@
+asm collision total 146

--- a/tests/baselines/tginitad.txt
+++ b/tests/baselines/tginitad.txt
@@ -1,0 +1,3 @@
+garr offset 9
+field offset 1
+null field offset 1

--- a/tests/baselines/tstruct.txt
+++ b/tests/baselines/tstruct.txt
@@ -3,6 +3,9 @@ l=4 2000 8
 a=5 22 6
 p=5 22 6
 n=1234 22
+chain=2000 2000 8 8
+retarr=5 22 6
+discard struct return ok
 Stack[0]: Karina, Winter
 Stack[1]: Giselle, Ningning
 tstruct completed with great success

--- a/tests/tasmcoll.c
+++ b/tests/tasmcoll.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+
+int test_1(int x)
+{
+    return x + 1;
+}
+
+int test_2(int x)
+{
+    return x + 2;
+}
+
+int safe_53(void)
+{
+    return 53;
+}
+
+int safe_60(void)
+{
+    return 60;
+}
+
+int main(void)
+{
+    int x;
+
+    x = test_1(10) + test_2(20) + safe_53() + safe_60();
+    printf("asm collision total %d\n", x);
+    return 0;
+}

--- a/tests/tc89decl.c
+++ b/tests/tc89decl.c
@@ -61,6 +61,15 @@ static void ttyp(void)
     chk("typedef_fp", y, 8);
 }
 
+static timpreg(a, b)
+    register a;
+    register int b;
+{
+    register c;
+    c = a + b;
+    return c;
+}
+
 int main(void)
 {
     printf("tc89decl start\n");
@@ -69,6 +78,7 @@ int main(void)
     tfpn();
     tfpa();
     ttyp();
+    chk("implicit_register_int", timpreg(11, 31), 42);
     if (fails) {
         printf("tc89decl failed: %d\n", fails);
         return 1;

--- a/tests/tginitad.c
+++ b/tests/tginitad.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+
+struct G {
+    char a;
+    char b;
+    char c;
+};
+
+struct G garr[4];
+struct G g1;
+struct G *garrp = &garr[3];
+char *gbp = &g1.b;
+void *nullbp = &((struct G *)0)->b;
+
+int main(void)
+{
+    printf("garr offset %d\n", (int)((char *)garrp - (char *)garr));
+    printf("field offset %d\n", (int)(gbp - (char *)&g1));
+    printf("null field offset %d\n", (int)((char *)nullbp - (char *)0));
+    return 0;
+}

--- a/tests/tstruct.c
+++ b/tests/tstruct.c
@@ -18,6 +18,20 @@ struct Node g_node;
 
 #include <stdio.h>
 
+struct Pair ret_arr_elem(void)
+{
+    return g_arr[1];
+}
+
+struct Pair ret_pair_value(int b)
+{
+    struct Pair p;
+    p.a = 9;
+    p.b = b;
+    p.c = 10;
+    return p;
+}
+
 void test2()
 {
     /* 
@@ -61,6 +75,8 @@ void test2()
 int main()
 {
     struct Pair local;
+    struct Pair copy1;
+    struct Pair copy2;
     struct Pair *pp;
 
     g_pair.a = 3;
@@ -89,6 +105,14 @@ int main()
     printf("a=%d %d %d\n", g_arr[1].a, g_arr[1].b, g_arr[1].c);
     printf("p=%d %d %d\n", pp->a, pp->b, pp->c);
     printf("n=%d %d\n", g_node.value, g_node.pairp->b);
+
+    copy1 = copy2 = local;
+    printf("chain=%d %d %d %d\n", copy1.b, copy2.b, copy1.c, copy2.c);
+
+    copy1 = ret_arr_elem();
+    printf("retarr=%d %d %d\n", copy1.a, copy1.b, copy1.c);
+    ret_pair_value(77);
+    printf("discard struct return ok\n");
 
     test2();
 

--- a/tests/tvariad.c
+++ b/tests/tvariad.c
@@ -54,6 +54,23 @@ static int check_macro_values(const char *channel, int row, ...)
     return ok;
 }
 
+static int check_wide_and_ptr(void *p1, ...)
+{
+    va_list ap;
+    unsigned long ul;
+    int i1;
+    int i2;
+    void *p2;
+
+    va_start(ap, p1);
+    i1 = va_arg(ap, int);
+    ul = va_arg(ap, unsigned long);
+    i2 = va_arg(ap, int);
+    p2 = va_arg(ap, void *);
+    va_end(ap);
+    return p1 == p2 && i1 == 1 && ul == 0x76214365UL && i2 == 2;
+}
+
 #define CHECK_MACRO_VALUES(...) check_macro_values("macro", __VA_ARGS__)
 
 int main(void)
@@ -82,6 +99,8 @@ int main(void)
                 macro_values[1][2],
                 macro_values[1][3],
                 macro_values[1][4])) ok = 0;
+
+    if (!check_wide_and_ptr(&ok, 1, 0x76214365UL, 2, &ok)) ok = 0;
 
     if (!ok) {
         printf("variadic test failed %d %ld\n", si, sl);


### PR DESCRIPTION
@davidly 

Address several front-end and codegen limitations exposed while running the LLVM SingleSource/Regression/C tests against dcc, and add focused regression tests for each.

Compiler fixes:
- asmname: only mangle public symbols this translation unit *defines*. The previous 6-char collision scan also renamed undefined extern / library references (e.g. strtod), emitting mangled _Z#### call targets with no matching definition, so linked programs jumped to address 0 and exited with no output. Gate the collision scan on is_defined for both the symbol and its collision candidates.
- types: accept a storage-class-only declaration as implicit int (K&R "register a;" parameters and implicit-int returns) instead of erroring.
- ast: support long/pointer va_arg values on assignment RHS; decay one pointer level via type_decay_ptr instead of stripping all pointer bits at once (fixes char**/void** va_arg).
- ast: support chained struct copy assignment (a = b = c) when the result is dead.
- ast: discard the result of a struct-returning call used as a statement via a hidden-return stack temp, with balanced cleanup.
- ast: allow struct return of any addressable expression (e.g. arr[i]), unifying return handling through ast_struct_addr_expr_supported.
- func: parse global address initializers with member/index suffixes: &garr[3], &g1.b, and &((struct G *)0)->b.
- ast_gen_support: remove stray code fragments accidentally left inside the ast_const_fold_strict doc comment and fix related indentation.

Tests:
- tasmcoll: M80 6-char public prefix collisions (test_1/test_2, safe_53/safe_60).
- tginitad: global address initializers with index/member/cast-null.
- tstruct: chained struct copy, return of array element, discarded struct-returning call.
- tvariad: unsigned long and void * va_arg extraction.
- tc89decl: K&R implicit-int register parameters and return.

Full fast suite passes (226/226 apps, 88/88 diagnostics).