### PR TITLE
Support C99 compound literals in value contexts

### DIFF
--- a/src/dcc/dcc_ast_build.c
+++ b/src/dcc/dcc_ast_build.c
@@ -445,12 +445,8 @@ static struct AstNode *p_primary(struct AstArena *ar)
     }
 }
 
-static struct AstNode *p_postfix(struct AstArena *ar)
+static struct AstNode *p_postfix_tail(struct AstArena *ar, struct AstNode *n)
 {
-    struct AstNode *n = p_primary(ar);
-    if (n == NULL)
-        return NULL;
-
     for (;;) {
         if (tok.kind == '[') {
             struct AstNode *m = ast_new(ar, AST_INDEX);
@@ -519,6 +515,14 @@ static struct AstNode *p_postfix(struct AstArena *ar)
     return n;
 }
 
+static struct AstNode *p_postfix(struct AstArena *ar)
+{
+    struct AstNode *n = p_primary(ar);
+    if (n == NULL)
+        return NULL;
+    return p_postfix_tail(ar, n);
+}
+
 static struct AstNode *p_unary(struct AstArena *ar)
 {
     int k = tok.kind;
@@ -563,7 +567,7 @@ static struct AstNode *p_unary(struct AstArena *ar)
         parse_type_name_decl(&cty, &csz); /* parse ( type-name */
         expect(')');
         if (tok.kind == '{')
-            return ast_build_compound_literal(ar, cty);
+            return p_postfix_tail(ar, ast_build_compound_literal(ar, cty));
         operand = p_unary(ar);
         return ast_cast(ar, cty, operand);
     }

--- a/src/dcc/dcc_ast_gen.c
+++ b/src/dcc/dcc_ast_gen.c
@@ -225,6 +225,9 @@ int ast_value_is_plain_int(const struct AstNode *n)
         return ast_index_plain_int_read(n);
     case AST_MEMBER:
         return ast_member_plain_int_read(n) || ast_member_bitfield_read(n);
+    case AST_COMPOUND_LITERAL:
+        return ast_is_plain_int_type(n->type) && type_size(n->type) <= 2 &&
+               type_ptr_depth(n->type) == 0;
     case AST_CALL: {
         int rt;
         int callee_type;
@@ -1490,6 +1493,11 @@ int ast_member_base_type(const struct AstNode *n, int *out_type)
             return !no_deref;
         return ast_index_struct_object_type(n->a, out_type);
     }
+    if (n->op == '.' && n->a->kind == AST_COMPOUND_LITERAL &&
+        type_is_struct_object(n->a->type)) {
+        *out_type = n->a->type;
+        return 1;
+    }
     if (n->op == TOK_ARROW && ast_pointer_expr_type(n->a, out_type, &no_deref))
         return !no_deref;
     if (n->op == '.' && n->a->kind == AST_MEMBER &&
@@ -2596,6 +2604,15 @@ int ast_struct_addr_expr_supported(const struct AstNode *n, int *out_type)
             return 0;
         if (out_type)
             *out_type = t;
+        return 1;
+    case AST_COMPOUND_LITERAL:
+        /* A struct-typed compound literal materializes into its backing local
+         * and yields that object's address - exactly what the struct-value
+         * contexts (by-value argument, copy-assignment) consume. */
+        if (!type_is_struct_object(n->type))
+            return 0;
+        if (out_type)
+            *out_type = n->type;
         return 1;
     default:
         return 0;

--- a/src/dcc/dcc_ast_gen_expr.c
+++ b/src/dcc/dcc_ast_gen_expr.c
@@ -16,6 +16,7 @@ static void emit_long_byte_from_reg(int byte_index);
 static int emit_low_byte_expr_to_a(const struct AstNode *n);
 static int emit_long_byte_shift_to_reg(const struct AstNode *n);
 static int emit_long_oreq_byte_lane(struct Sym *s, const struct AstNode *rhs);
+static void gen_compound_literal_ast(const struct AstNode *n);
 
 
 /* Recognize byte-truncation idioms that are common in hand-written portable C:
@@ -569,7 +570,7 @@ void gen_unary_ast(const struct AstNode *n)
             return;
         }
         if (n->a->kind == AST_COMPOUND_LITERAL) {
-            ast_gen_expr(n->a);
+            gen_compound_literal_ast(n->a);
             return;
         }
         s = find_sym(n->a->sval);
@@ -739,6 +740,18 @@ static void gen_compound_literal_ast(const struct AstNode *n)
 
     emit_load_sym_addr(clit_sym);
     g_expr_type = type_add_ptr(clit_type);
+}
+
+static void gen_compound_literal_value_ast(const struct AstNode *n)
+{
+    int clit_type = n->type;
+
+    gen_compound_literal_ast(n);
+    if (!type_is_struct_object(clit_type)) {
+        emit_load_from_hl(clit_type);
+        g_expr_type = clit_type;
+        g_long_from16 = 0;
+    }
 }
 
 void gen_pointer_cmp_operand_ast(const struct AstNode *n)
@@ -1532,6 +1545,25 @@ void ast_emit_struct_init_expr_assign(struct Sym *s)
         gen_struct_return_call_assign_ast(lhs, rhs);
         ast_arena_reset(&g_ast_init_arena);
         return;
+    }
+
+    /* Struct initializer from any struct-address expression - most notably a
+     * compound literal `struct T t = (struct T){ ... };` - is a whole-struct
+     * copy from the source object into the new local. */
+    if (rhs != NULL) {
+        int rhs_type;
+        if (ast_struct_addr_expr_supported(rhs, &rhs_type) &&
+            same_struct_type(s->type, rhs_type)) {
+            emit_load_sym_addr(s);                    /* HL = destination */
+            emit("\tpush hl\n");
+            gen_struct_addr_expr_ast(rhs, &rhs_type); /* HL = source       */
+            emit("\tex de,hl\n\tpop hl\n");           /* DE = source, HL = dest */
+            emit_copy_de_to_hl_bytes(type_size(s->type));
+            g_expr_type = s->type;
+            g_long_from16 = 0;
+            ast_arena_reset(&g_ast_init_arena);
+            return;
+        }
     }
 
     if (getenv("DCC_AST_REPORT") != NULL) {
@@ -3548,6 +3580,13 @@ void gen_struct_addr_expr_ast(const struct AstNode *n, int *out_type)
     case AST_MEMBER:
         gen_member_addr_ast(n, out_type);
         return;
+    case AST_COMPOUND_LITERAL:
+        /* Materialize the literal into its backing local; gen_compound_literal_ast
+         * emits the initializer and leaves the object's address in HL. */
+        gen_compound_literal_ast(n);
+        if (out_type)
+            *out_type = n->type;
+        return;
     default:
         fatal("gen_struct_addr_expr_ast: unsupported node");
     }
@@ -3679,6 +3718,10 @@ void gen_member_addr_ast(const struct AstNode *n, int *out_val_type)
             cur_type = TYPE_CHAR;
     } else if (!arrow && n->a->kind == AST_MEMBER) {
         gen_member_addr_ast(n->a, &cur_type);
+    } else if (!arrow && n->a->kind == AST_COMPOUND_LITERAL &&
+               type_is_struct_object(n->a->type)) {
+        gen_compound_literal_ast(n->a);
+        cur_type = n->a->type;
     } else {
         s = find_sym(n->a->sval);
         cur_type = s->type;
@@ -4343,7 +4386,7 @@ void ast_gen_expr(const struct AstNode *n)
         gen_cast_ast(n);
         break;
     case AST_COMPOUND_LITERAL:
-        gen_compound_literal_ast(n);
+        gen_compound_literal_value_ast(n);
         break;
     case AST_COMMA:
         ast_gen_expr(n->a);

--- a/src/dcc/dcc_ast_gen_support.c
+++ b/src/dcc/dcc_ast_gen_support.c
@@ -1147,6 +1147,8 @@ int ast_value_is_long_word(const struct AstNode *arg)
     }
     if (!ast_gen_supported(arg))
         return 0;
+    if (arg->kind == AST_COMPOUND_LITERAL)
+        return type_is_long(arg->type);
     if (arg->kind == AST_IDENT) {
         s = find_sym(arg->sval);
          return s != NULL && s->storage != SC_FUNC && !s->is_array &&
@@ -1409,6 +1411,8 @@ int ast_value_is_float_word(const struct AstNode *arg)
         return 0;
     if (arg->kind == AST_FLOAT_LIT)
         return 1;
+    if (arg->kind == AST_COMPOUND_LITERAL)
+        return type_is_float(arg->type);
     if (arg->kind == AST_UNARY && (arg->op == '-' || arg->op == '+') &&
         arg->a != NULL)
         return ast_value_is_float_word(arg->a);

--- a/tests/tclit.c
+++ b/tests/tclit.c
@@ -12,12 +12,37 @@ struct Holder {
     struct Pair *ptr;
 };
 
+struct Mix {
+    struct Pair p;
+    long z;
+    float f;
+};
+
 static int failures;
 
 static void check_int(int got, int want, const char *name)
 {
     if (got != want) {
         printf("FAIL %s got=%d want=%d\n", name, got, want);
+        failures++;
+    }
+}
+
+static void check_long(long got, long want, const char *name)
+{
+    if (got != want) {
+        printf("FAIL %s\n", name);
+        failures++;
+    }
+}
+
+static void check_float(float got, float want, const char *name)
+{
+    float diff = got - want;
+    if (diff < 0.0)
+        diff = -diff;
+    if (diff > 0.001) {
+        printf("FAIL %s\n", name);
         failures++;
     }
 }
@@ -57,6 +82,107 @@ static void check_block_literals(void)
     check_int(holder->values[2], 7, "holder.values[2]");
     check_int(holder->ptr->a, 11, "holder.ptr.a");
     check_int(*ip, 1235, "scalar literal");
+}
+
+static int pair_sum(struct Pair p)
+{
+    return p.a + p.b;
+}
+
+static struct Pair echo_pair(struct Pair p)
+{
+    return p;
+}
+
+static long add_two_long(long v)
+{
+    return v + 2L;
+}
+
+static float add_quarter(float v)
+{
+    return v + 0.25;
+}
+
+static void check_value_literals(void)
+{
+    struct Pair init = (struct Pair){ 12, 34 };
+    struct Pair assigned;
+    struct Pair echoed;
+    int *ip;
+    long *lp;
+
+    assigned = (struct Pair){ .b = 78, .a = 56 };
+    echoed = echo_pair((struct Pair){ 90, 10 });
+    ip = &(int){ 44 };
+    lp = &(long){ 123456L };
+
+    check_int(pair_sum((struct Pair){ 6, 7 }), 13, "struct literal argument");
+    check_pair(&init, 12, 34, "struct literal initializer");
+    check_pair(&assigned, 56, 78, "struct literal assignment");
+    check_pair(&echoed, 90, 10, "struct literal echo");
+    check_int((struct Pair){ 22, 33 }.a, 22, "struct literal member a");
+    check_int((struct Holder){ { 1, 2 }, { 3, 4, 5 }, 0 }.pair.b,
+              2, "nested literal member");
+    check_int((int){ 5 } + 1, 6, "scalar int literal value");
+    check_long((long){ 70000L } + 3L, 70003L, "scalar long literal value");
+    check_float((float){ 1.5 } + 0.25, 1.75, "scalar float literal value");
+    check_long(add_two_long((long){ 8L }), 10L, "scalar long literal argument");
+    check_float(add_quarter((float){ 2.0 }), 2.25, "scalar float literal argument");
+    check_int(*ip, 44, "address-taken int literal still works");
+    check_long(*lp, 123456L, "address-taken long literal still works");
+}
+
+static int two_pairs(struct Pair a, struct Pair b)
+{
+    return a.a * a.b + b.a * b.b;
+}
+
+static int sum_pair_val(struct Pair p)
+{
+    return p.a + p.b;
+}
+
+static struct Pair pick_pair(void)
+{
+    return (struct Pair){ 8, 9 };
+}
+
+static void check_value_literals_extra(void)
+{
+    struct Pair returned;
+
+    /* Multiple struct compound-literal arguments in a single call. */
+    check_int(two_pairs((struct Pair){ 2, 3 }, (struct Pair){ 4, 5 }),
+              26, "two struct literal arguments");
+
+    /* long / float fields read directly from a struct literal. */
+    check_long((struct Mix){ { 1, 2 }, 90000L, 1.5 }.z,
+               90000L, "long field of struct literal");
+    check_float((struct Mix){ { 1, 2 }, 90000L, 2.5 }.f,
+                2.5, "float field of struct literal");
+
+    /* A struct-typed field of a literal passed by value. */
+    check_int(sum_pair_val((struct Mix){ { 3, 4 }, 0L, 0.0 }.p),
+              7, "struct field of literal by value");
+
+    /* A function that returns a compound literal directly. */
+    returned = pick_pair();
+    check_pair(&returned, 8, 9, "return compound literal");
+
+    /* Scalar _Bool compound literal normalizes a nonzero value to 1
+     * (initializer context). */
+    {
+        int flag = (_Bool){ 5 };
+        check_int(flag, 1, "scalar _Bool literal normalizes");
+    }
+
+    /* Pointer-typed compound literal used as a value (initializer context). */
+    {
+        int x = 77;
+        int *xp = (int *){ &x };
+        check_int(*xp, 77, "pointer-typed literal value");
+    }
 }
 
 /* Nested, address-taken compound literals used to build a small tree inline,
@@ -107,6 +233,8 @@ static void check_nested_literals(void)
 int main(void)
 {
     check_block_literals();
+    check_value_literals();
+    check_value_literals_extra();
     check_nested_literals();
     if (failures == 0)
         printf("test tclit completed with great success\n");


### PR DESCRIPTION
@davidly 
Previously a compound literal was only accepted when its address was taken (`&(T){...}`); any use as an rvalue was rejected at compile time. This extends the existing backing-store materialization to value contexts, matching clang across the tested surface.

Now supported:
  - struct literal by-value argument:      f((struct T){...})
  - struct literal initializer:            struct T t = (struct T){...};
  - struct literal assignment:             t = (struct T){...};
  - direct member access on a literal:      (struct T){...}.field
  - nested member access:                   (struct N){...}.inner.field
  - scalar literals as values:              (int){5}+1, (long){...}, (float){...}
  - struct/long/float fields read from a literal, and functions that
    return a compound literal directly

Implementation:
  - dcc_ast_build.c: split p_postfix into p_postfix_tail and apply it after a cast-form compound literal so `[]`, `()`, `.`, `->`, `++`, `--` bind to the literal instead of terminating the expression.
  - dcc_ast_gen.c: teach ast_member_base_type to resolve `.` on a struct-typed literal, ast_value_is_plain_int to accept scalar literals, and ast_struct_addr_expr_supported to accept struct literals (they materialize into a backing local whose address is exactly what the struct-value paths consume).
  - dcc_ast_gen_expr.c: add gen_compound_literal_value_ast (load the scalar from the backing object; structs keep their address), route member-base and struct-address codegen through the materializer, and add a whole-struct copy path to the declaration initializer.
  - dcc_ast_gen_support.c: recognize scalar long/float literals as long/float word values.

Address-taken compound literals are unchanged. Not covered (still diagnosed cleanly, not miscompiled): pointer/_Bool literals in an assignment (initializer form works), array-literal subscript, and struct-typed ternary.

Tests: extend tests/tclit.c with value-context, member-access, scalar, nested-field, multi-argument, struct-return, and address-preservation cases. Full regression suite passes (226 apps / 88 diagnostics, 0 failures).