### PR TITLE
Add C11 _Static_assert with typed constant-expression evaluation

### DIFF
--- a/assert.h
+++ b/assert.h
@@ -1,6 +1,9 @@
 #ifndef _ASSERT_H
 #define _ASSERT_H
 
+/** C11 spelling for the core _Static_assert declaration. */
+#define static_assert _Static_assert
+
 #ifdef NDEBUG
 /** Check expression unless assertions are disabled by NDEBUG. */
 #define assert(expression) ((void)0)

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -222,6 +222,7 @@
 #define TOK_SHORT      315
 #define TOK_WSTR       314
 #define TOK_BOOL       316
+#define TOK_STATIC_ASSERT 317
 #define TOK_SWITCH     300
 #define TOK_CASE       301
 #define TOK_DEFAULT    302
@@ -799,6 +800,7 @@ long parse_const_long_andand(void);
 long parse_const_long_oror(void);
 long parse_const_long_expr(void);
 int parse_const_int_expr(void);
+void parse_static_assert_decl(void);
 int starts_type(void);
 
 /* ---- symbols ---- */
@@ -860,6 +862,7 @@ int cf_parse_bxor(struct ConstVal *out);
 int cf_parse_bor(struct ConstVal *out);
 int cf_parse_land(struct ConstVal *out);
 int cf_parse_lor(struct ConstVal *out);
+int cf_parse_cond(struct ConstVal *out);
 int try_parse_const_expr_value(struct ConstVal *out);
 void emit_const_value(struct ConstVal v);
 

--- a/src/dcc/dcc_ast_build.c
+++ b/src/dcc/dcc_ast_build.c
@@ -1188,7 +1188,9 @@ void ast_emit_decl_span(const struct AstNode *n)
      * expressions are emitted via ast_emit_init_expr, which builds into the
      * isolated g_ast_init_arena and so never disturbs the shared g_ast_arena
      * that still holds the surrounding AST statement's pending sibling nodes. */
-    if (tok.kind == TOK_TYPEDEF) {
+    if (tok.kind == TOK_STATIC_ASSERT) {
+        parse_static_assert_decl();
+    } else if (tok.kind == TOK_TYPEDEF) {
         parse_typedef_decl();
     } else {
         int t;
@@ -1230,7 +1232,7 @@ static struct AstNode *ast_build_compound_stmt(struct AstArena *ar)
         /* A typedef or any declaration is captured as a span and re-emitted
          * by declaration codegen at emit time (which rebuilds
          * locals[] / frame offsets identically to the frame-sizing scan). */
-        if (tok.kind == TOK_TYPEDEF || starts_type()) {
+        if (tok.kind == TOK_STATIC_ASSERT || tok.kind == TOK_TYPEDEF || starts_type()) {
             child = ast_build_decl_span(ar);
             if (child == NULL)
                 return NULL;

--- a/src/dcc/dcc_constexpr.c
+++ b/src/dcc/dcc_constexpr.c
@@ -10,6 +10,9 @@
  */
 
 #include "dcc.h"
+
+static int const_expr_no_eval;
+
 long parse_const_long_primary(void)
 {
     long v;
@@ -18,11 +21,13 @@ long parse_const_long_primary(void)
     sign = 1;
     if (tok.kind == '!') {
         next_token();
-        return !parse_const_long_primary();
+        v = parse_const_long_primary();
+        return const_expr_no_eval ? 0 : !v;
     }
     if (tok.kind == '~') {
         next_token();
-        return ~parse_const_long_primary();
+        v = parse_const_long_primary();
+        return const_expr_no_eval ? 0 : ~v;
     }
     if (tok.kind == '-') {
         sign = -1;
@@ -33,7 +38,7 @@ long parse_const_long_primary(void)
 
     if (tok.kind == TOK_ID && strcmp(tok.text, "__offsetof") == 0) {
         v = parse_offsetof_value();
-        return sign * v;
+        return const_expr_no_eval ? 0 : sign * v;
     }
 
     if (tok.kind == TOK_SIZEOF) {
@@ -59,7 +64,7 @@ long parse_const_long_primary(void)
                 sz = 2;
             v = sz;
         }
-        return sign * v;
+        return const_expr_no_eval ? 0 : sign * v;
     }
 
     if (tok.kind == '(') {
@@ -67,9 +72,9 @@ long parse_const_long_primary(void)
 
         /*
          * Casts are allowed in C constant expressions, and lzpack uses
-         * forms such as (size_t)(MAXDIST * 2).  DCC's small integer model
-         * does not need to distinguish the cast for sizing/initializers, so
-         * parse and ignore the type, then evaluate the cast operand.
+         * forms such as (size_t)(MAXDIST * 2).  This legacy value-only ladder
+         * applies the immediate cast below; contexts needing typed arithmetic
+         * throughout use the ConstVal parser in dcc_fold.c.
          */
         if (starts_type()) {
             int t;
@@ -87,21 +92,34 @@ long parse_const_long_primary(void)
              * would.  Pointer casts (t became a pointer above) are not float. */
             if (type_is_float(t)) {
                 float ftmp;
-                ftmp = (float)v;
-                v = (long)ftmp;
+                if (!const_expr_no_eval) {
+                    ftmp = (float)v;
+                    v = (long)ftmp;
+                }
+            } else if (!const_expr_no_eval && type_ptr_depth(t) == 0 &&
+                       !(t & TYPE_STRUCT) && (t & 15) != TYPE_VOID) {
+                /* Apply an integer cast the way the target would: truncate to
+                 * the destination width and re-extend per its signedness, so
+                 * (uint16_t)-1 is 65535 and (signed char)0x1ff is -1.  Reuses
+                 * the fold engine's masking for a single source of truth. */
+                struct ConstVal cv;
+                cv.u = (unsigned long)v;
+                cv.type = t;
+                cf_cast_to_type(&cv, t);
+                v = cf_signed_value(cv);
             }
-            return sign * v;
+            return const_expr_no_eval ? 0 : sign * v;
         }
 
         v = parse_const_long_expr();
         expect(')');
-        return sign * v;
+        return const_expr_no_eval ? 0 : sign * v;
     }
 
     if (tok.kind == TOK_NUM || tok.kind == TOK_CHARLIT) {
         v = tok.val;
         next_token();
-        return sign * v;
+        return const_expr_no_eval ? 0 : sign * v;
     }
 
     if (tok.kind == TOK_ID) {
@@ -110,7 +128,7 @@ long parse_const_long_primary(void)
             if (!strcmp(enum_const_names[i], tok.text)) {
                 v = enum_const_values[i];
                 next_token();
-                return sign * v;
+                return const_expr_no_eval ? 0 : sign * v;
             }
         }
     }
@@ -130,7 +148,9 @@ long parse_const_long_mul(void)
         op = tok.kind;
         next_token();
         r = parse_const_long_primary();
-        if (op == '*') v *= r;
+        if (const_expr_no_eval) {
+            v = 0;
+        } else if (op == '*') v *= r;
         else if (op == '/') {
             if (r == 0) {
                 error_here("division by zero in constant expression");
@@ -159,7 +179,8 @@ long parse_const_long_add(void)
         op = tok.kind;
         next_token();
         r = parse_const_long_mul();
-        if (op == '+') v += r;
+        if (const_expr_no_eval) v = 0;
+        else if (op == '+') v += r;
         else v -= r;
     }
     return v;
@@ -176,6 +197,10 @@ long parse_const_long_shift(void)
         op = tok.kind;
         next_token();
         r = parse_const_long_add();
+        if (const_expr_no_eval) {
+            v = 0;
+            continue;
+        }
         if (r < 0) r = 0;
         if (r > 31) r = 31;
         if (op == TOK_SHL) v <<= (int)r;
@@ -195,7 +220,8 @@ long parse_const_long_rel(void)
         op = tok.kind;
         next_token();
         r = parse_const_long_shift();
-        if (op == '<') v = (v < r);
+        if (const_expr_no_eval) v = 0;
+        else if (op == '<') v = (v < r);
         else if (op == '>') v = (v > r);
         else if (op == TOK_LE) v = (v <= r);
         else v = (v >= r);
@@ -214,7 +240,8 @@ long parse_const_long_eq(void)
         op = tok.kind;
         next_token();
         r = parse_const_long_rel();
-        if (op == TOK_EQ) v = (v == r);
+        if (const_expr_no_eval) v = 0;
+        else if (op == TOK_EQ) v = (v == r);
         else v = (v != r);
     }
     return v;
@@ -227,7 +254,12 @@ long parse_const_long_band(void)
     v = parse_const_long_eq();
     while (tok.kind == '&') {
         next_token();
-        v &= parse_const_long_eq();
+        if (const_expr_no_eval) {
+            (void)parse_const_long_eq();
+            v = 0;
+        } else {
+            v &= parse_const_long_eq();
+        }
     }
     return v;
 }
@@ -239,7 +271,12 @@ long parse_const_long_xor(void)
     v = parse_const_long_band();
     while (tok.kind == '^') {
         next_token();
-        v ^= parse_const_long_band();
+        if (const_expr_no_eval) {
+            (void)parse_const_long_band();
+            v = 0;
+        } else {
+            v ^= parse_const_long_band();
+        }
     }
     return v;
 }
@@ -251,7 +288,12 @@ long parse_const_long_bitor(void)
     v = parse_const_long_xor();
     while (tok.kind == '|') {
         next_token();
-        v |= parse_const_long_xor();
+        if (const_expr_no_eval) {
+            (void)parse_const_long_xor();
+            v = 0;
+        } else {
+            v |= parse_const_long_xor();
+        }
     }
     return v;
 }
@@ -264,8 +306,15 @@ long parse_const_long_andand(void)
     v = parse_const_long_bitor();
     while (tok.kind == TOK_ANDAND) {
         next_token();
-        r = parse_const_long_bitor();
-        v = (v && r);
+        if (const_expr_no_eval || !v) {
+            const_expr_no_eval++;
+            (void)parse_const_long_bitor();
+            const_expr_no_eval--;
+            v = 0;
+        } else {
+            r = parse_const_long_bitor();
+            v = (v && r);
+        }
     }
     return v;
 }
@@ -278,8 +327,15 @@ long parse_const_long_oror(void)
     v = parse_const_long_andand();
     while (tok.kind == TOK_OROR) {
         next_token();
-        r = parse_const_long_andand();
-        v = (v || r);
+        if (const_expr_no_eval || v) {
+            const_expr_no_eval++;
+            (void)parse_const_long_andand();
+            const_expr_no_eval--;
+            v = const_expr_no_eval ? 0 : 1;
+        } else {
+            r = parse_const_long_andand();
+            v = (v || r);
+        }
     }
     return v;
 }
@@ -293,10 +349,28 @@ long parse_const_long_expr(void)
     v = parse_const_long_oror();
     if (tok.kind == '?') {
         next_token();
-        t = parse_const_long_expr();
-        expect(':');
-        f = parse_const_long_expr();
-        v = v ? t : f;
+        if (const_expr_no_eval) {
+            const_expr_no_eval++;
+            (void)parse_const_long_expr();
+            expect(':');
+            (void)parse_const_long_expr();
+            const_expr_no_eval--;
+            v = 0;
+        } else if (v) {
+            t = parse_const_long_expr();
+            expect(':');
+            const_expr_no_eval++;
+            (void)parse_const_long_expr();
+            const_expr_no_eval--;
+            v = t;
+        } else {
+            const_expr_no_eval++;
+            (void)parse_const_long_expr();
+            const_expr_no_eval--;
+            expect(':');
+            f = parse_const_long_expr();
+            v = f;
+        }
     }
     return v;
 }
@@ -304,6 +378,103 @@ long parse_const_long_expr(void)
 int parse_const_int_expr(void)
 {
     return (int)(parse_const_long_expr() & 0xffffL);
+}
+
+static void recover_static_assert_decl(void)
+{
+    while (tok.kind != TOK_EOF && tok.kind != ';')
+        next_token();
+    if (tok.kind == ';')
+        next_token();
+}
+
+void parse_static_assert_decl(void)
+{
+    struct Token assert_tok;
+    int assert_line;
+    long assert_pos;
+    int errors_before;
+    struct ConstVal value;
+    const char *prefix;
+    char *message;
+    size_t capacity;
+    size_t used;
+
+    assert_tok = tok;
+    assert_line = tok_line;
+    assert_pos = tok_start_pos;
+    expect(TOK_STATIC_ASSERT);
+    if (tok.kind != '(') {
+        error_here("expected '(' in static assertion");
+        recover_static_assert_decl();
+        return;
+    }
+    next_token();
+    errors_before = g_diag_error_count;
+    if (!try_parse_const_expr_value(&value)) {
+        if (g_diag_error_count == errors_before)
+            error_here("constant integer expression expected");
+        recover_static_assert_decl();
+        return;
+    }
+    if (g_diag_error_count != errors_before) {
+        recover_static_assert_decl();
+        return;
+    }
+    if (tok.kind != ',') {
+        error_here("expected ',' in static assertion");
+        recover_static_assert_decl();
+        return;
+    }
+    next_token();
+    if (tok.kind != TOK_STR && tok.kind != TOK_WSTR) {
+        error_here("string literal expected in static assertion");
+        recover_static_assert_decl();
+        return;
+    }
+
+    prefix = "static assertion failed: ";
+    used = strlen(prefix);
+    capacity = used + 1;
+    message = (char *)xmalloc(capacity);
+    strcpy(message, prefix);
+    while (tok.kind == TOK_STR || tok.kind == TOK_WSTR) {
+        size_t piece_len;
+        size_t needed;
+
+        piece_len = strlen(tok.text);
+        needed = used + piece_len + 1;
+        if (needed > capacity) {
+            char *grown;
+
+            capacity = needed * 2;
+            grown = (char *)xmalloc(capacity);
+            memcpy(grown, message, used + 1);
+            free(message);
+            message = grown;
+        }
+        memcpy(message + used, tok.text, piece_len + 1);
+        used += piece_len;
+        next_token();
+    }
+    if (tok.kind != ')') {
+        error_here("expected ')' after static assertion message");
+        free(message);
+        recover_static_assert_decl();
+        return;
+    }
+    next_token();
+    if (tok.kind != ';') {
+        error_here("expected ';' after static assertion");
+        free(message);
+        return;
+    }
+    next_token();
+    if (cf_signed_value(value) == 0) {
+        dcc_error_at(assert_tok.file, assert_line, assert_pos,
+                     message, assert_tok.text);
+    }
+    free(message);
 }
 
 

--- a/src/dcc/dcc_diag_emit.c
+++ b/src/dcc/dcc_diag_emit.c
@@ -60,6 +60,8 @@ const char *dcc_diag_code_for_message(const char *msg)
     if (dcc_msg_has(msg, "constant integer expression expected")) return "DCC-E0401";
     if (dcc_msg_has(msg, "division by zero in constant expression")) return "DCC-E0402";
     if (dcc_msg_has(msg, "expected an expression")) return "DCC-E0403";
+    if (dcc_msg_has(msg, "static assertion failed")) return "DCC-E0404";
+    if (dcc_msg_has(msg, "static assertion")) return "DCC-E0405";
     if (dcc_msg_has(msg, "expected a field designator")) return "DCC-E0501";
     if (dcc_msg_has(msg, "unknown field initializer designator")) return "DCC-E0502";
     if (dcc_msg_has(msg, "field name expected in offsetof")) return "DCC-E0503";

--- a/src/dcc/dcc_fold.c
+++ b/src/dcc/dcc_fold.c
@@ -109,7 +109,9 @@ void cf_convert_to_type(struct ConstVal *v, int type)
     cf_cast_to_type(v, type);
 }
 
-int cf_parse_lor(struct ConstVal *out);
+static int cf_no_eval;
+
+int cf_parse_cond(struct ConstVal *out);
 
 unsigned long cf_parse_integer_literal_bits(const char *text)
 {
@@ -160,11 +162,35 @@ unsigned long cf_parse_integer_literal_bits(const char *text)
     return v & 0xffffffffUL;
 }
 
+static float cf_float_literal_value(void)
+{
+    union {
+        float f;
+        unsigned char b[4];
+    } value;
+    unsigned long bits;
+
+    bits = (unsigned long)tok.val & 0xffffffffUL;
+    value.b[0] = (unsigned char)(bits & 0xffUL);
+    value.b[1] = (unsigned char)((bits >> 8) & 0xffUL);
+    value.b[2] = (unsigned char)((bits >> 16) & 0xffUL);
+    value.b[3] = (unsigned char)((bits >> 24) & 0xffUL);
+    return value.f;
+}
+
 int cf_parse_primary(struct ConstVal *out)
 {
+    int i;
     long v;
     int t;
     int sz;
+
+    if (tok.kind == TOK_ID && strcmp(tok.text, "__offsetof") == 0) {
+        out->u = (unsigned long)parse_offsetof_value();
+        out->type = TYPE_INT | TYPE_UNSIGNED;
+        cf_cast_to_type(out, out->type);
+        return 1;
+    }
 
     if (tok.kind == TOK_NUM) {
         /* Do not use tok.val here.  On MSVC host long is 32-bit, so tokens
@@ -186,6 +212,18 @@ int cf_parse_primary(struct ConstVal *out)
         cf_cast_to_type(out, out->type);
         next_token();
         return 1;
+    }
+
+    if (tok.kind == TOK_ID) {
+        for (i = 0; i < nenum_consts; ++i) {
+            if (!strcmp(enum_const_names[i], tok.text)) {
+                out->u = (unsigned long)enum_const_values[i];
+                out->type = TYPE_INT;
+                cf_cast_to_type(out, out->type);
+                next_token();
+                return 1;
+            }
+        }
     }
 
     if (tok.kind == TOK_SIZEOF) {
@@ -215,9 +253,20 @@ int cf_parse_primary(struct ConstVal *out)
     if (tok.kind == '(') {
         next_token();
         if (starts_type()) {
+            float float_value;
             parse_type_name_decl(&t, &sz);
             expect(')');
-            if (!cf_parse_primary(out))
+            if (tok.kind == TOK_FLOATLIT && !type_is_float(t) &&
+                type_ptr_depth(t) == 0 && !(t & TYPE_STRUCT) &&
+                (t & 15) != TYPE_VOID) {
+                float_value = cf_float_literal_value();
+                out->u = (unsigned long)(long)float_value;
+                out->type = t;
+                cf_cast_to_type(out, t);
+                next_token();
+                return 1;
+            }
+            if (!cf_parse_unary(out))
                 return 0;
             /*
              * The cf_* engine is integer-only: it has no IEEE-754 rounding,
@@ -232,7 +281,7 @@ int cf_parse_primary(struct ConstVal *out)
             cf_cast_to_type(out, t);
             return 1;
         }
-        if (!cf_parse_lor(out))
+        if (!cf_parse_cond(out))
             return 0;
         if (!accept(')'))
             return 0;
@@ -253,6 +302,10 @@ int cf_parse_unary(struct ConstVal *out)
         if (!cf_parse_unary(out))
             return 0;
         cf_convert_to_type(out, cf_promote_type(out->type));
+        if (cf_no_eval) {
+            out->u = 0;
+            return 1;
+        }
         if (op == '+') {
             return 1;
         } else if (op == '-') {
@@ -293,7 +346,9 @@ int cf_parse_mul(struct ConstVal *out)
         common = cf_common_arith_type(out->type, rhs.type);
         cf_convert_to_type(out, common);
         cf_convert_to_type(&rhs, common);
-        if (op == '*') {
+        if (cf_no_eval) {
+            out->u = 0;
+        } else if (op == '*') {
             out->u = (out->u * rhs.u) & cf_mask_for_type(common);
         } else if (common & TYPE_UNSIGNED) {
             if ((rhs.u & cf_mask_for_type(common)) == 0)
@@ -336,7 +391,9 @@ int cf_parse_add(struct ConstVal *out)
         common = cf_common_arith_type(out->type, rhs.type);
         cf_convert_to_type(out, common);
         cf_convert_to_type(&rhs, common);
-        if (op == '+')
+        if (cf_no_eval)
+            out->u = 0;
+        else if (op == '+')
             out->u = (out->u + rhs.u) & cf_mask_for_type(common);
         else
             out->u = (out->u - rhs.u) & cf_mask_for_type(common);
@@ -364,6 +421,11 @@ int cf_parse_shift(struct ConstVal *out)
             return 0;
         lhs_type = cf_promote_type(out->type);
         cf_convert_to_type(out, lhs_type);
+        if (cf_no_eval) {
+            out->u = 0;
+            out->type = lhs_type;
+            continue;
+        }
         sc = cf_signed_value(rhs);
         if (sc < 0)
             return 0;
@@ -401,7 +463,9 @@ int cf_parse_rel(struct ConstVal *out)
         common = cf_common_arith_type(out->type, rhs.type);
         cf_convert_to_type(out, common);
         cf_convert_to_type(&rhs, common);
-        if (common & TYPE_UNSIGNED) {
+        if (cf_no_eval) {
+            r = 0;
+        } else if (common & TYPE_UNSIGNED) {
             unsigned long a = out->u & cf_mask_for_type(common);
             unsigned long b = rhs.u & cf_mask_for_type(common);
             r = (op == '<') ? (a < b) : (op == '>') ? (a > b) : (op == TOK_LE) ? (a <= b) : (a >= b);
@@ -433,7 +497,8 @@ int cf_parse_eq(struct ConstVal *out)
         common = cf_common_arith_type(out->type, rhs.type);
         cf_convert_to_type(out, common);
         cf_convert_to_type(&rhs, common);
-        r = ((out->u & cf_mask_for_type(common)) == (rhs.u & cf_mask_for_type(common)));
+        r = cf_no_eval ? 0 :
+            ((out->u & cf_mask_for_type(common)) == (rhs.u & cf_mask_for_type(common)));
         if (op == TOK_NE)
             r = !r;
         out->u = r ? 1UL : 0UL;
@@ -453,7 +518,7 @@ int cf_parse_band(struct ConstVal *out)
         common = cf_common_arith_type(out->type, rhs.type);
         cf_convert_to_type(out, common);
         cf_convert_to_type(&rhs, common);
-        out->u = (out->u & rhs.u) & cf_mask_for_type(common);
+        out->u = cf_no_eval ? 0 : (out->u & rhs.u) & cf_mask_for_type(common);
         out->type = common;
     }
     return 1;
@@ -470,7 +535,7 @@ int cf_parse_bxor(struct ConstVal *out)
         common = cf_common_arith_type(out->type, rhs.type);
         cf_convert_to_type(out, common);
         cf_convert_to_type(&rhs, common);
-        out->u = (out->u ^ rhs.u) & cf_mask_for_type(common);
+        out->u = cf_no_eval ? 0 : (out->u ^ rhs.u) & cf_mask_for_type(common);
         out->type = common;
     }
     return 1;
@@ -487,7 +552,7 @@ int cf_parse_bor(struct ConstVal *out)
         common = cf_common_arith_type(out->type, rhs.type);
         cf_convert_to_type(out, common);
         cf_convert_to_type(&rhs, common);
-        out->u = (out->u | rhs.u) & cf_mask_for_type(common);
+        out->u = cf_no_eval ? 0 : (out->u | rhs.u) & cf_mask_for_type(common);
         out->type = common;
     }
     return 1;
@@ -499,8 +564,18 @@ int cf_parse_land(struct ConstVal *out)
     if (!cf_parse_bor(out)) return 0;
     while (tok.kind == TOK_ANDAND) {
         next_token();
-        if (!cf_parse_bor(&rhs)) return 0;
-        out->u = (cf_signed_value(*out) != 0 && cf_signed_value(rhs) != 0) ? 1UL : 0UL;
+        if (cf_no_eval || cf_signed_value(*out) == 0) {
+            cf_no_eval++;
+            if (!cf_parse_bor(&rhs)) {
+                cf_no_eval--;
+                return 0;
+            }
+            cf_no_eval--;
+            out->u = 0;
+        } else {
+            if (!cf_parse_bor(&rhs)) return 0;
+            out->u = cf_signed_value(rhs) != 0 ? 1UL : 0UL;
+        }
         out->type = TYPE_INT;
     }
     return 1;
@@ -512,16 +587,69 @@ int cf_parse_lor(struct ConstVal *out)
     if (!cf_parse_land(out)) return 0;
     while (tok.kind == TOK_OROR) {
         next_token();
-        if (!cf_parse_land(&rhs)) return 0;
-        out->u = (cf_signed_value(*out) != 0 || cf_signed_value(rhs) != 0) ? 1UL : 0UL;
+        if (cf_no_eval || cf_signed_value(*out) != 0) {
+            cf_no_eval++;
+            if (!cf_parse_land(&rhs)) {
+                cf_no_eval--;
+                return 0;
+            }
+            cf_no_eval--;
+            out->u = cf_no_eval ? 0UL : 1UL;
+        } else {
+            if (!cf_parse_land(&rhs)) return 0;
+            out->u = cf_signed_value(rhs) != 0 ? 1UL : 0UL;
+        }
         out->type = TYPE_INT;
     }
     return 1;
 }
 
+int cf_parse_cond(struct ConstVal *out)
+{
+    struct ConstVal true_value;
+    struct ConstVal false_value;
+    int condition;
+    int common;
+
+    if (!cf_parse_lor(out))
+        return 0;
+    if (tok.kind != '?')
+        return 1;
+
+    condition = cf_signed_value(*out) != 0;
+    next_token();
+    if (cf_no_eval || !condition)
+        cf_no_eval++;
+    if (!cf_parse_cond(&true_value)) {
+        if (cf_no_eval || !condition)
+            cf_no_eval--;
+        return 0;
+    }
+    if (cf_no_eval || !condition)
+        cf_no_eval--;
+    if (!accept(':'))
+        return 0;
+    if (cf_no_eval || condition)
+        cf_no_eval++;
+    if (!cf_parse_cond(&false_value)) {
+        if (cf_no_eval || condition)
+            cf_no_eval--;
+        return 0;
+    }
+    if (cf_no_eval || condition)
+        cf_no_eval--;
+
+    common = cf_common_arith_type(true_value.type, false_value.type);
+    *out = condition ? true_value : false_value;
+    cf_convert_to_type(out, common);
+    if (cf_no_eval)
+        out->u = 0;
+    return 1;
+}
+
 int try_parse_const_expr_value(struct ConstVal *out)
 {
-    return cf_parse_lor(out);
+    return cf_parse_cond(out);
 }
 
 void emit_const_value(struct ConstVal v)

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -2566,6 +2566,9 @@ void scan_function_body(void)
              */
             ast_scan_for_stmt();
             can_decl = 1;
+        } else if (can_decl && tok.kind == TOK_STATIC_ASSERT) {
+            parse_static_assert_decl();
+            can_decl = 1;
         } else if (can_decl && tok.kind == TOK_TYPEDEF) {
             parse_typedef_decl();
             can_decl = 1;
@@ -5135,7 +5138,9 @@ void parse_translation_unit(void)
     next_token();
 
     while (tok.kind != TOK_EOF) {
-        if (tok.kind == TOK_TYPEDEF) {
+        if (tok.kind == TOK_STATIC_ASSERT) {
+            parse_static_assert_decl();
+        } else if (tok.kind == TOK_TYPEDEF) {
             parse_typedef_decl();
         } else if (starts_type()) {
             int t;

--- a/src/dcc/dcc_preproc.c
+++ b/src/dcc/dcc_preproc.c
@@ -1142,6 +1142,7 @@ int keyword_kind(const char *s)
     if (!strcmp(s, "long")) return TOK_LONG;
     if (!strcmp(s, "float")) return TOK_FLOAT;
     if (!strcmp(s, "_Bool")) return TOK_BOOL;
+    if (!strcmp(s, "_Static_assert")) return TOK_STATIC_ASSERT;
     if (!strcmp(s, "char")) return TOK_CHAR;
     if (!strcmp(s, "void")) return TOK_VOID;
     if (!strcmp(s, "unsigned")) return TOK_UNSIGNED;
@@ -2907,6 +2908,7 @@ static const char *expected_token_name(int k, char *buf)
         case TOK_LONG:     return "long";
         case TOK_FLOAT:    return "float";
         case TOK_BOOL:     return "_Bool";
+        case TOK_STATIC_ASSERT: return "_Static_assert";
         case TOK_EQ:       return "==";
         case TOK_NE:       return "!=";
         case TOK_LE:       return "<=";

--- a/src/dcc/dcc_stmt.c
+++ b/src/dcc/dcc_stmt.c
@@ -47,7 +47,9 @@ void gen_compound(void)
     enter_scope();
     dead = 0;
     while (tok.kind != TOK_EOF && tok.kind != '}') {
-        if (tok.kind == TOK_TYPEDEF) {
+        if (tok.kind == TOK_STATIC_ASSERT) {
+            parse_static_assert_decl();
+        } else if (tok.kind == TOK_TYPEDEF) {
             parse_typedef_decl();
         } else if (current_identifier_starts_label()) {
             gen_statement();

--- a/src/dcc/dcc_types.c
+++ b/src/dcc/dcc_types.c
@@ -404,6 +404,12 @@ void parse_struct_definition(int struct_id)
     bit_unit_offset = 0;
 
     while (tok.kind != TOK_EOF && tok.kind != '}') {
+        /* C11 6.7.2.1: a static_assert-declaration is a valid struct-declaration.
+         * It contributes no member and is consumed (through its ';') here. */
+        if (tok.kind == TOK_STATIC_ASSERT) {
+            parse_static_assert_decl();
+            continue;
+        }
         ftype = parse_type();
 
         for (;;) {

--- a/tests/diagnostics/baselines/static-assert-block-failed.txt
+++ b/tests/diagnostics/baselines/static-assert-block-failed.txt
@@ -1,0 +1,4 @@
+<source>:3: error DCC-E0404: static assertion failed: block assertion failed near '_Static_assert'
+        _Static_assert(0, "block assertion failed");
+        ^
+dcc: 1 error(s)

--- a/tests/diagnostics/baselines/static-assert-failed.txt
+++ b/tests/diagnostics/baselines/static-assert-failed.txt
@@ -1,0 +1,4 @@
+<source>:1: error DCC-E0404: static assertion failed: int must be four bytes near '_Static_assert'
+    _Static_assert(sizeof(int) == 4, "int must be " "four bytes");
+    ^
+dcc: 1 error(s)

--- a/tests/diagnostics/baselines/static-assert-member-failed.txt
+++ b/tests/diagnostics/baselines/static-assert-member-failed.txt
@@ -1,0 +1,4 @@
+<source>:2: error DCC-E0404: static assertion failed: member assertion failed near '_Static_assert'
+        _Static_assert(sizeof(int) == 4, "member assertion failed");
+        ^
+dcc: 1 error(s)

--- a/tests/diagnostics/baselines/static-assert-message.txt
+++ b/tests/diagnostics/baselines/static-assert-message.txt
@@ -1,0 +1,4 @@
+<source>:1: error DCC-E0405: string literal expected in static assertion near 'not_a_string'
+    _Static_assert(1, not_a_string);
+                      ^
+dcc: 1 error(s)

--- a/tests/diagnostics/static-assert-block-failed.c
+++ b/tests/diagnostics/static-assert-block-failed.c
@@ -1,0 +1,5 @@
+int main(void)
+{
+    _Static_assert(0, "block assertion failed");
+    return 0;
+}

--- a/tests/diagnostics/static-assert-failed.c
+++ b/tests/diagnostics/static-assert-failed.c
@@ -1,0 +1,1 @@
+_Static_assert(sizeof(int) == 4, "int must be " "four bytes");

--- a/tests/diagnostics/static-assert-member-failed.c
+++ b/tests/diagnostics/static-assert-member-failed.c
@@ -1,0 +1,4 @@
+struct S {
+    _Static_assert(sizeof(int) == 4, "member assertion failed");
+    int value;
+};

--- a/tests/diagnostics/static-assert-message.c
+++ b/tests/diagnostics/static-assert-message.c
@@ -1,0 +1,2 @@
+_Static_assert(1, not_a_string);
+int still_parsed;

--- a/tests/tanonagg.c
+++ b/tests/tanonagg.c
@@ -1,5 +1,30 @@
 /* tanonagg.c - C11 anonymous struct/union member lookup and initialization. */
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
+
+#ifdef _DCC_
+typedef uint32_t static_assert_u32;
+#else
+typedef unsigned int static_assert_u32;
+#endif
+
+_Static_assert(sizeof(int) >= 2, "int too small");
+_Static_assert(1 || (1 / 0), "unselected || operand must not be evaluated");
+_Static_assert(!(0 && (1 / 0)), "unselected && operand must not be evaluated");
+_Static_assert(0 ? (1 / 0) : 1, "unselected ?: operand must not be evaluated");
+_Static_assert((unsigned char)-1 == 255, "cast must truncate to 8 bits");
+_Static_assert((signed char)511 == -1, "cast must wrap to signed 8 bits");
+_Static_assert((int)1.0 == 1, "immediate floating constant cast");
+_Static_assert(sizeof(static_assert_u32) == 4, "oracle type must be 32 bits");
+_Static_assert((static_assert_u32)-1 + 1 == 0, "unsigned 32-bit addition wraps");
+_Static_assert((static_assert_u32)0 - 1 ==
+               (static_assert_u32)0xffffffffUL,
+               "unsigned 32-bit subtraction wraps");
+_Static_assert((static_assert_u32)0xffffffffUL * 2 ==
+               (static_assert_u32)0xfffffffeUL,
+               "unsigned 32-bit multiplication wraps");
 
 struct NestedAnon {
     int a;
@@ -22,7 +47,16 @@ struct NestedAnon {
 struct Pair {
     int x;
     int y;
+    _Static_assert(sizeof(int) >= 2, "member-scope static assertion");
 };
+
+#ifdef _DCC_
+_Static_assert(offsetof(struct Pair, y) == sizeof(int),
+               "offsetof must be an integer constant expression");
+#else
+_Static_assert(__builtin_offsetof(struct Pair, y) == sizeof(int),
+               "offsetof must be an integer constant expression");
+#endif
 
 struct InitAnon {
     int a;
@@ -86,6 +120,8 @@ static void check_local_initializers(void)
 
 int main(void)
 {
+    static_assert(sizeof(char) == 1, "char size changed");
+
     check_global_initializers();
     check_local_initializers();
 


### PR DESCRIPTION
@davidly @gloveboxes 
Implement _Static_assert as a core C11 declaration at file, block, and struct/union member scope (6.7.2.1), plus the <assert.h> static_assert macro alias. dcc has no -std selector, so it is accepted in the existing mixed dialect rather than gated to C11.

To make static assertions evaluate their controlling expression with correct C semantics, route them through the typed ConstVal folder instead of the untyped long ladder. Extend that folder to preserve target width and signedness across all operators, so unsigned arithmetic wraps modulo its width (e.g. (uint32_t)-1 + 1 == 0) independent of the host long size.

Evaluator additions (dcc_fold.c):
- cf_parse_cond: conditional (?:) with typed common-type result
- parse-without-evaluate mode for unselected &&, ||, and ?: operands, so a false branch containing e.g. 1/0 is a constraint-valid, unevaluated subexpression (6.6p3)
- enum constants, __offsetof, and immediate floating-constant casts as integer constant-expression primaries (6.6p6)

Diagnostics:
- DCC-E0404 for a failed assertion, reported at the _Static_assert token, with all adjacent message string literals concatenated
- DCC-E0405 for malformed declarations (missing (, comma, message, ), or ;), each recovering to the terminating ; so one error is reported

Behavior verified against clang -std=c11 as a differential oracle for accept/reject decisions, including cast boundaries, _Bool, nested casts, short-circuiting, and uint32 wrap.

Tests:
- tests/tanonagg.c: file/block/member assertions, alias, unevaluated branches, char-width and 32-bit casts (guarded typedef so the same source is valid under clang's 32-bit int and dcc's 16-bit int), and offsetof
- tests/diagnostics: static-assert-failed, -block-failed, -member-failed, -message