### PR TITLE
Emit closing-brace locations in debug metadata

### DIFF
--- a/src/dcc/dcc_ast.c
+++ b/src/dcc/dcc_ast.c
@@ -126,6 +126,8 @@ struct AstNode *ast_new(struct AstArena *ar, int kind)
     n->file = (char *)ast_arena_alloc(ar, file_len);
     memcpy(n->file, file, file_len);
     n->line = tok_line;
+    n->end_file = NULL;
+    n->end_line = 0;
     return n;
 }
 

--- a/src/dcc/dcc_ast.h
+++ b/src/dcc/dcc_ast.h
@@ -108,6 +108,8 @@ struct AstNode {
                             /* computes the arithmetic common-type choice    */
     char *file;             /* arena-owned source filename                  */
     int line;               /* source line, for diagnostics                */
+    char *end_file;         /* AST_COMPOUND closing-brace source filename  */
+    int end_line;           /* AST_COMPOUND closing-brace source line      */
 };
 
 #define AST_INT_UVAL_CHARLIT       1UL

--- a/src/dcc/dcc_ast_build.c
+++ b/src/dcc/dcc_ast_build.c
@@ -1248,6 +1248,9 @@ static struct AstNode *ast_build_compound_stmt(struct AstArena *ar)
 
     if (tok.kind != '}')
         return NULL;
+    n->end_file = ast_arena_strdup(ar, tok.file[0] ? tok.file :
+                                   (input_name ? input_name : "<input>"));
+    n->end_line = tok_line;
     next_token();                        /* consume '}' */
     return n;
 }

--- a/src/dcc/dcc_ast_gen_stmt.c
+++ b/src/dcc/dcc_ast_gen_stmt.c
@@ -874,21 +874,26 @@ int ast_last_statement_exits(void)
     return g_ast_last_stmt_exits;
 }
 
-static void ast_emit_debug_line(const struct AstNode *n)
+static void ast_emit_debug_location(const char *file, int line)
 {
     const char *p;
 
-    if (!opt_debug || scan_mode || n->line <= 0)
+    if (!opt_debug || scan_mode || line <= 0)
         return;
 
     fputs(";@dcc-line \"", outf);
-    p = n->file ? n->file : (input_name ? input_name : "<input>");
+    p = file ? file : (input_name ? input_name : "<input>");
     while (*p) {
         if (*p == '\\' || *p == '"')
             fputc('\\', outf);
         fputc(*p++, outf);
     }
-    fprintf(outf, "\" %d\n", n->line);
+    fprintf(outf, "\" %d\n", line);
+}
+
+static void ast_emit_debug_line(const struct AstNode *n)
+{
+    ast_emit_debug_location(n->file, n->line);
 }
 
 /* Emit statement node `n` (gated by ast_stmt_supported). */
@@ -1117,6 +1122,8 @@ void ast_gen_stmt(const struct AstNode *n)
         if (!dead && g_scope_depth < MAX_SCOPE_DEPTH &&
             g_vla_scope_off[g_scope_depth] != 0)
             emit_vla_restore_sp(g_vla_scope_off[g_scope_depth]);
+        if (!dead)
+            ast_emit_debug_location(n->end_file, n->end_line);
         leave_scope();
         break;
     }


### PR DESCRIPTION
Record the source location of each compound statement's closing brace in the AST. Emit that location when the block falls through so source stepping shows the block exit instead of implying that a skipped or completed statement ran.