### PR TITLE
Fix uint8_t post-increment in array subscripts

### DIFF
--- a/src/dcc/dcc_ast_gen.c
+++ b/src/dcc/dcc_ast_gen.c
@@ -2244,7 +2244,13 @@ int ast_postfix_plain_int(const struct AstNode *n)
     sz = type_size(s->type);
     if (sz != 1 && sz != 2)
         return 0;
-    if (!sym_can_ix_direct(s) && !is_global_word_sym(s) && s->storage != SC_LOCAL)
+    /* Accept IX-direct locals/params, global/extern words, any SC_LOCAL, and
+     * global/extern BYTES.  A global byte is not is_global_word_sym (that is
+     * word-only), so it needs its own clause; gen_postfix_ast lowers it through
+     * emit_load_sym_addr + gen_post_update_from_addr, the same address path the
+     * SC_LOCAL byte case uses. */
+    if (!sym_can_ix_direct(s) && !is_global_word_sym(s) && s->storage != SC_LOCAL &&
+        !((s->storage == SC_GLOBAL || s->storage == SC_EXTERN) && sz == 1))
         return 0;
     return 1;
 }

--- a/src/dcc/dcc_ast_gen_expr.c
+++ b/src/dcc/dcc_ast_gen_expr.c
@@ -4836,6 +4836,21 @@ void gen_postfix_ast(const struct AstNode *n)
         return;
     }
 
+    /* Global/static byte scalar (uint8_t/char): try_emit_post_update_sym_direct
+     * handles global WORDS (is_global_word_sym) and IX-direct locals but
+     * declines a global BYTE, and emit_load_sym_value_direct's byte branch
+     * assumes an (ix+d) frame slot.  Route it through its address like the
+     * SC_LOCAL case above so the load/increment/store and byte wrap are
+     * correct. */
+    if (s != NULL && (s->storage == SC_GLOBAL || s->storage == SC_EXTERN) &&
+        !s->is_array && ast_is_plain_int_type(s->type) &&
+        type_size(s->type) == 1) {
+        emit_load_sym_addr(s);
+        gen_post_update_from_addr(s->type, n->op);
+        g_long_from16 = 0;
+        return;
+    }
+
     /* long identifiers: update the full 32-bit value with carry ripple across
      * all four bytes via the address-based helper, which also selects an
      * in-place statement-context fast path when the result is dead (e.g. a

--- a/tests/baselines/tpostinc.txt
+++ b/tests/baselines/tpostinc.txt
@@ -7,3 +7,5 @@ int post++: old=10 new=11
 int post--: old=11 new=10
 int ptr+1 post++: old=200 new=201
 int ptr+k post--: old=300 new=299
+static u8 idx: buf=AB len=2
+global u8 idx: buf=XYZ len=3

--- a/tests/tpostinc.c
+++ b/tests/tpostinc.c
@@ -1,5 +1,31 @@
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
+
+static char g_buffer[16];
+static uint8_t g_static_len;
+uint8_t g_global_len;
+
+/* Regression: a global/static uint8_t post-incremented inside an array
+ * subscript (buffer[len++] = ...) used to be rejected with DCC-E1002. */
+static void test_global_byte_index(void)
+{
+    memset(g_buffer, 0, sizeof(g_buffer));
+    g_static_len = 0;
+    g_global_len = 0;
+
+    g_buffer[g_static_len++] = 'A';
+    g_buffer[g_static_len++] = 'B';
+    printf("static u8 idx: buf=%c%c len=%u\n",
+           g_buffer[0], g_buffer[1], (unsigned)g_static_len); /* AB 2 */
+
+    g_buffer[g_global_len++] = 'X';
+    g_buffer[g_global_len++] = 'Y';
+    g_buffer[g_global_len++] = 'Z';
+    printf("global u8 idx: buf=%c%c%c len=%u\n",
+           g_buffer[0], g_buffer[1], g_buffer[2],
+           (unsigned)g_global_len);                            /* XYZ 3 */
+}
 
 static void test_char_simple(void)
 {
@@ -70,5 +96,6 @@ extern int main()
     test_char_ptr_math();
     test_int_simple();
     test_int_ptr_math();
+    test_global_byte_index();
     return 0;
 }


### PR DESCRIPTION
Allow postfix increment and decrement of global and extern byte-sized integer variables when their value is consumed.

Lower global byte updates through the address-based path so the old value is preserved for the expression while the incremented byte is stored with the correct wrapping behavior.

Add regression coverage for static and global uint8_t array indices.