### PR TITLE
fix(dccmake): link helper modules before the main module

### DIFF
--- a/src/dccmake/dccmake.c
+++ b/src/dccmake/dccmake.c
@@ -1931,10 +1931,12 @@ static int run_build(struct Config *cfg)
     }
 
     copy_text(link_arg, sizeof(link_arg), "/P:100,RTLMIN");
-    for (i = 0; i < cfg->input_count; i++) {
+    for (i = 1; i < cfg->input_count; i++) {
         if (!cmd_append_raw(link_arg, sizeof(link_arg), ",")) return 0;
         if (!cmd_append_raw(link_arg, sizeof(link_arg), uppers[i])) return 0;
     }
+    if (!cmd_append_raw(link_arg, sizeof(link_arg), ",")) return 0;
+    if (!cmd_append_raw(link_arg, sizeof(link_arg), uppers[0])) return 0;
     if (!cmd_append_raw(link_arg, sizeof(link_arg), ",")) return 0;
     if (!cmd_append_raw(link_arg, sizeof(link_arg), output_upper)) return 0;
     if (!cmd_append_raw(link_arg, sizeof(link_arg), "/N/E/Y")) return 0;


### PR DESCRIPTION
Only the main translation unit emits the program-wide synthetic BSS boundaries (__bssb/__bsse/__hstart); helper modules built with -module emit ordinary DS storage. BSS globals in main are EQU aliases with no bytes in the image, so the range [__bssb, __bsse) is physically owned by whatever module L80 places next.

The old link order put main before the helpers
(RTLMIN,MAIN,HELPERS,OUTPUT), so __bssb resolved into helper code. DCCRTL's startup BSS clear then zeroed that helper code, turning later calls into a NOP sled and causing hangs/restarts at 0100h with no M80 or L80 diagnostic. Single-source builds were unaffected.

Build the L80 module list as RTLMIN,HELPERS...,MAIN,OUTPUT by appending inputs 1..N-1 first, then input 0. Helper source/compile order and debug metadata are unchanged; only the final linked placement of the main module moves to the end so its BSS boundaries follow all program code.