### PR TITLE
Fix volatile multiply, computed GOTO, and member pointer arrays

### DIFF
--- a/src/dcc/dcc_ast_build.c
+++ b/src/dcc/dcc_ast_build.c
@@ -143,6 +143,11 @@ int ast_expr_type_for_sizeof(const struct AstNode *n)
                   s->dim_count + 1 == index_count)))
                 return s->is_array ? s->type : type_decay_ptr(s->type);
         }
+        if (root != NULL && root->kind == AST_MEMBER) {
+            fd = ast_member_field_for_sizeof(root);
+            if (fd != NULL && fd->is_array && fd->dim_count == index_count)
+                return fd->elem_type;
+        }
         lt = ast_expr_type_for_sizeof(n->a);
         if (n->a != NULL && n->a->kind == AST_IDENT) {
             s = find_sym(n->a->sval);
@@ -285,6 +290,37 @@ static int ast_expr_is_array_row(const struct AstNode *n)
     return 0;
 }
 
+/*
+ * Descend an rvalue's base chain - through subscripts, member selections
+ * (. and ->) and pointer dereferences - to the identifier its value derives
+ * from, and report whether that identifier is absent from the symbol table.
+ * Such a base is a local declared in an inner block whose scope AST-build has
+ * not entered (nested-block locals register only when emitted), so the whole
+ * expression's type is unknowable here.  Enum constants are excluded: they
+ * carry a known int type and must keep the precise E0920 diagnostic.
+ */
+static int ast_expr_base_ident_unresolved(const struct AstNode *n)
+{
+    while (n != NULL) {
+        switch (n->kind) {
+        case AST_INDEX:
+        case AST_MEMBER:
+            n = n->a;
+            break;
+        case AST_UNARY:
+            if (n->op != '*')
+                return 0;
+            n = n->a;
+            break;
+        case AST_IDENT:
+            return find_sym(n->sval) == NULL && find_enum_const(n->sval) < 0;
+        default:
+            return 0;
+        }
+    }
+    return 0;
+}
+
 static int ast_expr_is_pointer_assignment_rhs(const struct AstNode *n)
 {
     const struct AstNode *cast;
@@ -303,17 +339,15 @@ static int ast_expr_is_pointer_assignment_rhs(const struct AstNode *n)
     if (ast_expr_is_null_pointer_constant(n))
         return 1;
     /*
-     * A bare identifier that is not yet in the symbol table denotes a
-     * declaration from an inner block whose scope has not been entered at
-     * AST-build time (nested-block locals only register when emitted).  Its
+     * When the value derives from an identifier not yet in the symbol table
+     * - a bare reference, or a subscript/member/deref rooted on one - that
+     * identifier is a declaration from an inner block whose scope AST-build
+     * has not entered (nested-block locals only register when emitted).  Its
      * type is not knowable here, so ast_expr_type_for_sizeof would wrongly
      * default it to int.  Do not treat that as an integer-to-pointer
      * assignment; a genuinely undeclared identifier is diagnosed later.
-     * Enum constants are excluded: they are looked up in their own table,
-     * have a known int type, and must keep the precise E0920 diagnostic.
      */
-    if (n->kind == AST_IDENT && find_sym(n->sval) == NULL &&
-        find_enum_const(n->sval) < 0)
+    if (ast_expr_base_ident_unresolved(n))
         return 1;
     if (type_ptr_depth(ast_expr_type_for_sizeof(n)) > 0)
         return 1;

--- a/src/dcc/dcc_ast_gen_expr.c
+++ b/src/dcc/dcc_ast_gen_expr.c
@@ -1026,7 +1026,8 @@ static int ast_same_plain_u16_source(const struct AstNode *a, const struct AstNo
     b = ast_strip_u16_widen_cast(b);
     if (a == NULL || b == NULL)
         return 0;
-    return a->kind == AST_IDENT && b->kind == AST_IDENT && a->sym != NULL && a->sym == b->sym;
+    return a->kind == AST_IDENT && b->kind == AST_IDENT && a->sym != NULL &&
+           !a->sym->is_volatile && a->sym == b->sym;
 }
 
 void gen_long_arith_ast(const struct AstNode *n)

--- a/src/dcc/dcc_ast_gen_support.c
+++ b/src/dcc/dcc_ast_gen_support.c
@@ -836,10 +836,13 @@ static int ast_gen_supported_uncached(const struct AstNode *n)
         return 1;
     }
     case AST_INDEX: {
+         int elem_type;
         int ptr_type;
         int no_deref;
         return ast_index_plain_int_read(n) || ast_index_long_read(n) ||
                ast_index_float_read(n) ||
+             (ast_index_2d_array_elem_type(n, &elem_type) &&
+              type_ptr_depth(elem_type) > 0) ||
                ast_pointer_expr_type(n, &ptr_type, &no_deref);
     }
     case AST_CALL: {
@@ -1568,8 +1571,12 @@ int ast_value_is_pointer_word(const struct AstNode *n)
         return s != NULL && type_ptr_depth(s->type) > 0;
     case AST_MEMBER:
         return ast_member_pointer_read(n);
-    case AST_INDEX:
-        return ast_pointer_expr_type(n, &ptr_type, &no_deref);
+    case AST_INDEX: {
+        int elem_type;
+        return ast_pointer_expr_type(n, &ptr_type, &no_deref) ||
+               (ast_index_2d_array_elem_type(n, &elem_type) &&
+                type_ptr_depth(elem_type) > 0);
+    }
     default:
         return 0;
     }

--- a/tests/forint.c
+++ b/tests/forint.c
@@ -1219,6 +1219,7 @@ static void run_prog(void)
             case OP_CGOTO: idx=eval_e(st->ae);
             if(idx>=1&&idx<=st->ntargets)
             {
+                if(st->targets[idx-1]==NULL)die("bad label");
                 g_pc=st->targets[idx-1];
                 continue;
             }

--- a/tests/tfldparr.c
+++ b/tests/tfldparr.c
@@ -26,7 +26,25 @@ struct Node {
     struct Node *kids[3];
 };
 
+struct Grid {
+    struct Node *cells[2][3];
+};
+
 static struct Node nodes[3];
+
+static int compile_2d_member_array(struct Grid *grid)
+{
+    struct Node *p;
+
+    /* Nested-block locals register only during AST emission.  The assignment
+     * must therefore tolerate an unresolved base while the AST is built. */
+    {
+        struct Grid *nested_grid = grid;
+
+        p = nested_grid->cells[0][0];
+    }
+    return p->val;
+}
 
 int main(void)
 {


### PR DESCRIPTION
Correct several compiler and FORTRAN interpreter issues found during review.

Compiler fixes:

- Prevent the `x * x` unsigned multiply fast path from reusing a single load when `x` is volatile. Each volatile operand evaluation now performs its required independent read.

- Preserve pointer element types when indexing one- and two-dimensional arrays stored in struct or union members. Keep the AST type resolver, code-generation support gate, and pointer-value classifier consistent so expressions such as `grid->cells[i][j]` are accepted and emitted correctly.

- Avoid a false DCC-E0920 integer-to-pointer diagnostic when an assignment RHS is based on a pointer declared in a nested block. Nested-block declarations are not registered until AST emission, so walk member, subscript, and dereference chains to identify an unresolved root and defer the diagnostic until its type is available. Enum constants and genuine integer-to-pointer assignments retain the existing diagnostic.

Interpreter fix:

- Validate the selected target of a computed GOTO before dispatch. An unresolved label now reports `bad label` instead of passing a null target into the statement-pointer loop.

Tests:

- Add compile-time coverage for one- and two-dimensional member pointer arrays.
- Exercise member-array access through a nested-block-local pointer so the deferred pointer-assignment check is covered directly.
- Preserve existing output and performance baselines.

Verified with the full optimized and unoptimized regression suite: 305 passed, 0 failed, all 106 diagnostics passed.