### PR TITLE
fix(dccpeep): restrict HL address folds to DCC-generated non-asm code

### DIFF
--- a/src/dcc/dcc_diag_emit.c
+++ b/src/dcc/dcc_diag_emit.c
@@ -443,7 +443,9 @@ void flush_pending_asm(void)
     if (asm_suppress_depth > 0)
         return;
     if (pending_asm_len > 0 && outf) {
+        fputs("\t; dcc user asm begin\n", outf);
         fwrite(pending_asm_buf, 1, (size_t)pending_asm_len, outf);
+        fputs("\t; dcc user asm end\n", outf);
         pending_asm_len = 0;
     }
 }

--- a/src/dccpeep/dccpeep.c
+++ b/src/dccpeep/dccpeep.c
@@ -866,6 +866,25 @@ static int pass_base_index_addr(void)
  * exact triple in that file alone; a broader sample of the tests directory's
  * .c files found it elsewhere too, just far less densely).
  */
+static int input_is_dcc_generated;
+
+static int range_is_user_asm(int start, int end)
+{
+    int depth;
+    int i;
+
+    depth = 0;
+    for (i = 0; i <= end && i < nlines; ++i) {
+        if (strcmp(lines[i], "; dcc user asm begin") == 0)
+            depth++;
+        if (i >= start && depth > 0)
+            return 1;
+        if (strcmp(lines[i], "; dcc user asm end") == 0 && depth > 0)
+            depth--;
+    }
+    return 0;
+}
+
 static int pass_fold_hl_base_const_offset(void)
 {
     int i;
@@ -877,6 +896,8 @@ static int pass_fold_hl_base_const_offset(void)
 
     changed = 0;
     for (i = 0; i + 2 < nlines; ++i) {
+        if (!input_is_dcc_generated || range_is_user_asm(i, i + 2))
+            continue;
         if (!parse_ld_hl_imm(lines[i], base))
             continue;
         if (base[0] == '(')
@@ -943,6 +964,8 @@ static int pass_fold_hl_label_word_deref(void)
 
     changed = 0;
     for (i = 0; i + 4 < nlines; ++i) {
+        if (!input_is_dcc_generated || range_is_user_asm(i, i + 4))
+            continue;
         if (!parse_ld_hl_imm(lines[i], label))
             continue;
         if (label[0] == '(')
@@ -9407,6 +9430,8 @@ static void read_file(const char *name)
 
     while (fgets(buf, sizeof(buf), f)) {
         trim(buf);
+        if (strcmp(buf, "; dcc stage-1d output") == 0)
+            input_is_dcc_generated = 1;
         if (nlines >= MAX_LINES) {
             fprintf(stderr, "too many lines\n");
             exit(1);


### PR DESCRIPTION
The pass_fold_hl_base_const_offset and pass_fold_hl_label_word_deref peepholes rewrote address-computation sequences without proving that DE and the flags set by `add hl,de` were dead afterward:

  ld hl,BASE / ld de,N / add hl,de   -> ld hl,BASE+N
  ld hl,LBL / ld e,(hl) / inc hl /
  ld d,(hl) / ex de,hl               -> ld hl,(LBL)

Both folds drop the final DE value (and, for the first, the H/N/C flags from add hl,de). For hand-written or inline assembly that observes DE or the carry after these sequences, that is a miscompile.

DCC's own code generator only emits these shapes where DE and the flags are scratch, so the fold is always safe on compiler output. Use that as the safety boundary instead of a post-hoc liveness scan (which was correct but rejected many safe generated patterns and regressed performance baselines):

  * flush_pending_asm() now brackets every inline #asm block with `; dcc user asm begin` / `; dcc user asm end` markers.
  * dccpeep detects the `; dcc stage-1d output` header to confirm the input is compiler-generated, and skips both folds for any line inside a user-asm region.

Hand-written .mac input and inline #asm are left untouched; all existing compiler-generated folds are preserved, so emitted binaries and performance baselines are byte-identical.

Validation: 307/307 apps pass, 106/106 diagnostics pass, performance check passes, tests/perf_baselines.csv unchanged.