### PR TITLE
build(dcc): adopt portable C11 host baseline and refresh source contr…

### DIFF
--- a/.github/skills/dcc-cpm-z80/SKILL.md
+++ b/.github/skills/dcc-cpm-z80/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dcc-cpm-z80
-description: 'Write, build, test, and debug C89/C99/C11-targeted code for the dcc compiler targeting CP/M 2.2 on the Z80 (run under the ntvcm Altair 8800 emulator). Use for .c/.h sources compiled with dcc, or tasks mentioning dcc, dccmake, C89, C99, C11, CP/M, CP/M 2.2, Z80, ntvcm, DCCRTL, or VT100/ANSI CP/M terminal apps. Treat dcc as standard C89 plus a first-class _Bool scalar type and target-appropriate C99/C11 front-end compatibility EXCEPT for the Z80/CP/M deviations this skill documents: no double or long long, 32-bit float as the only floating type, 16-bit int/short/pointer/size_t, 32-bit long, signed char, and a subset library/runtime. Full library/printf/scanf inventory and pitfalls are in the reference files.'
-argument-hint: 'Describe the C89/C99/C11 CP/M-Z80 task (write code, build, run under ntvcm, debug a failure)'
+description: 'Write, build, test, and debug C for dcc targeting CP/M 2.2 on the Z80 (run under the ntvcm Altair 8800 emulator). Use for .c/.h sources compiled with dcc, or tasks mentioning dcc, dccmake, C89, C99, C11, CP/M, Z80, ntvcm, DCCRTL, or VT100/ANSI terminal apps. Treat dcc as a C89-base compiler with documented selected C99/C11 features and Z80/CP/M deviations: no double or long long, 32-bit float as the only floating type, 16-bit int/short/pointer/size_t, 32-bit long, signed char, and a subset library/runtime. Full feature and library inventories are in the reference files.'
+argument-hint: 'Describe the dcc CP/M-Z80 task (write code, build, run under ntvcm, debug a failure)'
 ---
 
 # dcc C for CP/M 2.2 / Z80
@@ -10,12 +10,12 @@ dcc is a cross-compiler (runs on the host) that emits Z80 assembly for CP/M 2.2.
 The runtime is [DCCRTL.MAC](DCCRTL.MAC); programs run on real hardware or an
 emulator such as **ntvcm** (Altair 8800).
 
-**Assume standard C89 plus dcc's first-class `_Bool` scalar type and
-target-appropriate C99/C11 front-end compatibility.** dcc is not a hosted
+**Assume standard C89 plus the selected C99/C11 features documented by dcc.**
+dcc is not a hosted
 desktop C implementation: the CP/M 2.2 runtime, Z80 data model, and DCCRTL
-library subset are part of the compiler contract. Anything not listed here
-should be treated as ordinary C89/C99/C11, but CP/M/Z80 limits always win over
-host ABI expectations.
+library subset are part of the compiler contract. Do not assume an unlisted
+C99/C11 feature is supported; CP/M/Z80 limits always win over host ABI
+expectations.
 
 ## Compiler conformance level
 
@@ -31,7 +31,8 @@ host ABI expectations.
 
 ## When to use
 
-- Writing, porting, or reviewing C89/C99/C11 code compiled by `dcc`.
+- Writing, porting, or reviewing C89-base code using dcc's documented C99/C11
+  additions.
 - Building/running/debugging a dcc program (`dccmake`, `ntvcm`).
 - CP/M file I/O, VT100/ANSI console UIs, or DCCRTL work.
 

--- a/.github/skills/dcc-project/SKILL.md
+++ b/.github/skills/dcc-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dcc-project
-description: 'Develop, build, and test the dcc toolchain itself — the host programs dcc (C89/C99/C11 front end -> Z80/M80 assembler), dccpeep (peephole optimizer), and dccrtlstrip (runtime stripper), plus the DCCRTL.MAC Z80 runtime. Use when modifying or debugging compiler/optimizer/runtime sources under src/, running the regression suite (runall.ps1), building one app (dccmake), or rebuilding the host tools (build-dcc.ps1). NOT for writing ordinary C apps that target CP/M — use the dcc-cpm-z80 skill for that.'
+description: 'Develop, build, and test the dcc toolchain itself — the host programs dcc (C89-base front end with selected C99/C11 features -> Z80/M80 assembler), dccpeep (peephole optimizer), and dccrtlstrip (runtime stripper), plus the DCCRTL.MAC Z80 runtime. Use when modifying or debugging compiler/optimizer/runtime sources under src/, running the regression suite (runall.ps1), building one app (dccmake), or rebuilding the host tools (build-dcc.ps1). NOT for writing ordinary C apps that target CP/M — use the dcc-cpm-z80 skill for that.'
 argument-hint: 'Describe the dcc-project task (change codegen, run the test suite, build a single app, rebuild host tools)'
 ---
 
@@ -162,7 +162,7 @@ built AST tree to stderr before it is emitted.
 
 ## Rebuild the host tools after a source change
 
-For compiler-only edits, the fastest strict C89 build is:
+For compiler-only edits, the fastest host build is:
 
 ```sh
 sh src/dcc/build-dcc.sh
@@ -170,6 +170,11 @@ sh src/dcc/build-dcc.sh
 
 It links every `src/dcc/*.c`; when adding a module, also add it to the explicit
 `src/dcc/CMakeLists.txt` source list.
+
+The `dcc` implementation is host code, not code for the Z80 target. It may use
+portable C11 supported by modern Clang, GCC, and MSVC; do not constrain it to
+the language subset that dcc accepts as input. Keep vendor-only extensions
+behind platform guards.
 
 ```pwsh
 pwsh ./scripts/build-dcc.ps1            # MSVC on Windows, clang on macOS, gcc on Linux

--- a/docs/docs/en/appendix/00-architecture.md
+++ b/docs/docs/en/appendix/00-architecture.md
@@ -9,6 +9,10 @@ optimizer `dccpeep`, the runtime size reducer `dccrtlstrip`, and the Microsoft
   never run on a Z80. They emit Z80 assembly text and CP/M `.COM` files that
   run under CP/M-80, for example via the `ntvcm` emulator.
 
+  The compiler implementation is portable C11 host code built by modern Clang,
+  GCC, or MSVC. That implementation language is independent of `dcc`'s C89
+  base language and selected C99/C11 additions for the 16-bit Z80 target.
+
 ## The toolchain at a glance
 
 A single `.c` file becomes a CP/M `.COM` executable through a short pipeline.
@@ -34,7 +38,7 @@ flowchart LR
 
 | Stage | Tool | Input | Output | Role |
 | --- | --- | --- | --- | --- |
-| Compile | `dcc` | `.c` | `.MAC` | Translate the supported C89/C99/C11 subset to Z80/M80 assembly |
+| Compile | `dcc` | `.c` | `.MAC` | Translate C89 plus documented selected C99/C11 features to Z80/M80 assembly |
 | Optimize | `dccpeep` | `.MAC` | `.MAC` | Local peephole rewriting of the asm |
 | Reduce runtime | `dccrtlstrip` | `DCCRTL.MAC` + app `.MAC` | `RTLMIN.MAC` | Keep only the runtime routines the app references |
 | Assemble | `m80c` or `M80` | `.MAC` | `.REL` | Object code (relocatable); `dccmake` uses native `m80c` by default |
@@ -383,9 +387,9 @@ the runtime and rebuilding the docs is all that is needed to refresh them.
 
 ## Architecture summary
 
-- the DCC C Compiler is an **AST-driven** compiler for its supported
-  C89/C99/C11 subset, with direct lowering from typed function-body AST nodes
-  to Z80/M80 assembly.
+- the DCC C Compiler is an **AST-driven** C89-base compiler with selected
+  C99/C11 additions, with direct lowering from typed function-body AST nodes to
+  Z80/M80 assembly.
 - Typed AST expression nodes drive mixed-width (16/32-bit, pointer, float)
   codegen decisions from the tree being emitted.
 - Machine-dependent optimization is split out into **`dccpeep`**, a

--- a/scripts/build-dcc.ps1
+++ b/scripts/build-dcc.ps1
@@ -315,12 +315,12 @@ function Build-UnixNative {
     $baseCflags = if ($env:CFLAGS) {
         @($env:CFLAGS -split "\s+" | Where-Object { $_ })
     } else {
-        # Host build tools (run on the dev machine, not the Z80 target), so
-        # gnu89 is fine and lets glibc declare snprintf/etc. under C89.
+        # Host build tools run on the development machine, not the Z80 target.
+        # Use the same portable C11 baseline as the Windows/MSVC build.
         # -w suppresses compiler warnings for a quiet default build. -g
         # matches the Windows path's /Zi: debug symbols by default even in
         # an optimized build.
-        @("-std=gnu89", "-w", "-O2", "-g")
+        @("-std=c11", "-w", "-O2", "-g")
     }
     if ($IsMacOS -and ($baseCflags -notcontains "-fno-common")) {
         $baseCflags += "-fno-common"

--- a/src/dcc/CMakeLists.txt
+++ b/src/dcc/CMakeLists.txt
@@ -13,8 +13,9 @@
 cmake_minimum_required(VERSION 3.10)
 project(dcc C)
 
-set(CMAKE_C_STANDARD 90)
+set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
@@ -29,6 +30,7 @@ set(DCC_SOURCES
     dcc_diag_emit.c
     dcc_preproc.c
     dcc_pp_expr.c      # preprocessor #if/#elif expression evaluator
+    dcc_global_scan.c  # whole-file global write/address pre-scan
     dcc_types.c
     dcc_constexpr.c
     dcc_symbols.c
@@ -43,6 +45,9 @@ set(DCC_SOURCES
     dcc_func.c
     dcc_global_init.c   # file-scope object initializer parsing (split from dcc_func.c)
     dcc_regalloc.c      # speculative no-IX / BC-regalloc codegen (split from dcc_func.c)
+    dcc_loop_regalloc.c # loop-scoped BC register allocation
+    dcc_array_narrow.c  # conservative byte-narrowing proof
+    dcc_licm.c          # loop-invariant code motion / CSE
     dcc_data.c
     dcc_ast.c           # function-local AST (arena + nodes)
     dcc_ast_build.c     # function-local AST builder

--- a/src/dcc/README.md
+++ b/src/dcc/README.md
@@ -1,7 +1,9 @@
 # dcc — modularised compiler source
 
-`dcc` is a tiny bootstrap C89 compiler that targets Z80 assembly for the
-Microsoft M80 / LINK-80 toolchain on CP/M-80. This directory holds the
+`dcc` is a compact C compiler with a C89 base language plus selected C99 and
+C11 features that fit the CP/M/Z80 target. It emits Z80 assembly for the
+M80-compatible CP/M toolchain. The compiler implementation is portable C11 host
+code built with modern Clang, GCC, or MSVC. This directory holds the
 **modularised** form of the compiler: the original ~18.8k-line single file was
 split into focused, separately compiled modules — one `.c` per subsystem plus a
 shared umbrella header — so that both human and agentic developers can navigate
@@ -18,9 +20,8 @@ and modify one subsystem at a time.
 `dcc` now lowers function bodies through a **function-local AST**. The parser
 builds typed statement/expression trees for function bodies, then the AST
 walker emits Z80 assembly by calling shared low-level emit helpers. The compiler
-still shares a large amount of file-scope state, so the modules are organised
-the way a classic single-binary C compiler is: **one umbrella header that every
-module includes**, rather than many small per-module headers.
+still shares foundational types/state through `dcc.h`; focused AST,
+preprocessor, and register-allocation contracts use internal headers.
 
 - [`dcc.h`](dcc.h) is the umbrella header. It declares everything shared:
   capacity macros, the type/storage/token constants, the core record types
@@ -211,8 +212,8 @@ cmake -S src/dcc -B build/dcc
 cmake --build build/dcc      # also writes ./dcc at the repo root
 ```
 
-Both compile every module (`dcc.c`, `dcc_state.c`, and the `dcc_*.c` files) with
-`-std=c89 -Wall -Wextra -O2` and link them into `./dcc` at the repository root,
+Both compile every module (`dcc.c`, `dcc_state.c`, and the `dcc_*.c` files) as
+portable C11 and link them into `./dcc` at the repository root,
 matching the conventions the `ma.sh` / `runall.sh` harness expects. The
 companion tools `dccpeep` and `dccrtlstrip` are unchanged and are built by the
 existing root scripts (`mmacos.sh` / `m.sh`).
@@ -220,7 +221,7 @@ existing root scripts (`mmacos.sh` / `m.sh`).
 Override the compiler or flags via environment variables:
 
 ```sh
-CC=gcc CFLAGS="-std=c89 -O2" sh src/dcc/build-dcc.sh
+CC=gcc CFLAGS="-std=c11 -O2" sh src/dcc/build-dcc.sh
 ```
 
 > Note: linking may print `ld: warning: reducing alignment of section

--- a/src/dcc/build-dcc.sh
+++ b/src/dcc/build-dcc.sh
@@ -3,9 +3,8 @@
 # build-dcc.sh - build the modularised dcc compiler (separate compilation).
 #
 # Compiles each module translation unit (dcc.c and the dcc_*.c files, all of
-# which include the umbrella header dcc.h) and links them into the `dcc`
-# executable at the repo root, matching the flags used for the monolithic
-# build so the produced binary and its generated assembly are equivalent.
+# which include the shared dcc contracts) and links them into the `dcc`
+# executable at the repo root using the portable C11 host baseline.
 #
 # Usage (from anywhere):
 #   sh src/dcc/build-dcc.sh            # build ./dcc at the repo root
@@ -27,7 +26,7 @@ if [ -z "$CC" ]; then
         *)      CC=gcc ;;
     esac
 fi
-CFLAGS=${CFLAGS:--std=c89 -Wall -Wextra -O2 -g}
+CFLAGS=${CFLAGS:--std=c11 -Wall -Wextra -O2 -g}
 
 # On macOS, clang can emit large tentative definitions into __DATA,__common
 # with very high alignment (for large objects), which triggers an ld warning

--- a/src/dcc/dcc.c
+++ b/src/dcc/dcc.c
@@ -7,13 +7,13 @@
  * main(). The include search path (include_dirs/num_include_dirs, capped by
  * MAX_INCLUDE_DIRS) is kept module-local (static) here.
  *
- * MODULE: its own translation unit, linked with the other dcc_*.c modules;
- * all shared declarations come from the umbrella header dcc.h.
+ * MODULE: its own translation unit, using dcc.h plus the focused preprocessor
+ * and AST contracts.
  * Source provenance: monolith src/ddc.c lines 17975-18841.
  */
 
 /*
- * realpath() is a POSIX extension: under strict -std=c89, glibc/libc headers
+ * realpath() is a POSIX extension: under strict ISO C mode, glibc/libc headers
  * don't declare it in <stdlib.h> unless a feature-test macro asks for it
  * (_POSIX_C_SOURCE 200809L alone isn't enough on this glibc; _DEFAULT_SOURCE
  * is). Without a prototype in scope, C89's implicit-int rule assumes

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -1,15 +1,15 @@
 /*
- * dcc.h - umbrella header for the modularised dcc compiler.
+ * dcc.h - foundational shared contract for the modular dcc compiler.
  *
- * dcc is a tiny bootstrap C89 compiler that targets Z80 assembly for the
- * Microsoft M80 / LINK-80 toolchain on CP/M-80. Function bodies are lowered
- * through a function-local AST, while the parser, AST builder, and codegen
- * helpers still share a large amount of file-scope state. Because of that
- * tight coupling, the separate-compilation layout uses ONE shared header (this
- * file) included by every module's .c, in the spirit of a classic
- * single-binary C compiler.
+ * dcc uses C89 as its base language plus selected C99/C11 features suitable
+ * for CP/M/Z80, and emits Z80 assembly for the M80-compatible toolchain.
+ * Function bodies lower through a typed,
+ * function-local AST. This header holds broadly shared target constants, core
+ * records, state declarations, and cross-module APIs; narrower contracts live
+ * in dcc_ast_gen_internal.h, dcc_preproc_internal.h, and
+ * dcc_regalloc_internal.h.
  *
- * This header declares everything the modules agree on:
+ * This foundational contract includes:
  *   1. System headers used across the compiler.
  *   2. Capacity / translation-limit macros (MAX_*).
  *   3. Type-kind, storage-class and token-kind constants.
@@ -17,10 +17,10 @@
  *      StructDef, ConstVal, ByteOperand).
  *   5. `extern` declarations for the shared global state (defined once in
  *      dcc_state.c).
- *   6. Prototypes for every cross-module function, grouped by owning module.
+ *   6. Broadly used cross-module functions, grouped by owning module.
  *
  * Module .c files and their responsibilities:
- *   dcc_state.c     definitions of the shared globals declared extern below
+ *   dcc_state.c     definitions of cross-module compiler state
  *   dcc_asmname.c   C identifier -> M80 assembler symbol mapping
  *   dcc_diag_emit.c diagnostics, allocation, emit primitives, char input
  *   dcc_preproc.c   preprocessor + macro engine + lexer (next_token)
@@ -29,21 +29,25 @@
  *   dcc_constexpr.c integer constant-expression parser
  *   dcc_symbols.c   symbol tables + symbol-access codegen + EXTRN
  *   dcc_fold.c      constant folding + sizeof/offsetof
- *   dcc_expr.c      expression codegen (primary/unary/calls/fast paths)
+ *   dcc_expr.c      declarator parsing + low-level expression emit helpers
  *   dcc_cmp.c       comparison + conditional-branch codegen
  *   dcc_ops.c       binary-operator / arithmetic codegen
- *   dcc_assign.c    assignment, float r-values, gen_expr entry points
- *   dcc_stmt_fast.c statement-level fast-path idioms
+ *   dcc_assign.c    float constants + global byte-array address helper
+ *   dcc_stmt_fast.c in-place increment/decrement address helper
  *   dcc_decl.c      local declaration + initializer codegen
- *   dcc_stmt.c      statement codegen (if/while/for/switch/...)
- *   dcc_func.c      function + top-level declaration parsing
+ *   dcc_stmt.c      token-to-AST statement bridge + switch helpers
+ *   dcc_func.c      functions/top-level declarations + inline-body capture
  *   dcc_global_init.c file-scope object initializer parsing (record path)
  *   dcc_regalloc.c  speculative no-IX / BC-register-allocation codegen
+ *   dcc_loop_regalloc.c loop-scoped BC register allocation
+ *   dcc_global_scan.c whole-file lexical global-write/address scan
+ *   dcc_array_narrow.c conservative byte-narrowing proof
+ *   dcc_licm.c      loop-invariant code motion and loop-local CSE
+ *   dcc_ast*.c      function-local AST storage, building, gates and emission
  *   dcc_data.c      data-section emission
  *   dcc.c           driver: file I/O, #include, CLI, and main()
  *
- * A small amount of state is intentionally NOT declared here because it is
- * private to a single module and kept `static` there:
+ * Examples of state intentionally kept private to its owner:
  *   - pp_expr_p / pp_expr_depth        (dcc_pp_expr.c: #if expression cursor)
  *   - include_dirs / num_include_dirs  (dcc.c: include search path)
  */
@@ -310,6 +314,9 @@ typedef struct DeclState {
     int is_register;
 } DeclState;
 
+/* Destination role is metadata, not suppression: VERIFY sinks may still need
+ * raw formatted writes while scan_mode is active so their text can be read
+ * back for a commit/decline decision. */
 enum EmitSinkPurpose {
     EMIT_SINK_FINAL,
     EMIT_SINK_DISCARD,

--- a/src/dcc/dcc_array_narrow.c
+++ b/src/dcc/dcc_array_narrow.c
@@ -1,57 +1,14 @@
 /*
- * dcc_array_narrow.c - detect int arrays whose every stored element value is
- * provably in [0,255], so their declared element type can be narrowed to
- * unsigned char before normal codegen runs.
+ * dcc_array_narrow.c - conservative proof engine for narrowing eligible local
+ * int arrays, register scalars, and for-loop counters to unsigned char.
  *
- * Byte arrays are already a completely ordinary, fully-supported C
- * construct in dcc - narrowing an array's type is the entire fix; no new
- * codegen is needed, since type_index_elem_size() and friends already
- * derive addressing arithmetic from the element type dynamically. The hard
- * part, and the only thing this file does, is proving the narrowing is
- * safe.
- *
- * Two independent questions have to be answered, both by lexical/AST
- * scanning rather than symbol-table-based analysis (matching
- * dcc_global_scan.c's approach for the analogous whole-file question):
- *
- *   1. Does this array's name ever escape as a bare pointer (passed to a
- *      function, assigned to a pointer, etc.)? If so, some other code this
- *      scan cannot see might store an unbounded value through it, so
- *      narrowing is declined outright. A bare occurrence of the name not
- *      immediately followed by '[' is treated as an escape.
- *
- *   2. Is every value ever stored into the array provably in [0,255]? This
- *      needs both an upper bound *and* non-negativity - storing a negative
- *      int into unsigned char wraps to a large positive value, which is not
- *      the same value read back, so an upper-bound-only proof is not
- *      sufic.ient. Values that are themselves expressions referencing other
- *      local scalars (not just literals) require bounding those scalars
- *      too, by tracing every place they are reassigned within the same
- *      scope - which can require mutual reasoning (variable X's bound
- *      depends on array A's values, and A's bound depends on X), handled
- *      by hypothesize-then-verify: assume every name in the dependency
- *      closure has the target property, then check every reassignment site
- *      for every name in the closure is consistent with that assumption.
- *      This is a coinductive safety argument, not an inductive one - it is
- *      valid because the property being checked (nonneg-and-bounded) is
- *      preserved by the recognized operators, not because it needs a base
- *      case to build up from.
- *
- * The rule set for "is this expression nonneg and bounded by K" is
- * deliberately small and conservative: literals, +, *, / (bound derived
- * from operands, with / requiring a positive divisor), % (bounded by the
- * divisor's own bound minus 1, and only when the dividend is separately
- * proven nonneg), a bare reference to another name in the assumption set,
- * an index into an array in the assumption set, and a call to a
- * no-argument function whose entire body is a single return statement
- * (recursively bounded the same way). Anything else - unrecognized
- * operators, a variable outside the same function, a function with
- * parameters or a body of more than one statement - is an unconditional
- * decline, never a guess: this can only under-narrow (miss an
- * optimization), never over-narrow (corrupt a value), which is the
- * required safety direction throughout this codebase's other lexical
- * scans (see local_name_used_ahead, local_name_address_taken_ahead,
- * scan_global_write_info).
+ * The proof checks that every stored value is non-negative and <=255 and that
+ * no writable alias escapes its scope. Dependencies are discovered
+ * coinductively, then every write is verified against the small supported rule
+ * set (literals, bounded arithmetic, group references, array reads, and simple
+ * no-argument calls). Unknown shapes, aliases, recursive calls, or exhausted
+ * limits decline narrowing; they never guess. Normal byte codegen then handles
+ * accepted candidates without a separate lowering path.
  */
 
 #include "dcc.h"
@@ -1098,6 +1055,9 @@ static int narrow_is_byte_safe_impl(const struct AstNode *scope, const char *nam
     return 1;
 }
 
+/* Proves all visible writes preserve [0,255] and no writable alias escapes.
+ * Returns 0 conservatively for any unsupported, recursive, or over-limit
+ * shape; callers must then keep the original 16-bit representation. */
 int narrow_array_is_byte_safe(const struct AstNode *scope, const char *arr_name)
 {
     return narrow_is_byte_safe_impl(scope, arr_name, 1);

--- a/src/dcc/dcc_assign.c
+++ b/src/dcc/dcc_assign.c
@@ -3,7 +3,7 @@
  *
  * Low-level primitives the AST emitter calls while lowering assignments and
  * float values: emit_load_float_bits materialises a 32-bit float constant into
- * the HL:DE register pair, and emit_global_byte_array_index_addr computes the
+ * the DE:HL register pair, and emit_global_byte_array_index_addr computes the
  * address of a byte-array element at a global symbol (constant or ix-relative
  * index). Assignment statement/expression lowering itself lives in the AST
  * emitter (dcc_ast_gen*.c).

--- a/src/dcc/dcc_ast.c
+++ b/src/dcc/dcc_ast.c
@@ -1,12 +1,10 @@
 /*
  * dcc_ast.c - function-local AST: arena allocator and node constructors.
  *
- * See dcc_ast.h for the design rationale.  This module is intentionally
- * self-contained: it depends only on the umbrella header dcc.h for the
- * xmalloc/fatal helpers and the struct Sym definition, and it does not yet
- * participate in code generation.  It is compiled and linked so the data
- * structures and their invariants can be exercised as the AST migration
- * proceeds construct by construct.
+ * See dcc_ast.h for the design rationale. This module owns arena block
+ * allocation, reset/destruction, string/memory copies, node construction, and
+ * small AST query helpers. Parsing and emission live in dcc_ast_build.c and
+ * dcc_ast_gen*.c.
  */
 #include "dcc.h"
 #include "dcc_ast.h"

--- a/src/dcc/dcc_ast.h
+++ b/src/dcc/dcc_ast.h
@@ -8,7 +8,7 @@
  * tables) - hence "function-local".
  *
  * Design constraints:
- *   - C89 source (the host compiler builds dcc as -std=c89).
+ *   - Portable C11 source for modern Clang, GCC, and MSVC host compilers.
  *   - Must be able to drive the shared emit_* helpers,
  *     so the AST records exactly the information those helpers need (resolved
  *     struct Sym*, dcc type codes, operator token kinds, folded literals).

--- a/src/dcc/dcc_ast_build.c
+++ b/src/dcc/dcc_ast_build.c
@@ -7,10 +7,11 @@
  * source grammar (including dcc's C99 conveniences -
  * it operates purely on the token stream, so for-init/mid-block expressions
  * and // comments are handled transparently by the shared lexer).  It builds
- * an AstNode tree from the current lexer position by calling next_token(); it
- * never emits, interns strings, or allocates symbols, so the only global state
- * it touches is the lexer cursor.  The AST emitter consumes the built tree;
- * unsupported shapes are compiler errors in normal codegen.
+ * an AstNode tree from the current lexer position and emits no assembly.
+ * Compound-literal and optimization shapes may reserve compiler-generated
+ * locals while building, so speculative callers must restore lexer/frame state
+ * when discarding a tree. The AST emitter consumes the result; unsupported
+ * shapes are compiler errors in normal codegen.
  */
 #include "dcc.h"
 #include "dcc_ast.h"

--- a/src/dcc/dcc_ast_gen_internal.h
+++ b/src/dcc/dcc_ast_gen_internal.h
@@ -1,7 +1,8 @@
 /*
- * dcc_ast_gen_internal.h - internal prototypes shared across the
- * dcc_ast_gen* translation units.  Generated from the function
- * definitions; do not include outside the AST codegen module.
+ * dcc_ast_gen_internal.h - private contract shared by dcc_ast_gen*.c.
+ *
+ * Contains AST shape classifiers, emit helpers, and switch/codegen state.
+ * Do not include it outside the AST codegen module.
  */
 #ifndef DCC_AST_GEN_INTERNAL_H
 #define DCC_AST_GEN_INTERNAL_H

--- a/src/dcc/dcc_decl.c
+++ b/src/dcc/dcc_decl.c
@@ -5,7 +5,8 @@
  * arrays, structs/unions and bitfields, brace-enclosed initializer lists, and
  * const-scalar folding of local initializers into immediates.
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
+ * MODULE: compiled as its own translation unit; E-register allocation state is
+ * declared in dcc_regalloc_internal.h.
  * Source provenance: monolith src/ddc.c lines 13128-13991.
  */
 

--- a/src/dcc/dcc_diag_emit.c
+++ b/src/dcc/dcc_diag_emit.c
@@ -2,17 +2,20 @@
  * dcc_diag_emit.c - diagnostics, allocation, and low-level emit primitives.
  *
  * The compiler's "plumbing": fatal()/error_here() error reporting,
- * source_location_at() for #line-aware positions, xmalloc/xstrdup2, label
- * allocation, the emit()/emit_label()/emit_jp_label() assembly-output
- * primitives, and the raw source character readers (peekc/getc_src).
+ * source_location_at() for #line-aware positions, allocation and checked
+ * stream-reading helpers, EmitSink switching, assembly-output primitives, and
+ * raw source character readers (peekc/getc_src).
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
+ * MODULE: compiled as its own translation unit; macro helpers used for source
+ * rendering are declared in dcc_preproc_internal.h.
  * Source provenance: monolith src/ddc.c lines 495-691.
  */
 
 #include "dcc.h"
 #include "dcc_preproc_internal.h"
 
+/* Starts a nestable output scope and returns the complete previous sink. Every
+ * successful push must be paired with emit_sink_restore on every exit path. */
 EmitSink emit_sink_push(FILE *stream, int purpose)
 {
     EmitSink saved;
@@ -441,6 +444,8 @@ char *xstrdup2(const char *s)
     return p;
 }
 
+/* Returns a NUL-terminated copy and leaves stream at EOF. Callers that need to
+ * read the stream again must rewind it. */
 char *dcc_read_stream_text(FILE *stream, long *size_out, const char *error_msg)
 {
     long size;

--- a/src/dcc/dcc_expr.c
+++ b/src/dcc/dcc_expr.c
@@ -1,12 +1,10 @@
 /*
- * dcc_expr.c - expression code generation (core).
+ * dcc_expr.c - low-level expression/declarator parsing and emit helpers.
  *
-    if (!accept('*')) {
- * through HL, struct copies, cast detection and numeric conversions
- * (byte/int/long/float), bitfield extract/insert, pre/post increment-decrement,
- * and function-call stack cleanup. Also holds declaration-side parsing helpers
- * (sizeof operands, function-pointer and array declarators, initializer-atom
- * counting, enum constants, and user-label bookkeeping).
+ * Implements memory loads/stores through HL, struct copies, conversions,
+ * bitfield access, increment/decrement, and call cleanup used by the AST
+ * emitter. It also parses sizeof operands, function-pointer/array declarators,
+ * initializer atoms, enum constants, and user-label bookkeeping.
  *
  * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
  * Source provenance: monolith src/ddc.c lines 5373-8841.

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -2,18 +2,20 @@
  * dcc_func.c - function and top-level declaration parsing.
  *
  * Parameter lists (prototype and K&R old-style), function prologue/epilogue
- * and frame layout, the function-body scan, typedef declarations, and
+ * and frame layout, inline/narrowing candidate capture, the function-body scan,
+ * typedef declarations, and
  * top-level declaration dispatch (parse_function_or_global,
  * parse_translation_unit). File-scope initializer parsing is in
  * dcc_global_init.c.
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
+ * MODULE: compiled as its own translation unit; speculative codegen entry
+ * points are declared in dcc_regalloc_internal.h.
  * Source provenance: monolith src/ddc.c lines 15880-17705.
  */
 
 #ifndef _WIN32
 /* fileno()/ftruncate() (used by emit_function_epilogue's dead-tail-jump
- * elision) are POSIX, not ISO C89, so -std=c89 hides their declarations in
+ * elision) are POSIX, so strict ISO C mode hides their declarations in
  * <stdio.h>/<unistd.h> unless a POSIX feature-test macro is visible before
  * those headers are first included - which happens via dcc.h below, so this
  * must come first. */
@@ -853,11 +855,8 @@ static void bump_ident_count(const char *name)
     if (g_ident_count_n < MAX_IDENT_COUNTS) {
         /* Manual bounded copy, not strncpy: name (63+NUL) is far smaller than
          * a token's text (MAX_TOK_TEXT, 512), and GCC's fortify source flags
-         * that size disparity on strncpy as a possible truncation-without-
-         * termination bug even though the following assignment already
-         * null-terminates. snprintf would sidestep the warning but is C99,
-         * and this project builds its own source as strict C89
-         * (build-dcc.sh's default CFLAGS: -std=c89). */
+         * that size disparity as possible truncation despite the explicit
+         * terminator below. */
         size_t namelen = strlen(name);
         size_t cap = sizeof(g_ident_counts[0].name) - 1;
         if (namelen > cap) namelen = cap;

--- a/src/dcc/dcc_global_init.c
+++ b/src/dcc/dcc_global_init.c
@@ -1,8 +1,7 @@
 /*
  * dcc_global_init.c - file-scope (global/static) object initializer parsing.
  *
- * Split out of dcc_func.c (architectural-review item §5). This module parses a
- * global object's initializer from the token stream and RECORDS the resulting
+ * Parses a global object's initializer from the token stream and records the
  * initialized-data image (bytes + relocatable label references) on the symbol,
  * for later emission by the data section. It is the "record" counterpart to
  * dcc_decl.c's "emit" path for automatic (local) initializers.

--- a/src/dcc/dcc_preproc.c
+++ b/src/dcc/dcc_preproc.c
@@ -6,7 +6,8 @@
  * handling, and the main tokenizer next_token() that feeds the parser. The
  * #if expression evaluator lives in dcc_pp_expr.c.
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
+ * MODULE: compiled as its own translation unit; macro-table entry points shared
+ * with the driver/evaluator are declared in dcc_preproc_internal.h.
  * Source provenance: monolith src/ddc.c lines 692-2871.
  */
 

--- a/src/dcc/dcc_preproc_internal.h
+++ b/src/dcc/dcc_preproc_internal.h
@@ -1,3 +1,5 @@
+/* dcc_preproc_internal.h - macro-table and #if evaluator contract shared by
+ * the driver, preprocessor, diagnostics, and dcc_pp_expr.c. */
 #ifndef DCC_PREPROC_INTERNAL_H
 #define DCC_PREPROC_INTERNAL_H
 

--- a/src/dcc/dcc_regalloc.c
+++ b/src/dcc/dcc_regalloc.c
@@ -2,22 +2,23 @@
  * dcc_regalloc.c - speculative no-IX-frame and BC-register-allocation codegen.
  *
  * Speculative function-body generation passes that opportunistically emit a
- * tighter prologue/epilogue: omitting the IX frame pointer for leaf functions
- * with no local storage, and allocating a loop induction/pointer variable to
- * the BC (and optionally E) register. Each pass generates the body into a
- * scratch buffer, validates the result, and either keeps it or rewinds and
- * falls back to the ordinary IX-framed codegen.
+ * tighter prologue/epilogue: omitting IX for eligible leaf functions and
+ * keeping an eligible read-only word in BC (optionally with an E-register
+ * counter). It also orchestrates the loop-scoped BC trial implemented in
+ * dcc_loop_regalloc.c. Each pass generates into a verification sink, then
+ * commits or restores parser/frame state and falls back to ordinary codegen.
  *
  * Carved out of dcc_func.c; entry points are called from
  * parse_function_or_global. find_bc_regalloc_candidate and
  * plain_static_body_can_be_buffered remain in dcc_func.c.
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
+ * MODULE: compiled as its own translation unit; optimizer-only contracts are
+ * declared in dcc_regalloc_internal.h.
  */
 
 #ifndef _WIN32
-/* fileno()/ftruncate() (scratch-buffer management) are POSIX, not ISO C89, so
- * -std=c89 hides their declarations unless a POSIX feature-test macro is
+/* fileno()/ftruncate() (scratch-buffer management) are POSIX, so strict ISO C
+ * mode hides their declarations unless a POSIX feature-test macro is
  * visible before <stdio.h>/<unistd.h> are first included via dcc.h below. */
 #define _POSIX_C_SOURCE 200809L
 #endif

--- a/src/dcc/dcc_regalloc_internal.h
+++ b/src/dcc/dcc_regalloc_internal.h
@@ -1,3 +1,5 @@
+/* dcc_regalloc_internal.h - private state and entry points shared by
+ * speculative whole-function/loop register allocation and its callers. */
 #ifndef DCC_REGALLOC_INTERNAL_H
 #define DCC_REGALLOC_INTERNAL_H
 
@@ -10,6 +12,9 @@ extern int g_e_regalloc_claimed;
 extern struct Sym *g_e_regalloc_sym;
 extern int g_loop_regalloc_bc_claimed;
 
+/* Verifies generated text in `f`. On success, returns 1 and transfers a newly
+ * allocated, rewound commit stream through out_f; the caller owns that FILE.
+ * On failure, returns 0 and leaves out_f untouched. */
 int regalloc_buffer_finalize(FILE *f, struct Sym *bc_cand, struct Sym *e_cand,
                              FILE **out_f);
 int bc_regalloc_entry_lines(struct Sym *cand, char lines[3][40]);
@@ -27,6 +32,9 @@ struct Sym *find_bc_regalloc_candidate(int params_end);
 int plain_static_body_can_be_buffered(struct Sym *s, const char *name);
 int function_qualifies_for_speculative_noix(const char *name, int local_bytes);
 int function_qualifies_for_speculative_regalloc(const char *name);
+/* Trial generators return 1 only after committing a complete body to the
+ * current sink. A 0 return means the caller must emit the normal fallback;
+ * declined trials restore lexer/frame/function-pass state before returning. */
 int try_speculative_noix_function_body(const char *name, int type,
                                        int local_bytes, struct Sym *s,
                                        long body_start_pos, long body_start_tok_start,

--- a/src/dcc/dcc_state.c
+++ b/src/dcc/dcc_state.c
@@ -1,19 +1,15 @@
 /*
  * dcc_state.c - definitions of the shared mutable state for the dcc compiler.
  *
- * MODULE: its own translation unit. This file DEFINES the compiler's
- * file-scope globals; every other module references them through the matching
- * `extern` declarations in the umbrella header dcc.h.
+ * Defines cross-module compiler state declared in dcc.h and focused internal
+ * headers. Truly module-local state remains static in its owning file.
  *
  * Why dcc keeps so much shared state: parser, AST builder, and codegen helpers
  * share a large amount of "current position" state (the source buffer, the
  * lookahead token, the symbol tables, per-function codegen flags, ...).
- * Keeping all of it in one place, declared once in dcc.h, lets the modules
- * cooperate without threading the state through every call.
- *
- * Intentionally NOT here (kept private/static to one module for locality):
- *   - pp_expr_p / pp_expr_depth        -> dcc_preproc.c (#if expression cursor)
- *   - include_dirs / num_include_dirs  -> dcc.c (include search path)
+ * Related live fields are grouped by lifecycle in LexState, FrameState,
+ * ExprState, FunctionPassState, DeclState, and EmitSink rather than exposed as
+ * independent scalars.
  *
  * Source provenance: monolith src/ddc.c lines 199-203, 347-348, 378-489.
  */

--- a/src/dcc/dcc_symbols.c
+++ b/src/dcc/dcc_symbols.c
@@ -6,7 +6,8 @@
  * code that loads/stores a symbol's address or value (frame-relative or direct
  * for globals), including post-increment/decrement fast paths.
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
+ * MODULE: compiled as its own translation unit; register-allocation escape
+ * state is declared in dcc_regalloc_internal.h.
  * Source provenance: monolith src/ddc.c lines 3829-4801.
  */
 

--- a/src/dcc/toolchain-optimisations.md
+++ b/src/dcc/toolchain-optimisations.md
@@ -53,7 +53,7 @@ into **18 `.c` modules plus one umbrella header**, using true separate compilati
 
 - Largest unit any tool or developer must load drops from **18,841 → 3,482 lines** (~5.4×).
 - Build paths: `src/dcc/build-dcc.sh` and `src/dcc/CMakeLists.txt`.
-- Strict flags: `-std=c89 -Wall -Wextra -Werror=implicit-function-declaration -Werror=implicit-int`.
+- Host-language baseline: portable C11 across Clang, GCC, and MSVC.
 - Behaviour is byte-identical to the monolith (full regression green).
 
 ---

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,8 +1,8 @@
 # dcc test suite
 
-This folder holds the C source programs used to exercise the `dcc` C89 compiler
-(CP/M-80 / Z80 target) and its runtime, together with the expected-output
-baselines used to verify them.
+This folder holds C source programs used to exercise dcc's C89 base language,
+selected C99/C11 additions, CP/M-80/Z80 target model, and runtime, together with
+the expected-output baselines used to verify them.
 
 ## Layout
 


### PR DESCRIPTION
…acts

Separate the language used to implement the host compiler from the C subset that dcc accepts for the Z80 target. The dcc implementation may use portable C11 supported by modern Clang, GCC, and MSVC; it is not constrained to the target compiler's C89/C99/C11 feature subset.

Host build policy:
- Change the focused Clang/GCC build from C89 to C11.
- Change the Unix PowerShell build from GNU89 to C11.
- Keep the existing MSVC /std:c11 configuration.
- Configure CMake for required C11 with vendor extensions disabled.
- Add dcc_global_scan.c, dcc_loop_regalloc.c, dcc_array_narrow.c, and dcc_licm.c to CMake's explicit source list.
- Document that shared host code should remain portable across Clang, GCC, and MSVC, with vendor-only extensions guarded by platform checks.

Compiler source documentation:
- Audit all 37 C and header files under src/dcc.
- Refresh stale module headings and ownership descriptions.
- Remove obsolete AST-migration and architectural-review wording.
- Correct dcc_expr.c's corrupted opening comment.
- Correct the documented DE:HL register ordering.
- Describe lifecycle-grouped state and focused internal contracts.
- Add headings for the preprocessor and regalloc internal headers.
- Condense the narrowing overview while preserving its conservative proof and fallback guarantees.

Key function contracts:
- Document nestable EmitSink push/restore ownership.
- Clarify that sink purpose does not imply scan_mode suppression.
- Document dcc_read_stream_text buffer ownership and EOF positioning.
- Document narrowing proof failure semantics.
- Document regalloc verification stream ownership and speculative fallback requirements.

Project documentation:
- Update the dcc-project skill to distinguish host implementation language from target-language support.
- Update the MkDocs architecture appendix with the portable C11 host model.
- Update src/dcc README and toolchain notes to match current modules, internal headers, and build behavior.

Validation:
- Focused C11 compiler build passed with warnings enabled.
- Full PowerShell build compiled dcc, dccpeep, dccrtlstrip, dccmake, and m80c successfully.
- C89-built and C11-built dcc binaries produced 0 assembly differences across 316 tests and 0 diagnostic differences across 106 cases.
- CMake's explicit source list now covers every src/dcc/*.c module.
- MkDocs build --strict passed.
- No editor diagnostics or git diff whitespace errors.