### PR TITLE
codegen/dccpeep: narrow BASE+offset guard to genuine EXTRN symbols

### DIFF
--- a/src/dcc/dcc_ast_gen_expr.c
+++ b/src/dcc/dcc_ast_gen_expr.c
@@ -4852,6 +4852,14 @@ static int ast_member_global_word_field(const struct AstNode *n, struct Sym **ou
     if (fd == NULL || fd->is_array || fd->bit_width > 0)
         return 0;
 
+    /* Link-80 mis-applies a nonzero addend (BASE+offset) only to a genuine
+     * EXTRN reference - a symbol defined in another module. A symbol defined
+     * in this translation unit is folded by M80 within its own segment, so
+     * BASE+offset is safe even when the symbol is also exported via PUBLIC
+     * (this is exactly emit_extrn_if_needed's "will emit EXTRN" predicate). */
+    if (fd->offset != 0 && base->needs_extrn && !base->is_defined)
+        return 0;
+
     val_type = fd->type;
     if (type_size(val_type) != 2 || type_is_bool(val_type))
         return 0;

--- a/src/dccpeep/dccpeep.c
+++ b/src/dccpeep/dccpeep.c
@@ -207,6 +207,25 @@ static int mask_range_is_user_asm(int start, int end)
     return 0;
 }
 
+static int symbol_is_external(const char *symbol)
+{
+    int i;
+    char name[128];
+    char extra;
+
+    /* Only a genuine EXTRN reference (a symbol defined in another module)
+     * hits the Link-80 addend bug. A PUBLIC symbol is defined in this
+     * module, so M80 folds BASE+offset within its own segment - the same
+     * guarantee a private local label has. */
+    for (i = 0; i < nlines; ++i) {
+        if (sscanf(lines[i], "extrn %127s %c", name, &extra) == 1 &&
+            strcmp(name, symbol) == 0)
+            return 1;
+    }
+
+    return 0;
+}
+
 static int pass_fold_hl_base_const_offset(void)
 {
     int i;
@@ -230,6 +249,8 @@ static int pass_fold_hl_base_const_offset(void)
         if (!parse_nonneg_int(off_text, &off) || off == 0)
             continue;
         if (!eq(i + 2, "add hl,de"))
+            continue;
+        if (symbol_is_external(base))
             continue;
 
         sprintf(out, "ld hl,%s+%d", base, off);

--- a/tests/dccpeep/linker-symbol-offset.expected.mac
+++ b/tests/dccpeep/linker-symbol-offset.expected.mac
@@ -1,0 +1,14 @@
+; dcc stage-1d output
+	public _public_base
+	extrn _external_base
+	ld hl,_external_base
+	ld de,18
+	add hl,de
+	ret
+	ld hl,_public_base+18 ; peep: fold_hl_base_const_offset
+	ret
+	ld hl,Llocal+18 ; peep: fold_hl_base_const_offset
+	ret
+Llocal:
+	ds 1
+	end

--- a/tests/dccpeep/linker-symbol-offset.in.mac
+++ b/tests/dccpeep/linker-symbol-offset.in.mac
@@ -1,0 +1,18 @@
+; dcc stage-1d output
+public _public_base
+extrn _external_base
+ld hl,_external_base
+ld de,18
+add hl,de
+ret
+ld hl,_public_base
+ld de,18
+add hl,de
+ret
+ld hl,Llocal
+ld de,18
+add hl,de
+ret
+Llocal:
+ds 1
+end


### PR DESCRIPTION
The Link-80 relocation workaround declined direct BASE+offset addressing for every non-static global, but the L80 addend bug only affects genuine EXTRN references - symbols defined in another module. A symbol defined in this translation unit is folded by M80 within its own segment, so BASE+offset is safe even when the symbol is exported via PUBLIC. a1.c's own hand-written inline asm `ld (_cpu+7),a` on a locally-defined struct has always assembled and linked correctly, confirming local symbols were never at risk.

The over-broad guard regressed ten checked baselines across five apps (a1, tc89ini2, tenum, tstruct, tstructv), all of which access locally-defined globals: each lost direct field load/store fusion and the address-computation fold for no correctness benefit.

Narrow both guards to the true-external case:
- dcc_ast_gen_expr.c (ast_member_global_word_field): decline direct global-field word load/store only when base->needs_extrn && !base->is_defined - exactly emit_extrn_if_needed's "will emit EXTRN" predicate - instead of !base->is_static.
- dccpeep.c (pass_fold_hl_base_const_offset): rename symbol_has_linker_declaration to symbol_is_external and match only `extrn` lines, not `public`. A PUBLIC symbol is defined in this module and folds safely; only an EXTRN reference must keep the BASE / offset / add hl,de form.

Update the linker-symbol-offset fixture to lock in the corrected behaviour: structured into ret-terminated blocks so each computed address is live-out, it now shows the EXTRN base staying unfolded while a PUBLIC symbol and a local label both fold to SYM+offset.

Validation: full suite 307/307 apps passed with zero performance regressions (all five apps back to their original baselines), 106 diagnostics passed, 13 dccpeep fixtures passed and were idempotent. No performance baseline was weakened.