### PR TITLE
dcc MIR: support register-qualified objects

### DIFF
--- a/docs/docs/en/01-c-conformance.md
+++ b/docs/docs/en/01-c-conformance.md
@@ -49,7 +49,7 @@ portability surprises when code is moved from a hosted desktop compiler.
 | Function declarations and prototypes | Supported |
 | Old-style function declarations and definitions | Supported |
 | `typedef` | Supported |
-| Storage classes: `auto`, `extern`, `register`, `static` | Supported; `auto` is a no-op and `register` is only a hint |
+| Storage classes: `auto`, `extern`, `register`, `static` | Supported; `auto` is a no-op and `register` is an MIR allocation hint (see below) |
 | Type qualifiers: `const`, `volatile` | Accepted for source compatibility; no CP/M/Z80 memory-model semantics are provided |
 | Expressions and usual arithmetic conversions | Supported within the target type model |
 | `if`, `switch`, loops, `break`, `continue`, `goto`, `return` | Supported |
@@ -58,6 +58,32 @@ portability surprises when code is moved from a hosted desktop compiler.
 | `__FILE__`, `__LINE__`, `__DATE__`, `__TIME__`, `__STDC__` | Supported |
 | String literals and adjacent string literal concatenation | Supported |
 | Global and automatic initializers | Supported |
+
+### The `register` storage class
+
+`register` is an optimization hint for automatic objects and function
+parameters, including old-style parameter declarations. DCC preserves the
+hint through declaration parsing and MIR object promotion, and the MIR
+register allocator gives profitable register-backed values priority over
+otherwise-equivalent candidates. The allocator can still choose a stack home
+when calls, interference, value width, fixed operands, or transfer costs make
+that choice better, so the keyword does not guarantee a particular Z80
+register.
+
+Taking the address of a register-qualified object is a constraint violation:
+
+```c
+void example(void)
+{
+	register int value;
+	int *pointer = &value; /* error DCC-E0921 */
+}
+```
+
+The same rule applies in an unevaluated expression such as `sizeof &value`
+and to register-qualified function parameters. Arrays, aggregates, wide
+values, and values live across calls may remain in memory while still
+retaining these language semantics.
 
 ## Missing from C89
 
@@ -70,7 +96,6 @@ portability surprises when code is moved from a hosted desktop compiler.
 | Wide-character library behavior | Outside the CP/M 2.2 target model |
 | Read-only storage for `const` objects | Outside the CP/M 2.2 memory model |
 | Strict `volatile` memory/device access semantics | Outside the CP/M 2.2 memory model |
-| Forced register allocation from `register` | Not implemented |
 
 ## C99 additions
 

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -365,7 +365,11 @@ struct Sym {
     int is_volatile; /* object declared with the volatile qualifier: access-
                       * contracting fast paths must decline for it */
     int pointee_is_volatile; /* immediate pointed-to type is volatile */
-    int is_register; /* object declared with the register qualifier */
+    int is_register; /* object declared with the register qualifier: an MIR
+                      * allocation hint copied onto MirObject and consulted by
+                      * mir_allocate_registers to bias profitable
+                      * register-backed values ahead of otherwise equivalent
+                      * candidates - see mir_value_backs_declared_register_object. */
     int is_inline;   /* function declared with inline specifier */
     int is_noreturn; /* function declared with _Noreturn: licm_scan_modified
                       * (dcc_licm.c) tolerates a call to it in an otherwise-

--- a/src/dcc/dcc_ast_build.c
+++ b/src/dcc/dcc_ast_build.c
@@ -1217,8 +1217,8 @@ static struct AstNode *ast_build_decl_span(struct AstArena *ar)
             return NULL;
         /* C99/C11 6.8.5p3 permits only object declarations with storage class
          * auto or register in a for-init declaration.  dcc treats auto/register
-         * as ordinary automatic locals (no Z80 register allocation - the hint
-         * is a no-op, exactly as in block scope), so they are accepted.  The
+         * as automatic locals; `register` remains an allocation hint, exactly
+         * as in block scope.  The
          * remaining explicit storage classes and function specifiers
          * (static/extern/typedef/inline) are rejected here; direct function and
          * type/tag-only declarations are caught separately during replay. */

--- a/src/dcc/dcc_diag_emit.c
+++ b/src/dcc/dcc_diag_emit.c
@@ -119,6 +119,7 @@ const char *dcc_diag_code_for_message(const char *msg)
     if (dcc_msg_has(msg, "wide string cannot initialize char array")) return "DCC-E0914";
     if (dcc_msg_has(msg, "bitfield initializer must be constant integer")) return "DCC-E0915";
     if (dcc_msg_has(msg, "incompatible integer to pointer assignment")) return "DCC-E0920";
+    if (dcc_msg_has(msg, "cannot take address of register object")) return "DCC-E0921";
     if (dcc_msg_has(msg, "unsupported sizeof expression")) return "DCC-E1001";
     if (dcc_msg_has(msg, "unsupported")) return "DCC-E1002";
     if (dcc_msg_has(msg, "malformed")) return "DCC-E1003";

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -1333,6 +1333,7 @@ void parse_old_style_param_id_list(void)
 void parse_old_style_param_declarations(void)
 {
     int base;
+    int base_is_register;
     int base_is_volatile;
     int base_pointee_is_volatile;
     int type;
@@ -1341,6 +1342,7 @@ void parse_old_style_param_declarations(void)
 
     while (g_lex.tok.kind != TOK_EOF && g_lex.tok.kind != '{' && starts_type()) {
         base = parse_base_type();
+        base_is_register = g_decl.is_register;
         base_is_volatile = g_decl.is_volatile;
         base_pointee_is_volatile = g_decl.pointee_is_volatile;
 
@@ -1377,6 +1379,7 @@ void parse_old_style_param_declarations(void)
             } else {
                 int pi;
                 s->type = type;
+                s->is_register = base_is_register;
                 s->is_volatile = g_decl.is_volatile;
                 s->pointee_is_volatile = g_decl.pointee_is_volatile;
                 if (g_ptr_array_dim_count > 0) {
@@ -1489,6 +1492,7 @@ void parse_param_list(void)
             add_param_alloc(name, type);
             ps = find_local(name);
             if (ps != NULL) {
+                ps->is_register = g_decl.is_register;
                 ps->is_volatile = g_decl.is_volatile;
                 ps->pointee_is_volatile = g_decl.pointee_is_volatile;
             }

--- a/src/dcc/dcc_mir.c
+++ b/src/dcc/dcc_mir.c
@@ -1719,6 +1719,34 @@ static void mir_set_node_memory(struct MirInsn *insn,
         insn->memory_flags |= 4;
 }
 
+static int mir_reject_register_address(const struct AstNode *node)
+{
+    int index;
+
+    if (node == NULL)
+        return 0;
+    if (node->kind == AST_UNARY && node->op == '&' &&
+        node->a != NULL && node->a->kind == AST_IDENT) {
+        struct Sym *symbol = mir_ident_symbol(node->a);
+
+        if (symbol != NULL && symbol->is_register) {
+            dcc_error_at(node->file, node->line, -1,
+                         "cannot take address of register object",
+                         mir_ident_name(node->a));
+            return 1;
+        }
+    }
+    if (mir_reject_register_address(node->a) ||
+        mir_reject_register_address(node->b) ||
+        mir_reject_register_address(node->c) ||
+        mir_reject_register_address(node->d))
+        return 1;
+    for (index = 0; index < node->list_len; ++index)
+        if (mir_reject_register_address(node->list[index]))
+            return 1;
+    return 0;
+}
+
 static int mir_lower_lvalue_address(const struct AstNode *node)
 {
     struct MirInsn *insn;
@@ -1732,6 +1760,11 @@ static int mir_lower_lvalue_address(const struct AstNode *node)
     if (node->kind == AST_IDENT) {
         const char *name = mir_ident_name(node);
         symbol = mir_ident_symbol(node);
+        if (symbol != NULL && symbol->is_register) {
+            dcc_error_at(node->file, node->line, -1,
+                         "cannot take address of register object", name);
+            return -1;
+        }
         value = mir_new_value();
         insn = mir_emit(MIR_ADDRESS);
         insn->dst = value;
@@ -2123,6 +2156,8 @@ static int mir_lower_expr(const struct AstNode *node)
     case AST_SIZEOF_EXPR:
         {
             struct Sym *vla = ast_sizeof_whole_vla_sym(node->a);
+            if (mir_reject_register_address(node->a))
+                return -1;
             value = mir_new_value();
             if (vla != NULL && vla->vla_size_offset != 0) {
                 insn = mir_emit(MIR_VLA_SIZE);
@@ -7366,6 +7401,50 @@ static int mir_instruction_clobbers_caller_registers(
              (insn->immediate == '/' || insn->immediate == '%')));
 }
 
+/* Object promotion replaces named loads with SSA values, but parameter and
+ * PHI definitions plus retained stores still preserve enough provenance to
+ * apply C's `register` allocation hint after promotion. */
+static int mir_value_backs_declared_register_object(int value)
+{
+    const struct MirInsn *definition = mir_definition(value);
+    int instruction;
+
+    if (definition != NULL && definition->object >= 0 &&
+        definition->object < mir.object_count &&
+        mir.objects[definition->object].is_register)
+        return 1;
+    for (instruction = 0; instruction < mir.count; ++instruction)
+        if (mir.insns[instruction].opcode == MIR_STORE &&
+            mir.insns[instruction].src1 == value &&
+            mir.insns[instruction].object >= 0 &&
+            mir.insns[instruction].object < mir.object_count &&
+            mir.objects[mir.insns[instruction].object].is_register)
+            return 1;
+    return 0;
+}
+
+static int mir_declared_register_value_use_count(int value)
+{
+    int count = 0;
+    int instruction;
+
+    for (instruction = 0; instruction < mir.count; ++instruction) {
+        const struct MirInsn *insn = &mir.insns[instruction];
+
+        if (insn->opcode == MIR_STORE && insn->src1 == value &&
+            insn->object >= 0 && insn->object < mir.object_count &&
+            mir.objects[insn->object].is_register)
+            continue;
+        if (insn->src1 == value)
+            ++count;
+        if (insn->src2 == value)
+            ++count;
+        if (mir_call_uses_value(insn, value))
+            ++count;
+    }
+    return count;
+}
+
 int mir_iy_home_live_across_caller_clobber(void)
 {
     int instruction;
@@ -7394,6 +7473,7 @@ static void mir_allocate_registers(const unsigned char *live_in,
     int *color;
     int *fixed_color;
     int *preferences;
+    unsigned char *register_value;
     int i;
 
     memset(summary, 0, sizeof(*summary));
@@ -7428,10 +7508,15 @@ static void mir_allocate_registers(const unsigned char *live_in,
     fixed_color = (int *)malloc((size_t)value_count * sizeof(*fixed_color));
     preferences = (int *)calloc((size_t)value_count * MIR_COLOR_COUNT,
                                 sizeof(*preferences));
+    register_value = (unsigned char *)calloc((size_t)value_count, 1);
     if (interference == NULL || cross_call == NULL || cross_opaque == NULL ||
         degree == NULL || order == NULL || color == NULL || fixed_color == NULL ||
-        preferences == NULL)
+        preferences == NULL || register_value == NULL)
         fatal("out of memory simulating MIR allocation");
+
+    for (i = 0; i < value_count; ++i)
+        register_value[i] = (unsigned char)
+            mir_value_backs_declared_register_object(i);
 
     for (i = 0; i < mir.count; ++i) {
         const unsigned char *in = &live_in[(size_t)i * value_count];
@@ -7495,6 +7580,15 @@ static void mir_allocate_registers(const unsigned char *live_in,
         if (required2 >= 0 && insn->src2 >= 0)
             ++preferences[(size_t)insn->src2 * MIR_COLOR_COUNT + required2];
     }
+    for (i = 0; i < value_count; ++i) {
+        const struct MirInsn *definition = mir_definition(i);
+
+        if (definition != NULL && type_size(definition->type) <= 2 &&
+            register_value[i] &&
+            mir_declared_register_value_use_count(i) >= 2)
+            preferences[(size_t)i * MIR_COLOR_COUNT + MIR_COLOR_BC] +=
+                mir.count + 1;
+    }
     /* Stable selection sort is plenty for the small per-function prototype. */
     for (i = 0; i < value_count; ++i) {
         int best = i;
@@ -7512,11 +7606,15 @@ static void mir_allocate_registers(const unsigned char *live_in,
             int right_wide =
                 right_definition != NULL &&
                 type_size(right_definition->type) == 4;
+            int left_register = register_value[left];
+            int right_register = register_value[right];
             if (cross_call[right] > cross_call[left] ||
                 (cross_call[right] == cross_call[left] &&
                  (right_wide > left_wide ||
                   (right_wide == left_wide &&
-                   degree[right] > degree[left]))))
+                   (right_register > left_register ||
+                    (right_register == left_register &&
+                     degree[right] > degree[left]))))))
                 best = candidate;
         }
         if (best != i) {
@@ -7652,6 +7750,7 @@ static void mir_allocate_registers(const unsigned char *live_in,
     mir.allocation_phi_moves = summary->phi_moves;
 
     free(color);
+    free(register_value);
     free(preferences);
     free(fixed_color);
     free(order);

--- a/tests/diagnostics/baselines/register-object-address-sizeof.txt
+++ b/tests/diagnostics/baselines/register-object-address-sizeof.txt
@@ -1,0 +1,2 @@
+<source>:5: error DCC-E0921: cannot take address of register object near 'value'
+dcc: 1 error(s)

--- a/tests/diagnostics/baselines/register-object-address.txt
+++ b/tests/diagnostics/baselines/register-object-address.txt
@@ -1,0 +1,2 @@
+<source>:4: error DCC-E0921: cannot take address of register object near 'value'
+dcc: 1 error(s)

--- a/tests/diagnostics/baselines/register-parameter-address.txt
+++ b/tests/diagnostics/baselines/register-parameter-address.txt
@@ -1,0 +1,2 @@
+<source>:3: error DCC-E0921: cannot take address of register object near 'value'
+dcc: 1 error(s)

--- a/tests/diagnostics/register-object-address-sizeof.c
+++ b/tests/diagnostics/register-object-address-sizeof.c
@@ -1,0 +1,6 @@
+int main(void)
+{
+    register int value;
+
+    return sizeof &value;
+}

--- a/tests/diagnostics/register-object-address.c
+++ b/tests/diagnostics/register-object-address.c
@@ -1,0 +1,7 @@
+int main(void)
+{
+    register int value;
+    int *pointer = &value;
+
+    return pointer != 0;
+}

--- a/tests/diagnostics/register-parameter-address.c
+++ b/tests/diagnostics/register-parameter-address.c
@@ -1,0 +1,9 @@
+static int read(register int value)
+{
+    return *(&value);
+}
+
+int main(void)
+{
+    return read(1);
+}

--- a/tests/treg.c
+++ b/tests/treg.c
@@ -112,7 +112,7 @@ static void test_call_around(void)
     chk(*p == 30, "ptr correct after advance+call");
 }
 
-/* 5. register int is silently treated as a plain local (pointer-only feature) */
+/* 5. register int remains correct when no physical-register home is profitable */
 static void test_register_int(void)
 {
     register int i;
@@ -204,6 +204,18 @@ static void test_long_indirect_shift_reg(void)
     chk(p == dummy,                  "BC intact after want_dead=0");
 }
 
+/* 9. A register-qualified parameter remains eligible after parameter parsing
+ * and is preferred for the loop-carried MIR value. */
+static int sum_down(register int n)
+{
+    int total;
+
+    total = 0;
+    while (n-- > 0)
+        total += n;
+    return total;
+}
+
 int main(void)
 {
     test_walk();
@@ -214,6 +226,7 @@ int main(void)
     test_postinc();
     test_write();
     test_long_indirect_shift_reg();
+    chk(sum_down(100) == 4950, "register parameter loop");
 
     if (g_ng == 0)
         printf("success\n");


### PR DESCRIPTION
Replay the deferred wip/mir-register-support prototype against the completed AST/MIR compiler on main. The prototype's original base (perf/unified-regalloc at fa2027e) and main share an untouched mir_allocate_registers, so the allocator-side change ports directly:

* Sym::is_register (already an MIR allocation hint on main) is now also copied onto old-style and modern function parameters in dcc_func.c, not just plain local declarations.
* dcc_mir.c rejects address-of on a register-qualified identifier both in direct lvalue-address lowering and in a recursive scan used for unevaluated expressions such as `sizeof &object`, diagnosed as stable code DCC-E0921 (dcc_diag_emit.c).
* mir_allocate_registers now recognizes values that back a register- qualified object (via defining instruction or retained store) and adds a strong BC preference for narrow (<=2 byte) values with two or more semantic uses, ordered ahead of otherwise-equivalent candidates after call-crossing and width constraints. Bookkeeping stores back to the same object are excluded from the use count. Wide (4-byte) values and one-use values are intentionally left alone per the prototype's measurements.

tests/treg.c gains a register-qualified parameter case exercising the loop-carried preferred value. Three new diagnostics fixtures cover direct address-of, sizeof of an address-of, and a register parameter's address.

Validation: full+extended regression suite (peep/nopeep, with and without -NoStackCheck) passes with zero regressions; 109/109 diagnostics pass; strict MkDocs build passes. treg/tregnarw show sizeable checked- workload cycle/size improvements, left as unrecorded headroom per the prototype's own approach (not promoted to tests/perf_baselines.csv here).