### PR TITLE
Document MIR module responsibilities

### DIFF
--- a/src/dcc/dcc_mir.c
+++ b/src/dcc/dcc_mir.c
@@ -1,14 +1,20 @@
-/* dcc_mir.c - MIR core: lowering, capture API, CFG/dataflow analysis,
- * register allocation, and generated-candidate selection plumbing.
+/**
+ * @file dcc_mir.c
+ * @brief Builds, analyzes, allocates, and verifies a function's MIR.
  *
- * This is one of several dcc_mir_*.c translation units that together
- * implement the typed virtual-register machine IR and transactional
- * backend described in dcc_mir_internal.h. See that header for the
- * shared IR types and cross-file helper prototypes.
+ * @par Role
+ * Owns the current MirFunction and lowers frontend capture events into typed
+ * virtual-register instructions. It also repairs metadata, builds the CFG and
+ * def-use information, runs liveness and home allocation, canonicalizes MIR,
+ * and verifies or reports the completed function.
  *
- * Set DCC_MIR_REPORT=1 to dump every generated function attempt, or
- * DCC_MIR_FUNCTION=name to restrict the dump. Production function output is
- * always selected from generated MIR candidates.
+ * @par Key entry points
+ * mir_begin_function(), the mir_capture_*() API, mir_verify_and_dump(), and
+ * mir_finish_translation_unit().
+ *
+ * @par Boundary
+ * dcc_mir_select.c owns candidate ordering and final output commit; emitter
+ * modules consume the verified state declared in dcc_mir_internal.h.
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -17,23 +23,6 @@
 #include "dcc_ast.h"
 #include "dcc_mir.h"
 #include "dcc_mir_internal.h"
-
-/* dcc_mir.c - typed virtual-register machine IR and generated backend.
- *
- * dcc currently assigns HL/DE/BC while walking one statement AST at a time.
- * This module is the first vertical slice toward a real allocator: before an
- * AST is emitted, lower it into a persistent per-function stream of unlimited
- * virtual values, then build CFG successors and solve virtual-value liveness.
- *
- * Set DCC_MIR_REPORT=1 to dump every generated function attempt, or
- * DCC_MIR_FUNCTION=name to restrict the dump.
- */
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include "dcc.h"
-#include "dcc_ast.h"
-#include "dcc_mir.h"
 
 
 struct MirFunction mir;

--- a/src/dcc/dcc_mir.h
+++ b/src/dcc/dcc_mir.h
@@ -1,13 +1,29 @@
-/* dcc_mir.h - typed virtual-register MIR capture and generated backend. */
+/**
+ * @file dcc_mir.h
+ * @brief Declares the frontend-facing lifecycle and capture API for MIR.
+ *
+ * @par Role
+ * Parser, statement, initializer, scope, and debug-metadata code call this
+ * interface to describe one function without depending on MIR internals.
+ * Implementations live primarily in dcc_mir.c; mir_end_function() hands the
+ * completed function to candidate selection in dcc_mir_select.c.
+ *
+ * @par Boundary
+ * IR types, analysis helpers, allocation state, and emitter contracts are
+ * private to dcc_mir_internal.h.
+ */
 #ifndef DCC_MIR_H
 #define DCC_MIR_H
 
 struct AstNode;
 struct Sym;
 
+/* Function lifecycle. */
 void mir_begin_function(const char *name, int sink_purpose, int has_vla,
 						int local_bytes, int implicit_zero_return);
 int mir_is_active(void);
+
+/* Statements, declarations, and initializer events. */
 void mir_capture_stmt(const struct AstNode *stmt);
 void mir_begin_declaration(const struct AstNode *node);
 void mir_end_declaration(void);
@@ -25,20 +41,28 @@ void mir_capture_init_char_array(struct Sym *symbol, const char *bytes,
 void mir_set_init_expression_target(struct Sym *symbol, int offset, int type);
 void mir_begin_compound_literal(struct Sym *symbol);
 void mir_end_compound_literal(struct Sym *symbol);
+
+/* Metadata-only scope, control-flow, and label replay. */
 void mir_begin_scope_replay(void);
 void mir_end_scope_replay(void);
 void mir_begin_flow_replay(void);
 void mir_end_flow_replay(void);
 void mir_begin_label_replay(const char *name);
 void mir_end_label_replay(void);
+
+/* Declared-symbol facts used while resolving lowered values. */
 void mir_note_declared_symbol(struct Sym *symbol);
 void mir_note_declared_alias(const char *source_name, struct Sym *symbol);
 void mir_note_narrowed_for_counter(void);
+
+/* Debug records preserved for the selected generated candidate. */
 int mir_capture_debug_location(const char *file, int line);
 int mir_capture_debug_variable(
     const char *function, const struct Sym *symbol, int end);
 int mir_capture_debug_function_end(
     const char *assembly_name, const char *source_name);
+
+/* Finalize one function, then enforce translation-unit completeness. */
 void mir_end_function(void);
 void mir_finish_translation_unit(void);
 

--- a/src/dcc/dcc_mir_emit_common.c
+++ b/src/dcc/dcc_mir_emit_common.c
@@ -1,10 +1,15 @@
-/* dcc_mir_emit_common.c - shared scalar-value emission helpers used by
- * more than one MIR selector (homed prologue/epilogue, home<->HL/DE
- * moves, PHI copies, comparison fusion helpers) plus the
- * mir_try_emit_scalar_dag / mir_try_emit_homed_scalar_dag selectors
- * that are built directly on top of them.
+/**
+ * @file dcc_mir_emit_common.c
+ * @brief Provides scalar Z80 emission shared by multiple MIR candidates.
  *
- * Part of the dcc_mir.c MIR backend split; see dcc_mir_internal.h.
+ * @par Role
+ * Implements home/register moves, prologues and epilogues, address
+ * resolution, casts, arithmetic, comparisons, PHI copies, and other reusable
+ * scalar operations. It also owns the straight-line scalar DAG candidates.
+ *
+ * @par Key entry points
+ * mir_try_emit_scalar_dag(), mir_try_emit_homed_scalar_dag(), and the
+ * mir_emit_* helpers declared in dcc_mir_internal.h.
  */
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/dcc/dcc_mir_homed_cfg.c
+++ b/src/dcc/dcc_mir_homed_cfg.c
@@ -1,9 +1,15 @@
-/* dcc_mir_homed_cfg.c - the mir_try_emit_homed_scalar_cfg selector: emits
- * Z80 for acyclic control flow whose scalar values can all stay in
- * fixed "home" registers/temporaries without a full backend spill
- * frame.
+/**
+ * @file dcc_mir_homed_cfg.c
+ * @brief Emits the fixed-home scalar CFG candidate.
  *
- * Part of the dcc_mir.c MIR backend split; see dcc_mir_internal.h.
+ * @par Role
+ * Proves and emits supported acyclic control flow when scalar values can stay
+ * in allocated register or temporary homes, avoiding the general spill-slot
+ * frame. It handles home-aware calls, PHI edges, memory operations, and
+ * selected forwarding/fusion forms.
+ *
+ * @par Key entry point
+ * mir_try_emit_homed_scalar_cfg().
  */
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/dcc/dcc_mir_internal.h
+++ b/src/dcc/dcc_mir_internal.h
@@ -1,11 +1,37 @@
+/**
+ * @file dcc_mir_internal.h
+ * @brief Defines the private data model and cross-module contracts of MIR.
+ *
+ * @par Role
+ * Central source of truth for MIR opcodes, instructions, objects, functions,
+ * liveness/allocation records, target constraints, shared state, and helpers
+ * used by more than one MIR translation unit. Frontend code must use
+ * dcc_mir.h instead.
+ *
+ * @par Module map
+ * - dcc_mir.c: lowering, metadata repair, CFG/dataflow, allocation, verifier.
+ * - dcc_mir_select.c: candidate orchestration, cost policy, output commit.
+ * - dcc_mir_emit_common.c: shared scalar/home emission and DAG candidates.
+ * - dcc_mir_homed_cfg.c: fixed-home CFG candidate.
+ * - dcc_mir_spilled_cfg.c: general spill-slot CFG candidate.
+ * - dcc_mir_target.c: diagnostic Z80 constraint model.
+ * - dcc_mir_schedule.c: diagnostic sparse schedule model.
+ * - dcc_mir_stream.c/.h: transactional in-memory candidate streams.
+ * - dcc_mir_machine_emit.c: exact-schedule coordinator and common machinery.
+ * - dcc_mir_machine_internal.h: private exact-schedule family interface.
+ * - dcc_mir_machine_attention.c: attention and softmax kernels.
+ * - dcc_mir_machine_aggregate_checks.c: aggregate/data-layout kernels.
+ * - dcc_mir_machine_call_runners.c: call-heavy orchestration kernels.
+ * - dcc_mir_machine_endgame.c: late and no-stack schedule bands.
+ * - dcc_mir_machine_float_reports.c: floating-point kernels and reports.
+ * - dcc_mir_machine_interpreter_runners.c: interpreter and lexer kernels.
+ * - dcc_mir_machine_numeric.c: numeric and algorithmic kernels.
+ * - dcc_mir_machine_runtime_runners.c: runtime, file, and system kernels.
+ * - dcc_mir_machine_scanners.c: scanner, parser, and text kernels.
+ * - dcc_mir_machine_validation_runners.c: validation-harness kernels.
+ */
 #ifndef DCC_MIR_INTERNAL_H
 #define DCC_MIR_INTERNAL_H
-
-/* Internal MIR module header: shared IR types, global compiler state,
- * and prototypes for helpers that cross the dcc_mir_*.c file split.
- * Not part of the public dcc_mir.h API - only the dcc_mir_*.c
- * translation units that implement the MIR backend include this.
- */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/dcc/dcc_mir_machine_aggregate_checks.c
+++ b/src/dcc/dcc_mir_machine_aggregate_checks.c
@@ -1,4 +1,15 @@
-/* dcc_mir_machine_aggregate_checks.c - strict aggregate check schedules. */
+/**
+ * @file dcc_mir_machine_aggregate_checks.c
+ * @brief Emits exact schedules for aggregate and data-layout operations.
+ *
+ * @par Role
+ * Handles proven array, matrix, VLA, record, union, bitfield, initializer,
+ * pointer-layout, and aggregate validation shapes that benefit from a
+ * dedicated machine schedule.
+ *
+ * @par Key entry point
+ * mir_try_emit_aggregate_checks().
+ */
 
 #include <limits.h>
 

--- a/src/dcc/dcc_mir_machine_attention.c
+++ b/src/dcc/dcc_mir_machine_attention.c
@@ -1,4 +1,15 @@
-/* dcc_mir_machine_attention.c - strict attention-kernel schedules. */
+/**
+ * @file dcc_mir_machine_attention.c
+ * @brief Emits exact Z80 schedules for attention-model kernels.
+ *
+ * @par Role
+ * Matches complete MIR shapes for matrix products, vector maxima, fixed and
+ * variable softmax, and the multi-stage backward pass, then emits their
+ * specialized schedules.
+ *
+ * @par Key entry point
+ * mir_try_emit_attention_kernels().
+ */
 
 #include "dcc_mir_machine_internal.h"
 

--- a/src/dcc/dcc_mir_machine_call_runners.c
+++ b/src/dcc/dcc_mir_machine_call_runners.c
@@ -1,4 +1,15 @@
-/* dcc_mir_machine_call_runners.c - strict call/check orchestration schedules. */
+/**
+ * @file dcc_mir_machine_call_runners.c
+ * @brief Emits exact schedules for call-heavy orchestration functions.
+ *
+ * @par Role
+ * Matches functions dominated by argument packing, ABI-sensitive calls,
+ * allocation/file/system call sequences, aggregate-value calls, and
+ * call-containing control loops, then emits one complete schedule.
+ *
+ * @par Key entry point
+ * mir_try_emit_call_runners().
+ */
 
 #include "dcc_mir_machine_internal.h"
 

--- a/src/dcc/dcc_mir_machine_emit.c
+++ b/src/dcc/dcc_mir_machine_emit.c
@@ -1,4 +1,17 @@
-/* dcc_mir_machine_emit.c - Z80 emission from scheduled MIR templates. */
+/**
+ * @file dcc_mir_machine_emit.c
+ * @brief Coordinates structurally exact MIR-to-Z80 machine schedules.
+ *
+ * @par Role
+ * Implements shared exact-schedule matching/emission utilities, retains the
+ * general exact-template families, and dispatches specialized
+ * dcc_mir_machine_*.c families in selector-policy order.
+ *
+ * @par Key entry point
+ * mir_try_emit_scheduled_machine_cfg() returns emitted output only after a
+ * matcher has proved the complete supported MIR shape. Candidate selection
+ * and profitability remain in dcc_mir_select.c.
+ */
 
 #include "dcc_mir_machine_internal.h"
 #include <stdint.h>

--- a/src/dcc/dcc_mir_machine_endgame.c
+++ b/src/dcc/dcc_mir_machine_endgame.c
@@ -1,4 +1,16 @@
-/* dcc_mir_machine_endgame.c - strict endgame machine schedules. */
+/**
+ * @file dcc_mir_machine_endgame.c
+ * @brief Owns late and no-stack exact-schedule bands.
+ *
+ * @par Role
+ * Preserves the final selector ordering for no-stack kernels and broad
+ * array, numeric, scope, conversion, file, formatting, and float validation
+ * runners. Phase 0 handles the early no-stack band; later phases handle the
+ * late runner band and its aggregate handoff.
+ *
+ * @par Key entry point
+ * mir_try_emit_endgame_runners().
+ */
 
 #include "dcc_mir_machine_internal.h"
 

--- a/src/dcc/dcc_mir_machine_float_reports.c
+++ b/src/dcc/dcc_mir_machine_float_reports.c
@@ -1,4 +1,15 @@
-/* dcc_mir_machine_float_reports.c - strict float schedules. */
+/**
+ * @file dcc_mir_machine_float_reports.c
+ * @brief Emits exact floating-point kernels and report schedules.
+ *
+ * @par Role
+ * Matches float sweeps, transcendental wrappers, normalization and log
+ * series, pi computations, tolerance/comparison reports, and raw conversion
+ * checks while preserving the target's 32-bit float ABI.
+ *
+ * @par Key entry point
+ * mir_try_emit_float_reports().
+ */
 
 #include "dcc_mir_machine_internal.h"
 

--- a/src/dcc/dcc_mir_machine_internal.h
+++ b/src/dcc/dcc_mir_machine_internal.h
@@ -1,3 +1,13 @@
+/**
+ * @file dcc_mir_machine_internal.h
+ * @brief Declares the private interface shared by exact-schedule modules.
+ *
+ * @par Role
+ * Exposes semantic proof helpers, common Z80 emission helpers, exact-family
+ * dispatchers, and phase/profile contracts used by dcc_mir_machine_emit.c and
+ * the dcc_mir_machine_*.c family modules. It is not a frontend or general MIR
+ * API.
+ */
 #ifndef DCC_MIR_MACHINE_INTERNAL_H
 #define DCC_MIR_MACHINE_INTERNAL_H
 

--- a/src/dcc/dcc_mir_machine_interpreter_runners.c
+++ b/src/dcc/dcc_mir_machine_interpreter_runners.c
@@ -1,4 +1,15 @@
-/* dcc_mir_machine_interpreter_runners.c - strict control/interpreter schedules. */
+/**
+ * @file dcc_mir_machine_interpreter_runners.c
+ * @brief Emits exact schedules for interpreter and language-tool kernels.
+ *
+ * @par Role
+ * Covers file loading plus lexer, parser, storage, arithmetic, and control
+ * kernels used by the Forth, Pascal, Ada, COBOL, BASIC, and Fortran
+ * workloads.
+ *
+ * @par Key entry point
+ * mir_try_emit_interpreter_runners().
+ */
 
 #include "dcc_mir_machine_internal.h"
 

--- a/src/dcc/dcc_mir_machine_numeric.c
+++ b/src/dcc/dcc_mir_machine_numeric.c
@@ -1,4 +1,15 @@
-/* dcc_mir_machine_numeric.c - strict numeric kernel schedules. */
+/**
+ * @file dcc_mir_machine_numeric.c
+ * @brief Emits exact schedules for numeric and algorithmic kernels.
+ *
+ * @par Role
+ * Matches fixed/wide arithmetic, affine loops, shifts, roots, searches,
+ * dynamic programming, board algorithms, and numeric validation runners.
+ * Its phase argument preserves each family's selector position.
+ *
+ * @par Key entry point
+ * mir_try_emit_numeric_kernels().
+ */
 
 #include "dcc_mir_machine_internal.h"
 

--- a/src/dcc/dcc_mir_machine_runtime_runners.c
+++ b/src/dcc/dcc_mir_machine_runtime_runners.c
@@ -1,4 +1,16 @@
-/* dcc_mir_machine_runtime_runners.c - strict runtime/file/system schedules. */
+/**
+ * @file dcc_mir_machine_runtime_runners.c
+ * @brief Emits exact schedules for runtime, file, and system workloads.
+ *
+ * @par Role
+ * Covers allocation, nonlocal control, process/BDOS calls, file and directory
+ * I/O, string/report helpers, sorting/search edges, and related runtime
+ * drivers. Phase 2 classifies strict spilled-candidate profiles without
+ * emitting.
+ *
+ * @par Key entry point
+ * mir_try_emit_runtime_runners().
+ */
 
 #include "dcc_mir_machine_internal.h"
 

--- a/src/dcc/dcc_mir_machine_scanners.c
+++ b/src/dcc/dcc_mir_machine_scanners.c
@@ -1,4 +1,15 @@
-/* dcc_mir_machine_scanners.c - strict scanner/parser schedules. */
+/**
+ * @file dcc_mir_machine_scanners.c
+ * @brief Emits exact schedules for scanners, parsers, and text kernels.
+ *
+ * @par Role
+ * Matches character/token scans, bounded parsing, preprocessing, text
+ * transforms, board/path scans, VLA loops, and symbol-table operations.
+ * The late flag preserves the symbol/path family's later selector band.
+ *
+ * @par Key entry point
+ * mir_try_emit_scanner_kernels().
+ */
 
 #include "dcc_mir_machine_internal.h"
 

--- a/src/dcc/dcc_mir_machine_validation_runners.c
+++ b/src/dcc/dcc_mir_machine_validation_runners.c
@@ -1,4 +1,15 @@
-/* dcc_mir_machine_validation_runners.c - strict scope/wide/validation schedules. */
+/**
+ * @file dcc_mir_machine_validation_runners.c
+ * @brief Emits exact schedules for compiler and runtime validation harnesses.
+ *
+ * @par Role
+ * Matches complete test-runner shapes for scope, calls, wide/indexed values,
+ * callbacks, allocation, memory, files, directories, and buffered console
+ * behavior. The phase argument preserves distinct selector positions.
+ *
+ * @par Key entry point
+ * mir_try_emit_validation_runners().
+ */
 
 #include "dcc_mir_machine_internal.h"
 

--- a/src/dcc/dcc_mir_schedule.c
+++ b/src/dcc/dcc_mir_schedule.c
@@ -1,7 +1,15 @@
-/* dcc_mir_schedule.c - shadow sparse register scheduling for MIR.
+/**
+ * @file dcc_mir_schedule.c
+ * @brief Builds the diagnostic sparse register schedule for MIR.
  *
- * The first stage builds live segments split at CFG and call boundaries and
- * accounts for edge-specific PHI uses. It deliberately emits no Z80 yet.
+ * @par Role
+ * Splits virtual-value live ranges at CFG and call boundaries, accounts for
+ * edge-specific PHI uses, assigns legal target colors or spill/rematerialize
+ * outcomes, and summarizes pressure and boundary moves.
+ *
+ * @par Boundary
+ * mir_build_shadow_schedule() and mir_schedule_report_shadow_plan() analyze
+ * only; they do not affect candidate selection or emit Z80.
  */
 
 #include "dcc_mir_internal.h"

--- a/src/dcc/dcc_mir_select.c
+++ b/src/dcc/dcc_mir_select.c
@@ -1,9 +1,17 @@
-/* dcc_mir_select.c - loop selectors (countdown/accumulator/unsigned-
- * division/repeated-invariant-add), the general CFG rollout and
- * comparison-branch selectors, the top-level mir_try_emit_z80
- * dispatcher, and mir_end_function's generated-candidate commit entry point.
+/**
+ * @file dcc_mir_select.c
+ * @brief Builds, compares, selects, and commits generated MIR candidates.
  *
- * Part of the dcc_mir.c MIR backend split; see dcc_mir_internal.h.
+ * @par Role
+ * Owns mir_end_function(), candidate attempt isolation, selector ordering,
+ * mir-v1 cost policy, diagnostics, and the final copy to the real output
+ * stream. It also contains compact loop, regional rollout, and
+ * comparison-branch selectors that arbitrate with the general emitters.
+ *
+ * @par Boundary
+ * Each candidate writes to its own MirStream. This module selects only among
+ * generated candidates; lowering and verification live in dcc_mir.c, while
+ * candidate implementations live in the emitter modules.
  */
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/dcc/dcc_mir_spilled_cfg.c
+++ b/src/dcc/dcc_mir_spilled_cfg.c
@@ -1,10 +1,15 @@
-/* dcc_mir_spilled_cfg.c - the mir_try_emit_spilled_scalar_cfg selector
- * (the dominant selector, covering most of the corpus) plus its
- * exclusive helpers: virtual IY/offset addressing, HL/stack value
- * forwarding, comparison fusion, fastcall shape detection, and
- * backend-slot preparation.
+/**
+ * @file dcc_mir_spilled_cfg.c
+ * @brief Emits the general spill-slot scalar CFG candidate.
  *
- * Part of the dcc_mir.c MIR backend split; see dcc_mir_internal.h.
+ * @par Role
+ * Covers most functions by assigning MIR values to backend frame slots and
+ * emitting arbitrary supported CFGs. It owns virtual-IY addressing, slot
+ * preparation, call ABI handling, PHI transfers, value forwarding,
+ * comparison/branch fusion, and general scalar/wide instruction emission.
+ *
+ * @par Key entry point
+ * mir_try_emit_spilled_scalar_cfg().
  */
 
 /* fmemopen() (used below for elided-epilogue byte accounting) is a POSIX

--- a/src/dcc/dcc_mir_stream.c
+++ b/src/dcc/dcc_mir_stream.c
@@ -1,6 +1,10 @@
-/*
- * dcc_mir_stream.c - implementation of the portable in-memory scratch
- * stream declared in dcc_mir_stream.h. See that header for rationale.
+/**
+ * @file dcc_mir_stream.c
+ * @brief Implements the in-memory stream used for isolated MIR candidates.
+ *
+ * @par Role
+ * Owns the growable buffer and the FILE-like read, write, seek, rewind, copy,
+ * and final-file transfer operations declared in dcc_mir_stream.h.
  */
 
 #include "dcc_mir_stream.h"

--- a/src/dcc/dcc_mir_stream.h
+++ b/src/dcc/dcc_mir_stream.h
@@ -1,21 +1,16 @@
-/*
- * dcc_mir_stream.h - portable in-memory scratch stream for MIR candidate
- * codegen, replacing tmpfile()-backed FILE* scratch streams.
+/**
+ * @file dcc_mir_stream.h
+ * @brief Declares the portable in-memory stream for MIR candidate output.
  *
- * MirStream mimics the small subset of ISO C stdio semantics the MIR
- * backend's candidate-matrix codegen actually uses (sequential and
- * seek/rewind text writes and reads; never a real file, never platform
- * I/O). tmpfile() is cheap on Linux (anonymous tmpfs-backed) but touches
- * the real filesystem on every call on Windows, and the candidate matrix
- * creates one scratch stream per codegen attempt per function - this
- * type removes that filesystem traffic entirely, uniformly on every
- * platform.
+ * @par Role
+ * MirStream supplies the small sequential and seekable stdio subset needed by
+ * candidate emitters without touching the filesystem. Candidate attempts stay
+ * isolated until selection; mir_stream_copy_to_file() is the sole boundary to
+ * the compiler's real FILE output.
  *
- * Every field of the underlying struct (defined privately in
- * dcc_mir_stream.c) is stdint.h/stddef.h fixed-width, so behavior is
- * identical on LP64 (Linux/macOS 64-bit), LLP64 (MSVC), and ILP32
- * (32-bit Linux). MirStream is opaque here; callers only ever hold a
- * MirStream*, exactly like FILE*.
+ * @par Design
+ * The type is opaque and implemented in dcc_mir_stream.c. Its byte-oriented
+ * state has identical semantics on LP64, LLP64, and ILP32 hosts.
  */
 
 #ifndef DCC_MIR_STREAM_H

--- a/src/dcc/dcc_mir_target.c
+++ b/src/dcc/dcc_mir_target.c
@@ -1,9 +1,15 @@
-/* dcc_mir_target.c - shadow Z80 constraints for MIR scheduling.
+/**
+ * @file dcc_mir_target.c
+ * @brief Models Z80 constraints for the diagnostic shadow scheduler.
  *
- * This module describes physical register aliases, call clobbers and the
- * cheapest legal instruction-template class for each semantic MIR opcode.
- * It does not select or emit code yet; DCC_MIR_TARGET_REPORT exposes the
- * model without changing production output.
+ * @par Role
+ * Maps semantic MIR instructions to legal register colors, fixed inputs and
+ * outputs, call clobbers, aliasing, and approximate template costs.
+ *
+ * @par Boundary
+ * mir_target_constraint_for_insn() feeds dcc_mir_schedule.c, and
+ * mir_target_report_shadow_plan() reports the model. This module neither
+ * selects a production candidate nor emits Z80.
  */
 
 #include "dcc_mir_internal.h"

--- a/tests/tmircfg.c
+++ b/tests/tmircfg.c
@@ -1,3 +1,11 @@
+/**
+ * @file tmircfg.c
+ * @brief Smoke-tests MIR lowering and emission for a loop CFG.
+ *
+ * @par Coverage
+ * sum_to() creates a backedge and loop-carried values for both the countdown
+ * and accumulator, exercising basic blocks, liveness, and PHI-edge handling.
+ */
 #include <stdio.h>
 
 static int sum_to(int n)

--- a/tests/tmirfast.c
+++ b/tests/tmirfast.c
@@ -1,37 +1,17 @@
-/*
- * tmirfast.c -- DCC regression tests
+/**
+ * @file tmirfast.c
+ * @brief Validates MIR scalar constant and comparison fast paths.
  *
- * Permanent regression fixture for MIR Plan-100 Phase 3 constant/comparison
- * fast paths added in Items 25/27/30/31:
- *   - Item 25: compare-with-zero fast path (ld a,h / or l) for equality and
- *     inequality against constant 0, avoiding a full 16-bit subtract.
- *   - Item 27: sign-bit test fast path (bit 7,h) for signed < and >= against
- *     constant 0.
- *   - Item 30: shift-and-subtract fast path ((x << k) - x) for multipliers
- *     that are a bottom-aligned run of ones (7, 15, 31, 63, 127, 255),
- *     including multipliers large enough to have previously exceeded the
- *     naive per-bit op-count cap and fallen back to a runtime __mulu call.
- *   - Item 31: fused inc (ix+n) / dec (ix+n) in-place update for a bare
- *     x++;/x--; on a 16-bit local or parameter whose incremented value is
- *     never read again (dead-after-increment), replacing a full
- *     load/add-or-sub/store round trip.
+ * @par Coverage
+ * Exercises equality/sign tests against zero, shift/subtract multiplication
+ * by runs-of-one constants, and in-place increment/decrement when the updated
+ * value is dead or observed through an alias. Extra live values make the
+ * spill-slot candidate plausible without making selector choice part of the
+ * correctness contract.
  *
- * Each helper below has enough surrounding locals/arithmetic to give the
- * MIR selector a chance to accept the function through the spilled-scalar-
- * cfg path rather than falling back on text-size or being handled entirely
- * by the fully-registerized homed-scalar-cfg path (which would not exercise
- * these fast paths at all); whether a given helper is actually accepted
- * into MIR on any given day is a selector heuristic, not a correctness
- * requirement of this fixture; either way, the assertions below must hold
- * under both the MIR and legacy backends, and under both nopeep and peep,
- * so a regression in the fast paths' semantics shows up as a wrong-answer
- * failure here rather than only as a byte-count change.
- *
- * Host validation is skipped (tests/_test_overrides.json's "host": true):
- * several checks deliberately overflow/wrap a 16-bit `int`, matching dcc's
- * Z80 target where `int` is 2 bytes. A host's `int` is 4 bytes even under
- * a 32-bit (-m32) compile - unlike `long`, there's no host compiler mode
- * that reproduces a 16-bit `int`, so this can't be validated on any host.
+ * @par Platform note
+ * Checks depend on dcc's 16-bit wrapping int semantics, so host execution is
+ * disabled in tests/_test_overrides.json.
  */
 
 #include <stdio.h>

--- a/tests/tmirfix.c
+++ b/tests/tmirfix.c
@@ -1,5 +1,11 @@
-/*
- * tmirfix.c - regressions found by the generated compiler test archive.
+/**
+ * @file tmirfix.c
+ * @brief Collects MIR correctness regressions found by archive testing.
+ *
+ * @par Coverage
+ * Exercises union/designated initialization, bitfield stores, boolean
+ * normalization, indexed byte formatting, scoped declarations, VLAs with
+ * narrow and wide elements, and local/global name collisions.
  */
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/tmirfuse.c
+++ b/tests/tmirfuse.c
@@ -1,19 +1,12 @@
-/*
- * tmirfuse.c -- DCC regression tests
+/**
+ * @file tmirfuse.c
+ * @brief Validates MIR comparison-to-branch fusion.
  *
- * Permanent regression fixture for MIR Plan-100 Items 1/4: fusing a scalar
- * comparison directly into its consuming branch (mir_try_emit_spilled_scalar_cfg /
- * mir_emit_fused_comparison_branch), including the logical-not extension.
- * Exercises every comparison operator, signed and unsigned, bare and negated,
- * across boundary values (INT_MIN/INT_MAX, 0/-1, unsigned wraparound) so a
- * future regression in the fused branch polarity or sign handling shows up
- * as a wrong-answer failure here rather than only as a byte-count change.
- *
- * Expected output:
- *   tmirfuse: all tests passed
- *
- * Expected exit status:
- *   0
+ * @par Coverage
+ * Exercises all signed comparison operators, unsigned relational operators,
+ * logical negation, boundary values, spill-pressure forms, and chained
+ * conditions. It detects wrong branch polarity or signedness in fused
+ * comparison emission.
  */
 
 #include <stdio.h>

--- a/tests/tmirlife.c
+++ b/tests/tmirlife.c
@@ -1,5 +1,11 @@
-/*
- * tmirlife.c - MIR physical-lifetime and helper-ABI regressions.
+/**
+ * @file tmirlife.c
+ * @brief Validates MIR physical lifetimes and helper-call ABI handling.
+ *
+ * @par Coverage
+ * Exercises late PHI uses, spill-slot values across calls and loops, regional
+ * address homes, dead definitions, wide scanner arguments/returns, byte
+ * sign extension, and float helper results.
  */
 #include <stdio.h>
 

--- a/tests/tmirslot.c
+++ b/tests/tmirslot.c
@@ -1,26 +1,11 @@
-/*
- * tmirslot.c -- DCC regression tests
+/**
+ * @file tmirslot.c
+ * @brief Validates MIR backend-slot liveness and value forwarding.
  *
- * Permanent regression fixture for MIR Plan-100 Item 21: backend-slot
- * live-range hygiene / dead-store elimination (Items 13/15/16/17/18).
- * Exercises:
- *   - immediate use of a call result across a backend slot boundary;
- *   - a value forwarded across a single-predecessor label (Item 15's
- *     label-forwarding extension of Item 13's HL-forwarding);
- *   - a value forwarded straight into a store with no intervening use;
- *   - a slot written but never read again anywhere in the function
- *     (dead-store elision, Item 16);
- *   - per-object backward liveness for a promoted local that is stored
- *     but never subsequently loaded (Item 17);
- *   - a phi destination that is dead on one incoming path but live on
- *     another, so the copy must still be emitted for the live path
- *     while the dead-path skip (Item 18) does not misfire.
- *
- * Expected output:
- *   tmirslot: all tests passed
- *
- * Expected exit status:
- *   0
+ * @par Coverage
+ * Exercises immediate call-result use, forwarding across labels and stores,
+ * dead slot/local stores, PHI values live on only one incoming path, and
+ * values that must survive a caller-clobbering call.
  */
 
 #include <stdio.h>


### PR DESCRIPTION
## Summary
- standardize all 23 MIR backend C/header files and six `tmir` fixtures with concise Doxygen file documentation
- describe each module's role, key entry points, and boundaries for agent-friendly navigation
- add a central MIR module map and group the public capture API by responsibility
- remove the stale duplicate overview/include block from `dcc_mir.c`

## Validation
- `sh src/dcc/build-dcc.sh`
- documentation coverage: 29/29 MIR C/header files contain `@file` and `@brief`
- `git diff --check`
