### PR TITLE
Document AST module responsibilities

### DIFF
--- a/.github/skills/dcc-project/SKILL.md
+++ b/.github/skills/dcc-project/SKILL.md
@@ -21,6 +21,7 @@ legacy register-allocation retries do not exist.
 | --- | --- |
 | Driver, parser, symbols | `src/dcc/dcc.c`, `dcc_func.c`, `dcc_symbols.c` |
 | Preprocessor | `src/dcc/dcc_preproc.c`, `dcc_pp_expr.c` |
+| Function-local AST | `dcc_ast.c`, `dcc_ast.h`, `dcc_ast_build.c`, `dcc_ast_gen*.c` |
 | Non-emitting AST metadata | `dcc_ast_metadata.c`, `dcc_ast_stmt_meta.c` |
 | MIR lowering and verification | `dcc_mir.c`, `dcc_mir.h` |
 | MIR selection and cost policy | `dcc_mir_select.c` |
@@ -41,6 +42,23 @@ python3 scripts/audit-c-module-exports.py \
   src/dcc/dcc_mir_machine_attention.c \
   --allow-function mir_try_emit_attention_kernels
 ```
+
+## AST/MIR module documentation
+
+All `src/dcc/dcc_ast*.c/.h` and `src/dcc/dcc_mir*.c/.h` files use concise
+Doxygen-style file headers for human and agent navigation:
+
+- `@file` and `@brief` identify the module and primary purpose.
+- `@par Role` states what the file owns.
+- `@par Key entry points` names the principal callable surface when useful.
+- `@par Boundary` states what neighboring modules own and what this file does
+  not do.
+
+Keep the AST module map in `dcc_ast.h` and the MIR module map in
+`dcc_mir_internal.h` current when adding, removing, renaming, or moving
+modules. Do not describe `dcc_ast_gen*` as a production function-body fallback;
+AST processing after parsing is metadata/classification support and production
+body Z80 comes only from selected MIR candidates.
 
 ## Build
 

--- a/.github/skills/mir-migration/SKILL.md
+++ b/.github/skills/mir-migration/SKILL.md
@@ -45,6 +45,12 @@ Use `dcc-project` for build, test, runtime, and baseline conventions.
 | Exact schedule dispatch | `dcc_mir_machine_emit.c` |
 | Exact schedule families | `dcc_mir_machine_*.c` |
 
+AST and MIR C/header modules follow the Doxygen file-header convention defined
+in the `dcc-project` skill: `@file`, `@brief`, explicit role, key entry points,
+and module boundaries. Keep the module maps in `dcc_ast.h` and
+`dcc_mir_internal.h` current whenever files move or responsibilities change.
+Never document `dcc_ast_gen*` as a production body-codegen fallback.
+
 Place new schedules in the closest family module. Keep plan/matcher state
 automatic and expose only that module's dispatch function:
 

--- a/src/dcc/dcc_ast.c
+++ b/src/dcc/dcc_ast.c
@@ -1,10 +1,16 @@
-/*
- * dcc_ast.c - function-local AST: arena allocator and node constructors.
+/**
+ * @file dcc_ast.c
+ * @brief Owns function-local AST storage and node construction.
  *
- * See dcc_ast.h for the design rationale. This module owns arena block
- * allocation, reset/destruction, string/memory copies, node construction, and
- * small AST query helpers. Parsing and emission live in dcc_ast_build.c and
- * dcc_ast_gen*.c.
+ * @par Role
+ * Implements arena block allocation and reset, arena-owned string/memory
+ * copies, AstNode constructors, child-list growth, and small tree/name
+ * queries. It contains no parser, MIR lowering, metadata walk, or target-code
+ * selection.
+ *
+ * @par Key entry points
+ * ast_arena_init(), ast_arena_alloc(), ast_arena_reset(), ast_new(), and the
+ * ast_*() node constructors declared in dcc_ast.h.
  */
 #include "dcc.h"
 #include "dcc_ast.h"

--- a/src/dcc/dcc_ast.h
+++ b/src/dcc/dcc_ast.h
@@ -1,26 +1,38 @@
-/*
- * dcc_ast.h - function-local abstract syntax tree for dcc.
+/**
+ * @file dcc_ast.h
+ * @brief Defines dcc's function-local AST and its shared frontend API.
  *
- * dcc now lowers function bodies through a function-local AST.  The parser
- * builds one statement/expression tree at a time, then hands it to the AST
- * codegen walker.  Nothing outside a function is represented here (top-level
- * declarations, types, structs and the preprocessor keep using the existing
- * tables) - hence "function-local".
+ * @par Role
+ * Declares arena storage, node kinds and payloads, constructors, parsers,
+ * semantic classifiers, statement analysis, and metadata entry points. The
+ * parser builds one statement or expression tree at a time; production
+ * function semantics are captured into MIR, while post-parse AST traversal
+ * preserves declarations, scopes/VLAs, inline temporaries, strings, labels,
+ * diagnostics, and debug events.
  *
- * Design constraints:
- *   - Portable C11 source for modern Clang, GCC, and MSVC host compilers.
- *   - Must be able to drive the shared emit_* helpers,
- *     so the AST records exactly the information those helpers need (resolved
- *     struct Sym*, dcc type codes, operator token kinds, folded literals).
- *   - Arena-allocated and reset per function so there is no per-node free and
- *     no long-lived heap growth across a translation unit.
+ * @par Design
+ * Nodes are arena-allocated and use fixed generic child slots plus optional
+ * child lists. They carry resolved symbols, dcc type codes, operators, folded
+ * literals, and source locations needed by MIR lowering and metadata replay.
+ * Top-level declarations, types, structs, and preprocessing remain outside
+ * this function-local representation.
  *
- * The node payload is a deliberately small, fixed struct with a handful of
- * generic child slots (a..d) plus an optional child LIST (for compound-
- * statement bodies and call argument lists).  This keeps construction cheap
- * and avoids a sprawling tagged union while still expressing every C89
- * construct dcc accepts, including its C99 extensions (for-init declarations,
- * mid-block declarations, // comments are a lexer concern and need no node).
+ * @par Module map
+ * - dcc_ast.c: arena ownership, node construction, and small tree queries.
+ * - dcc_ast_build.c: token-to-AST expression and statement parsing.
+ * - dcc_ast_stmt_meta.c: statement gating, MIR capture, sizing, exit analysis.
+ * - dcc_ast_metadata.c: non-emitting declaration/scope/debug metadata replay.
+ * - dcc_ast_gen.c: type, lvalue, pointer, member, and index classifiers.
+ * - dcc_ast_gen_support.c: support gates, constant folds, structural proofs.
+ * - dcc_ast_gen_expr.c: initializer capture, inline metadata, expression
+ *   helpers.
+ * - dcc_ast_gen_cond.c: statement/condition gates and branch-shape helpers.
+ * - dcc_ast_gen_internal.h: private contract shared by the split modules.
+ *
+ * @par Boundary
+ * The dcc_ast_gen* helpers do not provide a production body-codegen fallback.
+ * dcc_mir.h exposes function capture; dcc_mir_select.c owns generated
+ * candidate selection.
  */
 #ifndef DCC_AST_H
 #define DCC_AST_H

--- a/src/dcc/dcc_ast_build.c
+++ b/src/dcc/dcc_ast_build.c
@@ -1,16 +1,21 @@
-/*
- * dcc_ast_build.c - function-local AST builder.
+/**
+ * @file dcc_ast_build.c
+ * @brief Parses function tokens into expression and statement ASTs.
  *
- * dcc lowers function bodies through a function-local AST (see dcc_ast.h).
+ * @par Role
+ * Implements recursive-descent expression parsing, statement/block parsing,
+ * declaration-span capture/replay, sizeof typing, arena initialization, and
+ * diagnostic AST dumps. Building may reserve compiler-generated locals, so
+ * speculative callers must restore lexer and frame state when discarding a
+ * tree.
  *
- * ast_build_expr() is a recursive-descent expression parser that mirrors the
- * source grammar (including dcc's C99 conveniences -
- * it operates purely on the token stream, so for-init/mid-block expressions
- * and // comments are handled transparently by the shared lexer).  It builds
- * an AstNode tree from the current lexer position and emits no assembly.
- * Compound-literal and optimization shapes may reserve compiler-generated
- * locals while building, so speculative callers must restore lexer/frame state
- * when discarding a tree. MIR and the metadata walkers consume the result.
+ * @par Key entry points
+ * ast_build_expr(), ast_build_assign_expr(), ast_build_stmt(),
+ * ast_replay_decl_span(), ast_scan_decl_span(), and ast_build_init().
+ *
+ * @par Boundary
+ * This module emits no target code. MIR capture, metadata replay, and retained
+ * semantic classifiers consume its trees.
  */
 #include "dcc.h"
 #include "dcc_ast.h"

--- a/src/dcc/dcc_ast_gen.c
+++ b/src/dcc/dcc_ast_gen.c
@@ -1,21 +1,23 @@
-/*
- * dcc_ast_gen.c - AST-driven code generation (classifiers / type & lvalue
- * resolvers).
+/**
+ * @file dcc_ast_gen.c
+ * @brief Implements shared AST type, value, lvalue, and address classifiers.
  *
- * The function-local AST is the codegen path.  This walker produces Z80
- * assembly by calling the shared low-level emit helpers; unsupported AST shapes
- * are compiler errors.
+ * @par Role
+ * Resolves scalar, pointer, array, member, dereference, aggregate, comparison,
+ * and assignment shapes used by statement gating, MIR lowering, initializer
+ * handling, and retained low-level AST helpers.
  *
- * Expression and statement lowering emits tight, peephole-friendly byte
- * sequences that the dccpeep patterns and regression baselines depend on.
+ * @par Key entry points
+ * ast_pointer_expr_type(), ast_member_lvalue_type(),
+ * ast_index_composite_elem_type(), ast_value_is_plain_int(), and the other
+ * ast_*_supported()/ast_*_type() predicates declared in
+ * dcc_ast_gen_internal.h.
  *
- * The AST codegen module is split across several translation units that share
- * prototypes via dcc_ast_gen_internal.h:
- *   - dcc_ast_gen.c         classifiers / type & lvalue resolvers (this file)
- *   - dcc_ast_gen_support.c ast_gen_supported dispatch, call/struct gates, folds
- *   - dcc_ast_gen_expr.c    expression emitters (ast_gen_expr)
- *   - dcc_ast_gen_cond.c    statement-support gates, comparison/branch emitters
- *   - dcc_ast_stmt_meta.c   statement parsing, sizing, and metadata analysis
+ * @par Boundary
+ * Despite the historical gen name, this module is not a production
+ * function-body fallback. dcc_ast_gen_expr.c owns expression helpers,
+ * dcc_ast_gen_cond.c owns condition/statement gates, and MIR owns final body
+ * emission.
  */
 #include "dcc.h"
 #include "dcc_ast.h"

--- a/src/dcc/dcc_ast_gen_cond.c
+++ b/src/dcc/dcc_ast_gen_cond.c
@@ -1,8 +1,19 @@
-/*
- * dcc_ast_gen_cond.c - statement-support gates, comparison/condition branch emitters.
+/**
+ * @file dcc_ast_gen_cond.c
+ * @brief Classifies statements and condition/branch AST shapes.
  *
- * Split from dcc_ast_gen.c; part of the AST codegen module.  Shared
- * prototypes live in dcc_ast_gen_internal.h.
+ * @par Role
+ * Implements statement admission, return/expression checks, comparison and
+ * truth-condition classifiers, switch-table analysis, and retained branch
+ * helpers shared by AST expression/initializer machinery.
+ *
+ * @par Key entry points
+ * ast_stmt_supported(), ast_return_stmt_supported(), ast_expr_stmt_supported(),
+ * ast_gen_cond_branch(), and the ast_is_*_cond() predicates.
+ *
+ * @par Boundary
+ * dcc_ast_stmt_meta.c captures accepted production statements into MIR; these
+ * gates and helpers do not constitute a body-codegen fallback.
  */
 #include <string.h>
 #include "dcc_ast_gen_internal.h"

--- a/src/dcc/dcc_ast_gen_expr.c
+++ b/src/dcc/dcc_ast_gen_expr.c
@@ -1,8 +1,21 @@
-/*
- * dcc_ast_gen_expr.c - expression emitters (ast_gen_expr).
+/**
+ * @file dcc_ast_gen_expr.c
+ * @brief Provides AST expression helpers, initializer capture, and inline
+ * metadata.
  *
- * Split from dcc_ast_gen.c; part of the AST codegen module.  Shared
- * prototypes live in dcc_ast_gen_internal.h.
+ * @par Role
+ * Owns expression dispatch and retained low-level gen_* helpers, parses and
+ * captures scalar/aggregate declaration initializers, and clones inline
+ * bodies for either value setup or non-emitting metadata traversal.
+ *
+ * @par Key entry points
+ * ast_emit_init_expr(), ast_emit_struct_init_expr_assign(),
+ * ast_process_inline_call_metadata(), and ast_gen_expr().
+ *
+ * @par Boundary
+ * When MIR is active, initializer semantics go through mir_capture_initializer()
+ * or mir_capture_struct_initializer(). Production function-body output is
+ * never selected from this AST helper layer.
  */
 #include <string.h>
 #include "dcc_ast_gen_internal.h"

--- a/src/dcc/dcc_ast_gen_internal.h
+++ b/src/dcc/dcc_ast_gen_internal.h
@@ -1,8 +1,23 @@
-/*
- * dcc_ast_gen_internal.h - private contract shared by dcc_ast_gen*.c.
+/**
+ * @file dcc_ast_gen_internal.h
+ * @brief Declares the private contract shared by split AST helper modules.
  *
- * Contains AST shape classifiers, emit helpers, and switch/codegen state.
- * Do not include it outside the AST codegen module.
+ * @par Role
+ * Exposes cross-file type/lvalue classifiers, support gates, constant folds,
+ * condition analysis, retained expression helpers, and shared statement state
+ * used by dcc_ast_gen*.c and dcc_ast_stmt_meta.c.
+ *
+ * @par Module split
+ * - dcc_ast_gen.c: type, value, lvalue, pointer, member, and index resolution.
+ * - dcc_ast_gen_support.c: support dispatch, call gates, folds, and proofs.
+ * - dcc_ast_gen_expr.c: initializer/inline handling and expression helpers.
+ * - dcc_ast_gen_cond.c: statement/condition gates and branch-shape helpers.
+ * - dcc_ast_stmt_meta.c: statement capture, sizing, and control metadata.
+ *
+ * @par Boundary
+ * Do not include this header outside the AST helper module. Public AST data
+ * and entry points belong in dcc_ast.h; production body emission belongs to
+ * MIR.
  */
 #ifndef DCC_AST_GEN_INTERNAL_H
 #define DCC_AST_GEN_INTERNAL_H

--- a/src/dcc/dcc_ast_gen_support.c
+++ b/src/dcc/dcc_ast_gen_support.c
@@ -1,8 +1,20 @@
-/*
- * dcc_ast_gen_support.c - ast_gen_supported dispatch, call/struct gates, const folds.
+/**
+ * @file dcc_ast_gen_support.c
+ * @brief Implements AST support gates, constant folds, and structural proofs.
  *
- * Split from dcc_ast_gen.c; part of the AST codegen module.  Shared
- * prototypes live in dcc_ast_gen_internal.h.
+ * @par Role
+ * Caches expression-shape admission, validates call/argument, pointer,
+ * aggregate, and assignment forms, folds target-width constants, and proves
+ * reusable loop/address transformations used by MIR capture and metadata
+ * planning.
+ *
+ * @par Key entry points
+ * ast_gen_supported(), ast_support_cache_begin(), ast_const_*_fold(),
+ * ast_call_*_supported(), and the ast_for_*_supported() proof helpers.
+ *
+ * @par Boundary
+ * A successful gate proves the frontend understands a shape; it does not
+ * select a production body emitter or establish profitability.
  */
 #include <string.h>
 #include <stdint.h>

--- a/src/dcc/dcc_ast_metadata.c
+++ b/src/dcc/dcc_ast_metadata.c
@@ -1,11 +1,20 @@
-/*
- * dcc_ast_metadata.c - non-emitting function-body AST metadata walk.
+/**
+ * @file dcc_ast_metadata.c
+ * @brief Replays non-emitting metadata from function-body ASTs.
  *
- * MIR owns production function code generation.  This walker preserves the
- * parser side effects that historically happened while the legacy AST emitter
- * traversed a supported statement: declaration replay, lexical scopes,
- * for-init renames, VLA control metadata, user-label diagnostics, debug
- * events, and AST transforms that reserve compiler temporaries.
+ * @par Role
+ * Walks expressions and statements to preserve declaration replay, lexical
+ * scopes, for-init renames, VLA save/restore facts, inline expansion metadata,
+ * strings, user-label diagnostics, static-function references, debug events,
+ * and temporary-reserving AST plans.
+ *
+ * @par Key entry points
+ * ast_process_stmt_metadata(), ast_process_expr_metadata(),
+ * ast_validate_expr_symbols(), and ast_replay_compound_literal().
+ *
+ * @par Boundary
+ * MIR owns production function code generation. This walker records frontend
+ * side effects only and does not select or emit a function-body candidate.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_ast_stmt_meta.c
+++ b/src/dcc/dcc_ast_stmt_meta.c
@@ -1,5 +1,20 @@
-/*
- * dcc_ast_stmt_meta.c - statement parsing, sizing, and metadata analysis.
+/**
+ * @file dcc_ast_stmt_meta.c
+ * @brief Coordinates statement acceptance, MIR capture, and metadata analysis.
+ *
+ * @par Role
+ * Builds and support-checks one statement, captures accepted semantics into
+ * MIR, runs the non-emitting metadata walk, and tracks fallthrough/re-entry
+ * behavior. It also owns scan-mode statement sizing and loop metadata plans
+ * that reserve safe optimization temporaries.
+ *
+ * @par Key entry points
+ * ast_process_statement(), ast_scan_for_stmt(), ast_stmt_exits(),
+ * ast_stmt_has_reentry_label(), and ast_plan_for_metadata().
+ *
+ * @par Boundary
+ * Statement legality classifiers live in dcc_ast_gen_cond.c; final body Z80
+ * comes from a selected MIR candidate rather than this orchestration layer.
  */
 #include <string.h>
 #include "dcc_ast_gen_internal.h"


### PR DESCRIPTION
## Summary
- standardize all ten `dcc_ast*.c/.h` modules with concise Doxygen file documentation
- replace stale AST body-codegen descriptions with the generated-only MIR architecture
- add a central AST module map and explicit role, entry-point, and boundary guidance
- update the `dcc-project` and `mir-migration` skills to require the shared AST/MIR documentation convention

## Validation
- `sh src/dcc/build-dcc.sh`
- documentation coverage: 10/10 AST C/header files contain `@file`, `@brief`, and `@par Role`
- `git diff --check`

Companion to #152, which applies the same convention to MIR modules.
