### PR TITLE
Document project source module responsibilities

### DIFF
--- a/.github/skills/dcc-project/SKILL.md
+++ b/.github/skills/dcc-project/SKILL.md
@@ -43,10 +43,12 @@ python3 scripts/audit-c-module-exports.py \
   --allow-function mir_try_emit_attention_kernels
 ```
 
-## AST/MIR module documentation
+## C module documentation
 
-All `src/dcc/dcc_ast*.c/.h` and `src/dcc/dcc_mir*.c/.h` files use concise
-Doxygen-style file headers for human and agent navigation:
+Every maintained C and header module under `src/` uses a concise Doxygen-style
+file header for human and agent navigation. Tests, archived snapshots,
+generated/build output, and external fixtures are outside this blanket rule
+unless their own subsystem requires it.
 
 - `@file` and `@brief` identify the module and primary purpose.
 - `@par Role` states what the file owns.
@@ -54,11 +56,13 @@ Doxygen-style file headers for human and agent navigation:
 - `@par Boundary` states what neighboring modules own and what this file does
   not do.
 
-Keep the AST module map in `dcc_ast.h` and the MIR module map in
-`dcc_mir_internal.h` current when adding, removing, renaming, or moving
-modules. Do not describe `dcc_ast_gen*` as a production function-body fallback;
-AST processing after parsing is metadata/classification support and production
-body Z80 comes only from selected MIR candidates.
+Keep the source map above, the AST map in `dcc_ast.h`, the MIR map in
+`dcc_mir_internal.h`, and subsystem maps in private headers current when
+adding, removing, renaming, or moving modules. Update a file's header whenever
+its ownership or boundary changes. Do not describe `dcc_ast_gen*` as a
+production function-body fallback: AST processing after parsing is
+metadata/classification support and production body Z80 comes only from
+selected MIR candidates.
 
 ## Build
 

--- a/.github/skills/mir-migration/SKILL.md
+++ b/.github/skills/mir-migration/SKILL.md
@@ -45,11 +45,11 @@ Use `dcc-project` for build, test, runtime, and baseline conventions.
 | Exact schedule dispatch | `dcc_mir_machine_emit.c` |
 | Exact schedule families | `dcc_mir_machine_*.c` |
 
-AST and MIR C/header modules follow the Doxygen file-header convention defined
-in the `dcc-project` skill: `@file`, `@brief`, explicit role, key entry points,
-and module boundaries. Keep the module maps in `dcc_ast.h` and
-`dcc_mir_internal.h` current whenever files move or responsibilities change.
-Never document `dcc_ast_gen*` as a production body-codegen fallback.
+All maintained C/header modules under `src/` follow the Doxygen file-header
+convention defined in the `dcc-project` skill: `@file`, `@brief`, explicit
+role, and useful entry-point/boundary notes. For MIR changes, keep the module
+map in `dcc_mir_internal.h` current whenever files move or responsibilities
+change. Never document `dcc_ast_gen*` as a production body-codegen fallback.
 
 Place new schedules in the closest family module. Keep plan/matcher state
 automatic and expose only that module's dispatch function:

--- a/src/apps/bsearch/bsearch.c
+++ b/src/apps/bsearch/bsearch.c
@@ -1,10 +1,17 @@
-/* bsearch.c - sample: searching with the runtime bsearch.
+/**
+ * @file bsearch.c
+ * @brief Demonstrates dcc's runtime bsearch with present and absent keys.
  *
- * bsearch is now part of the dcc runtime (DCCRTL.MAC).  This file used to
- * supply a C implementation of bsearch for programs to link against, back when
- * the runtime did not provide one; it now simply demonstrates calling the
- * built-in function.  See tbsearch.c for the full unit test and the "Searching
- * and sorting" section of the dcc C89 reference guide.
+ * @par Role
+ * Provides a deterministic, no-input CP/M sample that searches a fixed sorted
+ * integer array and prints the index of each hit or a not-found result.
+ *
+ * @par Key entry points
+ * main() drives the sample; cmp_int() supplies the ordering callback.
+ *
+ * @par Boundary
+ * DCCRTL.MAC owns the bsearch implementation. tests/tbsearch.c provides the
+ * comprehensive validation; this file is an API example, not a replacement.
  */
 
 #include <stdio.h>

--- a/src/apps/mathf/mathf.c
+++ b/src/apps/mathf/mathf.c
@@ -1,16 +1,21 @@
-/*
- * mathf.c - single-precision <math.h> transcendental functions for dcc.
+/**
+ * @file mathf.c
+ * @brief Preserves historical C implementations of dcc math routines.
  *
- * HISTORICAL ONLY. This originally generated the math routines merged into
- * DCCRTL.MAC (see git history for the build/merge procedure that used to
- * apply). That block is now hand-maintained directly in DCCRTL.MAC, has
- * diverged from this file, and must NOT be regenerated from here - doing
- * so would silently discard hand-applied fixes (e.g. Inf/NaN/domain
- * handling) that only exist in the assembly. Kept for reference/context,
- * not as a build input.
+ * @par Role
+ * Retains 32-bit-float reference implementations for exponential, logarithmic,
+ * hyperbolic, trigonometric, inverse-trigonometric, and decomposition APIs.
+ * The file has no main() or standalone I/O; it formerly generated routines
+ * merged into DCCRTL.MAC.
  *
- * Constraints honoured: no double (32-bit float only), 16-bit int, 32-bit long.
- * Trig/inverse-trig polynomials are the verified approximations from trig.c.
+ * @par Key entry points
+ * expf(), logf(), powf(), sinf(), cosf(), tanf(), atanf(), atan2f(), asinf(),
+ * acosf(), frexpf(), ldexpf(), and modff().
+ *
+ * @par Boundary
+ * This is historical reference material, not a runtime build input.
+ * DCCRTL.MAC is the hand-maintained source of truth and contains fixes absent
+ * here; tests/tmathf.c validates the active runtime implementations.
  */
 
 #include <math.h>

--- a/src/apps/qsort/qsort.c
+++ b/src/apps/qsort/qsort.c
@@ -1,10 +1,19 @@
-/* qsort.c - sample: sorting with the runtime qsort.
+/**
+ * @file qsort.c
+ * @brief Demonstrates dcc's runtime qsort in ascending and descending order.
  *
- * qsort is now part of the dcc runtime (DCCRTL.MAC).  This file used to supply
- * a C implementation of qsort for programs to link against, back when the
- * runtime did not provide one; it now simply demonstrates calling the built-in
- * function.  See tqsort.c for the full unit test and the "Searching and
- * sorting" section of the dcc C89 reference guide.
+ * @par Role
+ * Provides a deterministic, no-input CP/M sample that prints a fixed integer
+ * array before sorting, after ascending sorting, and after descending sorting,
+ * with an explicit ascending-order check.
+ *
+ * @par Key entry points
+ * main() drives the sample; cmp_int_asc(), cmp_int_desc(), and show() provide
+ * callbacks and output.
+ *
+ * @par Boundary
+ * DCCRTL.MAC owns the qsort implementation. tests/tqsort.c provides the
+ * comprehensive validation; this file is an API example, not a replacement.
  */
 
 #include <stdio.h>

--- a/src/apps/soak/soak.c
+++ b/src/apps/soak/soak.c
@@ -1,39 +1,22 @@
-/* tsoak.c - long-running soak test for the dcc C runtime.
+/**
+ * @file soak.c
+ * @brief Runs deterministic long-duration validation of the dcc runtime.
  *
- * Purpose
- * -------
- * Hammer the two subsystems that this runtime-memory pass touched:
+ * @par Role
+ * Builds as a no-input CP/M target that churns the heap, creates and verifies
+ * temporary files, stresses interleaved buffered I/O, and exercises string,
+ * memory, formatted-conversion, qsort, and bsearch routines. It checks all
+ * generated data, prints progress and a final summary, and exits on any
+ * mismatch while treating transient allocation failure as expected load.
  *
- *   1. the heap allocator  - malloc / calloc / realloc / free, with random
- *      sizes, random operation order, in-place shrink/grow, and full data
- *      integrity verification of every live block;
- *   2. the buffered file I/O layer - fopen / fwrite / fread / fseek / rewind /
- *      fgets / fclose / unlink, including multi-record files, partial records,
- *      random-access seeks (which exercise the read sector cache), and the
- *      rewind seek-to-zero path, plus a multi-file interleaved phase that holds
- *      several files open at once to stress the shared-DMA read sector cache.
+ * @par Key entry points
+ * main() schedules the run; file_roundtrip(), multifile_stress(),
+ * string_stress(), format_stress(), sort_stress(), and sort_edges() implement
+ * the self-checking phases.
  *
- * It also runs three CPU/heap phases that drive runtime library routines the
- * loops above do not touch, each self-checking against a trivial oracle:
- *   3. string / memory routines (strcpy/strcat/strchr/strstr/memcpy/memmove/
- *      memset/memcmp/memchr/strdup) over heap buffers;
- *   4. printf / scanf numeric round-trips (sprintf/sscanf/atoi);
- *   5. qsort + bsearch (now runtime routines) over a heap array of ~400
- *      elements, comparator via a function pointer; the sort is checked
- *      element-for-element against an independent insertion-sort oracle and
- *      bsearch against every present key plus absent sentinels, with a
- *      separate boundary-case pass (empty, single, two, sorted, reverse,
- *      all-equal, heavy duplicates, and a descending comparator).
- *
- * The test is fully deterministic (its own LCG PRNG), validates everything it
- * writes, and treats any mismatch as a hard failure with positional context.
- * Transient out-of-memory is expected under churn and handled softly (it frees
- * a block and continues), so the only way the test stops early is a genuine
- * runtime defect.
- *
- * It runs ITERS iterations of heap churn and performs a file round-trip every
- * FILE_EVERY iterations, printing a diagnostic line every DIAG_EVERY iterations
- * so progress is visible during the (intentionally long) run.
+ * @par Boundary
+ * This application validates DCCRTL through the normal dcc target pipeline; it
+ * does not implement the runtime services it stresses.
  */
 
 #include <stdio.h>

--- a/src/apps/strconv/strconv.c
+++ b/src/apps/strconv/strconv.c
@@ -1,36 +1,20 @@
-/*
- * strconv.c - C89 string-conversion / tokenising helpers for dcc.
+/**
+ * @file strconv.c
+ * @brief Defines C89 sources for dcc runtime string conversion and tokenising.
  *
- * SOURCE OF TRUTH for strtol/strtoul/strtok, which are folded into DCCRTL.MAC
- * the same way as mathf.c (the math.h routines).  Written in portable dcc C89
- * on top of the runtime's existing helpers (strspn/strpbrk for strtok, the
- * 32-bit long divide/modulo primitives for strtol/strtoul, and errno).
+ * @par Role
+ * Provides the source-of-truth implementations of strtol(), strtoul(), and
+ * strtok() that are compiled with dcc, optimized, label-renamed, and merged
+ * into DCCRTL.MAC. The conversion routines report endpoints and range errors;
+ * strtok() keeps its required scan state. There is no main() or console I/O.
  *
- * Build/merge procedure (identical in spirit to src/apps/mathf/mathf.c):
- *   1. dcc -c strconv.c -o strconv.mac
- *   2. dccpeep strconv.mac strconv.peep.mac   (ma.sh peeps apps, NOT the
- *      runtime, so merged blocks must be pre-optimized here)
- *   3. strip: "extrn " lines (those helpers live in DCCRTL.MAC and resolve
- *      locally), the "; dcc stage-1d" banner and the "cseg" line.  KEEP the
- *      data for strtok's saved pointer (see note below).
- *   4. rename local labels L<n> -> SCL<n> (perl -pe 's/\bL(\d+)\b/SCL$1/g')
- *      AND compiler temporaries _Z<n> -> SCZ<n>, so they cannot collide with
- *      an app's own L<n>/_Z<n> labels (the same whole-token collision class
- *      that bit the math merge; see repo memory).
- *   5. splice the public blocks into DCCRTL.MAC before "end start".
+ * @par Key entry points
+ * strtol(), strtoul(), and strtok().
  *
- * NAME MANGLING: L80 only honours 6 significant characters in external
- * symbols, so the literal publics _strtol/_strtoul/_strtok all collapse to
- * "_STRTO" and collide.  dcc therefore maps these C names to short runtime
- * labels in src/dcc/dcc_asmname.c (and the src/ddc.c monolith copy):
- *   strtol -> __stol, strtoul -> __stou, strtok -> __stok.
- * The merged runtime blocks use those mangled public labels.
- *
- * NOTE on strtok state: C89 strtok keeps a saved pointer between calls.  The
- * static below compiles to a single 2-byte cell; when merging, that cell is
- * carried into DCCRTL.MAC as an explicit "dw 0" so the routine keeps its state.
- *
- * Constraints honoured: no double (long is 32-bit), 16-bit int, signed char.
+ * @par Boundary
+ * Existing DCCRTL helpers provide long arithmetic, errno, strspn(), and
+ * strpbrk(); dcc_asmname.c maps the public names to __stol, __stou, and
+ * __stok for LINK-80. tests/tstrconv.c validates the merged runtime code.
  */
 
 #include <stdlib.h>

--- a/src/dcc/dcc.c
+++ b/src/dcc/dcc.c
@@ -1,15 +1,22 @@
-/*
- * dcc.c - compiler driver and entry point (the program's main translation unit).
+/**
+ * @file dcc.c
+ * @brief Drives one source translation from command line to M80 assembly.
  *
- * Ties the pipeline together: reads the input file, resolves #include
- * directives and splices line directives, runs the active-source filtering
- * pass, parses command-line options (-o/-c/-f/-I/-D/-U/...), and contains
- * main(). The include search path (include_dirs/num_include_dirs, capped by
- * MAX_INCLUDE_DIRS) is kept module-local (static) here.
+ * @par Role
+ * Parses compiler options, reads and splices source files, expands recursive
+ * includes, filters inactive preprocessing branches, initializes compilation
+ * state, and sequences translation-unit parsing, MIR finalization, data
+ * emission, and deferred extern emission.
  *
- * MODULE: its own translation unit, using dcc.h plus the focused preprocessor
- * and AST contracts.
- * Source provenance: monolith src/ddc.c lines 17975-18841.
+ * @par Key entry points
+ * main(), preprocess_includes_file(), filter_active_preprocessor_source(), and
+ * splice_backslash_newlines().
+ *
+ * @par Boundary
+ * dcc_preproc.c owns token-level preprocessing and lexing; frontend modules
+ * own parsing; selected MIR candidates are the only source of production
+ * function bodies. This file orchestrates those stages rather than lowering
+ * function bodies itself.
  */
 
 /*

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -1,52 +1,34 @@
-/*
- * dcc.h - foundational shared contract for the modular dcc compiler.
+/**
+ * @file dcc.h
+ * @brief Defines the shared compiler contract and CP/M/Z80 target model.
  *
- * dcc uses C89 as its base language plus selected C99/C11 features suitable
- * for CP/M/Z80, and emits Z80 assembly for the M80-compatible toolchain.
- * Function bodies lower through a typed,
- * function-local AST. This header holds broadly shared target constants, core
- * records, state declarations, and cross-module APIs; narrower contracts live
- * in dcc_ast_gen_internal.h and dcc_preproc_internal.h.
+ * @par Role
+ * Provides common system includes, translation limits, token/type/storage
+ * constants, core records, shared-state declarations, and cross-module APIs.
+ * Function declarations are grouped by their owning module; the corresponding
+ * storage definitions live in dcc_state.c.
  *
- * This foundational contract includes:
- *   1. System headers used across the compiler.
- *   2. Capacity / translation-limit macros (MAX_*).
- *   3. Type-kind, storage-class and token-kind constants.
- *   4. The core record types (Token, Sym, Def, AsmName, TypeDef, FieldDef,
- *      StructDef, ConstVal, ByteOperand).
- *   5. `extern` declarations for the shared global state (defined once in
- *      dcc_state.c).
- *   6. Broadly used cross-module functions, grouped by owning module.
+ * @par Module map
+ * - dcc.c: command-line driver, source loading, includes, and stage ordering.
+ * - dcc_preproc.c / dcc_pp_expr.c: macro-aware lexing and directive
+ *   expressions.
+ * - dcc_types.c / dcc_constexpr.c / dcc_fold.c: types and constant semantics.
+ * - dcc_symbols.c / dcc_asmname.c: symbols, scopes, linkage, and target names.
+ * - dcc_func.c / dcc_stmt.c / dcc_decl.c: declarations, body traversal, and
+ *   local initialization.
+ * - dcc_global_init.c / dcc_data.c: file-scope initializer records and data
+ *   layout.
+ * - dcc_array_narrow.c / dcc_licm.c: conservative frontend proofs and plans.
+ * - dcc_expr.c / dcc_cmp.c / dcc_ops.c / dcc_assign.c / dcc_stmt_fast.c:
+ *   shared typing and low-level target helpers.
+ * - dcc_ast*.c: function-local trees, MIR capture support, and metadata only.
+ * - dcc_mir*.c: production function capture, selection, scheduling, and
+ *   emission.
  *
- * Module .c files and their responsibilities:
- *   dcc_state.c     definitions of cross-module compiler state
- *   dcc_asmname.c   C identifier -> M80 assembler symbol mapping
- *   dcc_diag_emit.c diagnostics, allocation, emit primitives, char input
- *   dcc_preproc.c   preprocessor + macro engine + lexer (next_token)
- *   dcc_pp_expr.c   preprocessor #if/#elif expression evaluator
- *   dcc_types.c     type system, struct/union/typedef parsing
- *   dcc_constexpr.c integer constant-expression parser
- *   dcc_symbols.c   symbol tables + symbol-access codegen + EXTRN
- *   dcc_fold.c      constant folding + sizeof/offsetof
- *   dcc_expr.c      declarator parsing + low-level expression emit helpers
- *   dcc_cmp.c       comparison + conditional-branch codegen
- *   dcc_ops.c       binary-operator / arithmetic codegen
- *   dcc_assign.c    float constants + global byte-array address helper
- *   dcc_stmt_fast.c in-place increment/decrement address helper
- *   dcc_decl.c      local declaration + initializer codegen
- *   dcc_stmt.c      token-to-AST statement bridge + switch helpers
- *   dcc_func.c      functions/top-level declarations + inline-body capture
- *   dcc_global_init.c file-scope object initializer parsing (record path)
- *   dcc_global_scan.c whole-file lexical global-write/address scan
- *   dcc_array_narrow.c conservative byte-narrowing proof
- *   dcc_licm.c      loop-invariant code motion and loop-local CSE
- *   dcc_ast*.c      function-local AST storage, building, gates and emission
- *   dcc_data.c      data-section emission
- *   dcc.c           driver: file I/O, #include, CLI, and main()
- *
- * Examples of state intentionally kept private to its owner:
- *   - pp_expr_p / pp_expr_depth        (dcc_pp_expr.c: #if expression cursor)
- *   - include_dirs / num_include_dirs  (dcc.c: include search path)
+ * @par Boundary
+ * Focused AST, MIR, and preprocessor contracts live in their dedicated
+ * headers. Post-parse AST work is not a body-codegen fallback: production
+ * function bodies come only from selected MIR candidates.
  */
 #ifndef DCC_H
 #define DCC_H

--- a/src/dcc/dcc_array_narrow.c
+++ b/src/dcc/dcc_array_narrow.c
@@ -1,14 +1,21 @@
-/*
- * dcc_array_narrow.c - conservative proof engine for narrowing eligible local
- * int arrays, register scalars, and for-loop counters to unsigned char.
+/**
+ * @file dcc_array_narrow.c
+ * @brief Proves when selected local integers can use unsigned-byte storage.
  *
- * The proof checks that every stored value is non-negative and <=255 and that
- * no writable alias escapes its scope. Dependencies are discovered
- * coinductively, then every write is verified against the small supported rule
- * set (literals, bounded arithmetic, group references, array reads, and simple
- * no-argument calls). Unknown shapes, aliases, recursive calls, or exhausted
- * limits decline narrowing; they never guess. Normal byte codegen then handles
- * accepted candidates without a separate lowering path.
+ * @par Role
+ * Conservatively analyzes function-local ASTs for bounded writes, dependency
+ * groups, alias escape, simple call results, and exact counting-loop shapes.
+ * It covers eligible arrays, register scalars, and for-loop counters and
+ * declines unknown, recursive, aliased, or over-limit cases.
+ *
+ * @par Key entry points
+ * narrow_array_is_byte_safe(), narrow_scalar_is_byte_safe(), and
+ * narrow_for_counter_is_byte_safe().
+ *
+ * @par Boundary
+ * This module proves safety only; callers choose storage and perform normal
+ * byte lowering. It neither mutates the source tree nor emits a production
+ * function body.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_asmname.c
+++ b/src/dcc/dcc_asmname.c
@@ -1,14 +1,19 @@
-/*
- * dcc_asmname.c - C identifier -> M80 assembler symbol mapping.
+/**
+ * @file dcc_asmname.c
+ * @brief Maps C identifiers and runtime calls to safe M80 symbol names.
  *
- * Decides how each C name is spelled in the emitted assembly: when a name must
- * be mangled (to dodge M80's 6-significant-char publics and reserved words),
- * when it maps to a fixed runtime-library entry point, and caches the
- * allocated assembler names in the shared asm_names[] table.
+ * @par Role
+ * Applies reserved-name and short-significance mangling, recognizes fixed
+ * runtime labels and internal publics, selects printf-family variants, caches
+ * assigned names, and diagnoses collisions among emitted PUBLIC symbols.
  *
- * MODULE: its own translation unit. Uses struct AsmName / MAX_ASM_NAMES and the
- * asm_names[] table; all shared declarations come from the umbrella header dcc.h.
- * Source provenance: monolith src/ddc.c lines 207-336.
+ * @par Key entry points
+ * asm_name_for(), asm_name_for_runtime(), asm_name_for_pf_call(),
+ * asm_name_must_mangle(), and asm_name_check_public_collision().
+ *
+ * @par Boundary
+ * Symbol ownership and EXTRN tracking belong to dcc_symbols.c; callers that
+ * emit declarations decide when a mapped name becomes PUBLIC.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_assign.c
+++ b/src/dcc/dcc_assign.c
@@ -1,15 +1,18 @@
-/*
- * dcc_assign.c - shared assignment/float emit helpers for the AST emitter.
+/**
+ * @file dcc_assign.c
+ * @brief Supplies small target helpers shared by assignment-related paths.
  *
- * Low-level primitives the AST emitter calls while lowering assignments and
- * float values: emit_load_float_bits materialises a 32-bit float constant into
- * the DE:HL register pair, and emit_global_byte_array_index_addr computes the
- * address of a byte-array element at a global symbol (constant or ix-relative
- * index). Assignment statement/expression lowering itself lives in the AST
- * emitter (dcc_ast_gen*.c).
+ * @par Role
+ * Materializes a 32-bit float bit pattern in DE:HL and computes the address of
+ * an indexed global byte-array element for constant or frame-local indices.
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
- * Source provenance: monolith src/ddc.c lines 11521-12417.
+ * @par Key entry points
+ * emit_load_float_bits() and emit_global_byte_array_index_addr().
+ *
+ * @par Boundary
+ * This file does not own assignment semantics or candidate selection.
+ * Production function-body output is committed only through selected MIR
+ * candidates.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_cmp.c
+++ b/src/dcc/dcc_cmp.c
@@ -1,14 +1,21 @@
-/*
- * dcc_cmp.c - comparison and conditional-branch code generation.
+/**
+ * @file dcc_cmp.c
+ * @brief Implements shared Z80 comparison and conditional-branch primitives.
  *
- * Relational/equality comparison codegen (signed and unsigned, 16- and 32-bit)
- * and the direct condition-to-branch lowering used by if/while/for. Includes
- * the byte-operand fast comparators that emit a single cp + conditional jump.
- * struct ByteOperand is declared in dcc.h.
+ * @par Role
+ * Materializes 16-bit comparison results, emits signed and unsigned branches,
+ * supports direct byte operands, and provides small-constant local-variable
+ * branch fast paths.
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
- * Source provenance: monolith src/ddc.c lines 8842-9235 and 9242-10184
- * (the struct ByteOperand definition at 9236-9241 is hoisted to dcc.h).
+ * @par Key entry points
+ * gen_cmp_typed(), emit_cmp_branch_true(), emit_cmp_branch_false(),
+ * emit_byte_cmp_branch_after_cp(), and
+ * emit_cmp_const_branch_for_signed_local16().
+ *
+ * @par Boundary
+ * Callers establish operand types and registers. This module supplies target
+ * primitives but does not parse expressions or select production body
+ * candidates; final function bodies are MIR-selected.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_constexpr.c
+++ b/src/dcc/dcc_constexpr.c
@@ -1,9 +1,20 @@
-/*
- * dcc_constexpr.c - integer constant-expression context wrappers.
+/**
+ * @file dcc_constexpr.c
+ * @brief Applies declaration-context rules to typed constant expressions.
  *
- * Typed constant evaluation is implemented by the ConstVal engine in
- * dcc_fold.c.  This module provides the context-specific conversions used by
- * declarations and parses the C11 _Static_assert declaration.
+ * @par Role
+ * Wraps the ConstVal evaluator with range and validity checks for array
+ * bounds, designators, enumerators, integer and long contexts; parses
+ * _Static_assert declarations; and recognizes tokens that can start a type.
+ *
+ * @par Key entry points
+ * parse_typed_const_int_expr(), parse_typed_array_bound_expr(),
+ * parse_typed_const_long_expr(), parse_typed_enum_const_expr(),
+ * parse_static_assert_decl(), and starts_type().
+ *
+ * @par Boundary
+ * dcc_fold.c owns typed expression evaluation. This module validates specific
+ * declaration contexts and emits no function-body code.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_data.c
+++ b/src/dcc/dcc_data.c
@@ -1,12 +1,18 @@
-/*
- * dcc_data.c - data-section emission.
+/**
+ * @file dcc_data.c
+ * @brief Emits string, initialized-data, BSS, and stack-layout assembly.
  *
- * Writes the assembled data segment: the string-literal pool and global
- * object storage with their initializers, rendered as DEFB/DEFW (numbers and
- * label references) by emit_data().
+ * @par Role
+ * Serializes string literals and global initializer records, marks required
+ * externs, lays out uninitialized objects for application or module mode, and
+ * publishes data, BSS, heap, and stack boundary symbols.
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
- * Source provenance: monolith src/ddc.c lines 17706-17974.
+ * @par Key entry points
+ * emit_data(), emit_init_numeric(), and emit_init_label_or_number().
+ *
+ * @par Boundary
+ * dcc_global_init.c builds initializer records and dcc_symbols.c owns the
+ * referenced symbols. This module emits data layout, not function bodies.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_decl.c
+++ b/src/dcc/dcc_decl.c
@@ -1,12 +1,21 @@
-/*
- * dcc_decl.c - local declaration and initializer code generation.
+/**
+ * @file dcc_decl.c
+ * @brief Parses function-local declarations and their initialization plans.
  *
- * Emits storage and initialisation for function-local declarations: scalars,
- * arrays, structs/unions and bitfields, brace-enclosed initializer lists, and
- * const-scalar folding of local initializers into immediates.
+ * @par Role
+ * Allocates automatic objects, folds eligible constant locals, handles scalar,
+ * array, aggregate, bitfield, string, and VLA initialization, and keeps local
+ * declaration replay consistent with frame sizing and MIR capture.
  *
- * MODULE: compiled as its own translation unit.
- * Source provenance: monolith src/ddc.c lines 13128-13991.
+ * @par Key entry points
+ * gen_local_decl_after_type(), try_const_fold_local(),
+ * emit_init_auto_struct_from_list(), emit_init_auto_array_from_list(), and
+ * emit_zero_local_bytes().
+ *
+ * @par Boundary
+ * File-scope initializers are recorded by dcc_global_init.c. Expression trees
+ * and metadata come from the AST modules, while selected MIR candidates alone
+ * provide production function bodies.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_diag_emit.c
+++ b/src/dcc/dcc_diag_emit.c
@@ -1,14 +1,21 @@
-/*
- * dcc_diag_emit.c - diagnostics, allocation, and low-level emit primitives.
+/**
+ * @file dcc_diag_emit.c
+ * @brief Provides diagnostics, source locations, allocation, and text output.
  *
- * The compiler's "plumbing": fatal()/error_here() error reporting,
- * source_location_at() for #line-aware positions, allocation and checked
- * stream-reading helpers, EmitSink switching, assembly-output primitives, and
- * raw source character readers (peekc/getc_src).
+ * @par Role
+ * Maps diagnostics to stable codes, renders source-aware errors and warnings,
+ * caches #line-adjusted locations, supplies checked allocation and stream
+ * loading, manages assembly labels/text primitives, and reads translated
+ * source characters including trigraphs.
  *
- * MODULE: compiled as its own translation unit; macro helpers used for source
- * rendering are declared in dcc_preproc_internal.h.
- * Source provenance: monolith src/ddc.c lines 495-691.
+ * @par Key entry points
+ * dcc_error_at(), error_here(), warn_at(), source_location_at(), xmalloc(),
+ * emit(), emit_label(), peekc(), and getc_src().
+ *
+ * @par Boundary
+ * Parsers decide which diagnostics to issue, and MIR/data modules decide what
+ * assembly to produce. This module supplies shared reporting and output
+ * plumbing without owning those higher-level policies.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_expr.c
+++ b/src/dcc/dcc_expr.c
@@ -1,13 +1,22 @@
-/*
- * dcc_expr.c - low-level expression/declarator parsing and emit helpers.
+/**
+ * @file dcc_expr.c
+ * @brief Houses shared declarator, expression, and target-value utilities.
  *
- * Implements memory loads/stores through HL, struct copies, conversions,
- * bitfield access, increment/decrement, and call cleanup used by the AST
- * emitter. It also parses sizeof operands, function-pointer/array declarators,
- * initializer atoms, enum constants, and user-label bookkeeping.
+ * @par Role
+ * Parses sizeof operands and function-pointer/array declarators, counts
+ * initializer shapes, tracks user labels, and implements common memory,
+ * aggregate, conversion, bitfield, call-cleanup, and increment/decrement
+ * primitives.
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
- * Source provenance: monolith src/ddc.c lines 5373-8841.
+ * @par Key entry points
+ * parse_sizeof_expr_operand(), parse_funcptr_declarator(),
+ * parse_array_declarator_dims(), emit_load_from_hl(),
+ * emit_store_de_to_addr_hl(), and define_user_label().
+ *
+ * @par Boundary
+ * dcc_ast_build.c owns general expression grammar and dcc_types.c owns the
+ * target type model. These helpers do not form a production body fallback;
+ * final function bodies come from selected MIR candidates.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_fold.c
+++ b/src/dcc/dcc_fold.c
@@ -1,13 +1,20 @@
-/*
- * dcc_fold.c - compile-time constant folding and sizeof/offsetof.
+/**
+ * @file dcc_fold.c
+ * @brief Evaluates typed compile-time expressions into ConstVal results.
  *
- * The cf_* value engine evaluates constant sub-expressions (with C type and
- * promotion rules) to fold them to immediates; plus sizeof/offsetof operand
- * evaluation and emission of folded constant results. struct ConstVal is
- * declared in dcc.h.
+ * @par Role
+ * Implements the constant-expression precedence parser, target-width masks,
+ * promotions, casts, arithmetic, comparisons, logical operations, conditional
+ * expressions, integer/float literals, and sizeof/offsetof folding.
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
- * Source provenance: monolith src/ddc.c lines 4806-5372.
+ * @par Key entry points
+ * try_parse_const_expr_value(), try_parse_integer_const_expr_value(),
+ * cf_parse_cond(), cf_convert_to_type(), and emit_const_value().
+ *
+ * @par Boundary
+ * dcc_constexpr.c applies declaration-specific validity and range rules.
+ * Runtime expression capture and production function-body selection belong to
+ * the AST and MIR layers.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -1,15 +1,21 @@
-/*
- * dcc_func.c - function and top-level declaration parsing.
+/**
+ * @file dcc_func.c
+ * @brief Parses file-scope declarations and coordinates function capture.
  *
- * Parameter lists (prototype and K&R old-style), function prologue/epilogue
- * and frame layout, inline/narrowing candidate capture, the function-body scan,
- * typedef declarations, and
- * top-level declaration dispatch (parse_function_or_global,
- * parse_translation_unit). File-scope initializer parsing is in
- * dcc_global_init.c.
+ * @par Role
+ * Handles prototype and K&R parameter lists, typedefs, top-level declaration
+ * dispatch, frame-sizing scans, inline and narrowing metadata, debug records,
+ * deferred static bodies, and the begin/end lifecycle for each MIR function.
  *
- * MODULE: compiled as its own translation unit.
- * Source provenance: monolith src/ddc.c lines 15880-17705.
+ * @par Key entry points
+ * parse_translation_unit(), parse_function_or_global(), scan_function_body(),
+ * begin_function_mir(), finish_function_mir(), and
+ * emit_needed_deferred_bodies().
+ *
+ * @par Boundary
+ * dcc_stmt.c traverses compound bodies and dcc_global_init.c records file-scope
+ * initializers. This module coordinates MIR capture; selected MIR candidates,
+ * never AST or legacy output, supply production function bodies.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_global_init.c
+++ b/src/dcc/dcc_global_init.c
@@ -1,16 +1,20 @@
-/*
- * dcc_global_init.c - file-scope (global/static) object initializer parsing.
+/**
+ * @file dcc_global_init.c
+ * @brief Records file-scope object initializers for later data emission.
  *
- * Parses a global object's initializer from the token stream and records the
- * initialized-data image (bytes + relocatable label references) on the symbol,
- * for later emission by the data section. It is the "record" counterpart to
- * dcc_decl.c's "emit" path for automatic (local) initializers.
+ * @par Role
+ * Parses scalar, array, struct/union, bitfield, string, compound-literal, and
+ * designated initializers into each symbol's byte-and-relocation image,
+ * including padding, overwrites, and inferred array bounds.
  *
- * Entry points (declared in dcc.h): parse_global_init_type / _array / _struct
- * / _list, the parse_global_scalar_array_* helpers, parse_global_init_atom,
- * and the append_global_* image builders. Everything else here is file-local.
+ * @par Key entry points
+ * parse_global_init_list(), parse_global_init_type(),
+ * parse_global_init_array(), parse_global_init_struct(),
+ * parse_global_init_atom(), and append_global_init().
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
+ * @par Boundary
+ * dcc_data.c serializes the recorded image, while dcc_decl.c handles automatic
+ * objects. This module records data and emits no function body.
  */
 #include "dcc.h"
 

--- a/src/dcc/dcc_global_scan.c
+++ b/src/dcc/dcc_global_scan.c
@@ -1,41 +1,21 @@
-/*
- * dcc_global_scan.c - whole-translation-unit lexical scan of which
- * identifiers are ever written to or have their address taken, and (for
- * writes) which function that happens in.
+/**
+ * @file dcc_global_scan.c
+ * @brief Collects conservative whole-file global write and address facts.
  *
- * This exists to let a codegen fast path (see ast_for_hoist_global_member_
- * value_supported, dcc_ast_gen_support.c) prove a global variable's value is
- * invariant across an entire function's execution - specifically, across a
- * hot loop full of calls that the compiler cannot otherwise rule out as
- * reassigning it. dcc compiles in a single forward pass over the source, so
- * while generating one function it has no way to know whether some
- * later-defined function also reassigns a given global; this module runs a
- * dedicated pre-pass over the *entire* file first (before any real parsing
- * or codegen begins) purely to answer that one question, then rewinds all
- * lexer/preprocessor state as if it had never run.
+ * @par Role
+ * Runs a one-time lexical prepass over the finalized source, records writes
+ * and address-taking for names and direct fields with enclosing-function
+ * attribution, then restores source, lexer, macro, and option state before
+ * normal parsing begins.
  *
- * This is a lexical pattern match, not a semantic one: it does not resolve
- * identifiers through the real symbol table (which does not exist yet at
- * pre-pass time) and only recognises "this token looks like a write to name
- * X" from token-kind adjacency (an identifier immediately followed by an
- * assignment/increment/decrement operator, or immediately preceded by one,
- * or immediately preceded by '&', and not immediately preceded by '.' or
- * "->" - which would make it a struct member name, not a variable
- * reference). A local variable or struct field that happens to share a
- * global's name can therefore be counted as if it were a write to that
- * global; this is always the SAFE direction (it only makes the analysis
- * more conservative, never less), which is what matters here.
+ * @par Key entry points
+ * scan_global_write_info(), global_text_write_count(),
+ * global_text_addr_taken_count(), and the global_text_field_*() queries.
  *
- * What this does NOT prove: that the one recorded writer function can never
- * be re-entered from within the call graph of the function asking the
- * question. That would need real interprocedural call-graph analysis, which
- * this module does not attempt. The residual assumption is: once a global
- * has been written by its one writer, nothing later in the program's
- * execution calls that writer again. This holds for the ordinary "init once,
- * then treat as read-only" idiom this feature targets, and is exactly the
- * shape ast_for_hoist_global_member_value_supported requires (a single
- * textual write site outside the function being optimised) before it will
- * ever consider the global invariant.
+ * @par Boundary
+ * This is token-pattern analysis, not symbol resolution or call-graph proof;
+ * shadowing and uncertain shapes may only add conservative false positives.
+ * It builds no AST or symbols and emits no code.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_licm.c
+++ b/src/dcc/dcc_licm.c
@@ -1,64 +1,20 @@
-/*
- * dcc_licm.c - general loop-invariant code motion for `for` loop bodies.
+/**
+ * @file dcc_licm.c
+ * @brief Plans AST metadata for scalar LICM and loop-local CSE temporaries.
  *
- * dcc_ast_stmt_meta.c plans three narrow, single-statement-body
- * shapes (a loop-invariant lvalue address, a row-invariant 2D array read,
- * and a global-member value proven invariant via dcc_global_scan.c). This
- * file generalizes the same idea - "the same value gets recomputed every
- * iteration even though it can't actually change" - to loop bodies of any
- * shape (multiple statements, nested ifs), for the narrower but still very
- * common case of a pure scalar-arithmetic subexpression (no memory access,
- * no calls, no side effects) that doesn't depend on anything the loop
- * itself modifies.
+ * @par Role
+ * During frame-sizing and metadata walks, scans for-loop ASTs for modified
+ * names, models pure invariant or profitably repeated scalar arithmetic,
+ * allocates the required compiler temporaries, and builds copy-on-write
+ * rewrites without changing the original tree.
  *
- * Motivating case (tests/00040.c, an 8-queens solver profiled at 98.5% of
- * total runtime in one function):
+ * @par Key entry points
+ * ast_licm_plan_invariants().
  *
- *     int chk(int x, int y)
- *     {
- *         int i, r;
- *         for (r=i=0; i<8; i++) {
- *             r = r + t[x + 8*i];
- *             r = r + t[i + 8*y];   -- 8*y recomputed every iteration
- *             ...
- *         }
- *     }
- *
- * `y` is a parameter, never assigned anywhere in the loop, so `8*y` is the
- * same value on every one of the loop's iterations - and this shape (a
- * multi-statement body with several `if`s) doesn't match any of the three
- * existing narrow hoists at all.
- *
- * Design, deliberately conservative at every step (an unrecognized shape or
- * anything that could plausibly break the invariance argument is always a
- * decline, never a guess - matching dcc_array_narrow.c/dcc_global_scan.c):
- *
- *   1. Scan the loop's condition, increment, and body for every plain
- *      identifier that is assigned, incremented/decremented, or has its
- *      address taken anywhere - that's the set nothing invariant may depend
- *      on. Any function call anywhere, or any statement/expression shape
- *      this doesn't specifically recognize, marks the WHOLE set as
- *      "modified" (i.e. declines every candidate), since a call could modify
- *      anything through an escaped pointer or global that a purely lexical
- *      scan can't rule out.
- *   2. Walk the body looking for the largest (outermost) subexpressions that
- *      are pure scalar arithmetic (int-sized, no pointers, no memory access,
- *      no calls) and reference only locals/params outside that modified
- *      set - never descending further into an eligible subexpression once
- *      found, so `t[x + 8*i]`'s inner `8*i` is correctly left alone (`i` is
- *      modified) while `t[i + 8*y]`'s inner `8*y` is found and taken whole.
- *   3. For each distinct candidate (by structural equality - the same
- *      subexpression appearing more than once shares one temp), compute its
- *      value once, into a fresh compiler-temp local, before the loop.
- *   4. Return a rewritten copy of the body with every occurrence replaced by
- *      a reference to its temp; the original body node is never mutated,
- *      matching ast_hoist_row_invariant_2d_reads's sharing discipline
- *      (only allocate a fresh copy of a node when something beneath it
- *      actually changed).
- *
- * Runs independently of, and after, the three narrow metadata hoists -
- * only when none of them already produced a hoist body,
- * to keep this file's interaction with that existing code trivial.
+ * @par Boundary
+ * Calls, memory-dependent values, aliases, unsupported shapes, and exhausted
+ * limits cause conservative decline. These AST rewrites are planning support,
+ * not production output; MIR owns function capture, selection, and emission.
  */
 #include "dcc.h"
 #include "dcc_ast.h"

--- a/src/dcc/dcc_ops.c
+++ b/src/dcc/dcc_ops.c
@@ -1,13 +1,21 @@
-/*
- * dcc_ops.c - binary-operator and arithmetic code generation.
+/**
+ * @file dcc_ops.c
+ * @brief Implements shared arithmetic typing and Z80 operator primitives.
  *
- * Lowering for +, -, *, /, %, shifts and bitwise operators across 16- and
- * 32-bit and unsigned variants, integer promotion to the common type, the
- * element-size scaling used by pointer arithmetic, and the float-compare and
- * nonzero-test helpers the AST emitter calls into.
+ * @par Role
+ * Provides integer promotions and common types, 16- and 32-bit arithmetic,
+ * comparisons, shifts, masks, constant multiply/divide scaling, pointer
+ * element scaling, float comparisons, and nonzero tests.
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
- * Source provenance: monolith src/ddc.c lines 10185-11520.
+ * @par Key entry points
+ * gen_binop_typed(), gen_binop32_typed(), common_arith_type(),
+ * emit_mul_hl_const(), scale_hl_by_elem_size(), and
+ * emit_test_expr_nonzero().
+ *
+ * @par Boundary
+ * Callers own expression semantics and operand placement. These are reusable
+ * target helpers, not an alternate function-body generator; production bodies
+ * are emitted from selected MIR candidates.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_pp_expr.c
+++ b/src/dcc/dcc_pp_expr.c
@@ -1,9 +1,18 @@
-/*
- * dcc_pp_expr.c - preprocessor #if/#elif constant-expression evaluator.
+/**
+ * @file dcc_pp_expr.c
+ * @brief Evaluates preprocessor #if and #elif expression text.
  *
- * The evaluator parses an already-expanded expression string using a compact
- * recursive-descent precedence ladder. Only pp_eval_simple_expr is shared;
- * cursor state and precedence helpers are private to this translation unit.
+ * @par Role
+ * Implements a private recursive-descent precedence parser for integer and
+ * character constants, defined(), unary and binary operators, logical
+ * short-circuiting, and conditional expressions.
+ *
+ * @par Key entry points
+ * pp_eval_simple_expr().
+ *
+ * @par Boundary
+ * Macro-table lookup is provided by dcc_preproc.c. This evaluator implements
+ * preprocessing arithmetic, not the typed C constant semantics in dcc_fold.c.
  */
 
 #include "dcc_preproc_internal.h"

--- a/src/dcc/dcc_preproc.c
+++ b/src/dcc/dcc_preproc.c
@@ -1,14 +1,21 @@
-/*
- * dcc_preproc.c - preprocessor, macro engine, and lexer.
+/**
+ * @file dcc_preproc.c
+ * @brief Implements directive handling, macro expansion, and tokenization.
  *
- * Handles #define/#undef/#if/#ifdef directives, object- and function-like
- * macro expansion (including # stringize and ## paste), conditional-directive
- * handling, and the main tokenizer next_token() that feeds the parser. The
- * #if expression evaluator lives in dcc_pp_expr.c.
+ * @par Role
+ * Owns the macro table and conditional stack, processes active directives and
+ * pragmas, expands object/function/variadic macros with stringize and paste,
+ * rewrites source ranges safely, decodes literals, and supplies the parser's
+ * one-token lexer with save/restore support.
  *
- * MODULE: compiled as its own translation unit; macro-table entry points shared
- * with the driver/evaluator are declared in dcc_preproc_internal.h.
- * Source provenance: monolith src/ddc.c lines 692-2871.
+ * @par Key entry points
+ * next_token(), parse_preprocessor_line(), add_define(), remove_define(),
+ * macro_expand_argument_text(), lex_save(), and lex_restore().
+ *
+ * @par Boundary
+ * dcc.c owns recursive include expansion and the initial inactive-source
+ * filter; dcc_pp_expr.c evaluates directive expressions. C grammar and
+ * production body generation are outside this module.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_preproc_internal.h
+++ b/src/dcc/dcc_preproc_internal.h
@@ -1,5 +1,20 @@
-/* dcc_preproc_internal.h - macro-table and #if evaluator contract shared by
- * the driver, preprocessor, diagnostics, and dcc_pp_expr.c. */
+/**
+ * @file dcc_preproc_internal.h
+ * @brief Declares the focused cross-module preprocessing contract.
+ *
+ * @par Role
+ * Exposes macro-table lookup and mutation, preprocessing-expression
+ * evaluation, and replacement-comment stripping to the driver, lexer,
+ * diagnostics, and directive evaluator.
+ *
+ * @par Key entry points
+ * find_define(), add_define_ex(), remove_define(), pp_eval_simple_expr(), and
+ * strip_macro_replacement_comments().
+ *
+ * @par Boundary
+ * The public compiler-wide lexer and parser APIs remain in dcc.h; private
+ * macro-expansion state stays in dcc_preproc.c and dcc_pp_expr.c.
+ */
 #ifndef DCC_PREPROC_INTERNAL_H
 #define DCC_PREPROC_INTERNAL_H
 

--- a/src/dcc/dcc_state.c
+++ b/src/dcc/dcc_state.c
@@ -1,17 +1,17 @@
-/*
- * dcc_state.c - definitions of the shared mutable state for the dcc compiler.
+/**
+ * @file dcc_state.c
+ * @brief Defines compiler-wide mutable state declared by dcc.h.
  *
- * Defines cross-module compiler state declared in dcc.h and focused internal
- * headers. Truly module-local state remains static in its owning file.
+ * @par Role
+ * Instantiates shared option, type, symbol, lexer, preprocessing, function,
+ * scope, diagnostic, initializer, debug, and emission state. Related live
+ * fields are grouped in lifecycle records such as LexState, FrameState,
+ * ExprState, FunctionPassState, DeclState, and EmitSink.
  *
- * Why dcc keeps so much shared state: parser, AST builder, and codegen helpers
- * share a large amount of "current position" state (the source buffer, the
- * lookahead token, the symbol tables, per-function codegen flags, ...).
- * Related live fields are grouped by lifecycle in LexState, FrameState,
- * ExprState, FunctionPassState, DeclState, and EmitSink rather than exposed as
- * independent scalars.
- *
- * Source provenance: monolith src/ddc.c lines 199-203, 347-348, 378-489.
+ * @par Boundary
+ * This file provides storage, not behavior. State used by only one module
+ * remains static in that owner rather than becoming part of the shared
+ * contract.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_stmt.c
+++ b/src/dcc/dcc_stmt.c
@@ -1,11 +1,19 @@
-/*
- * dcc_stmt.c - statement code generation.
+/**
+ * @file dcc_stmt.c
+ * @brief Traverses function compounds and bridges statements into AST/MIR.
  *
- * Compound-block parsing plus shared statement/codegen helpers used by the AST
- * emitter. Statement lowering itself lives in dcc_ast_gen*.c.
+ * @par Role
+ * Parses compound-block sequencing, dispatches declarations and statements,
+ * maintains lexical/VLA scopes, suppresses unreachable work while preserving
+ * re-entry labels, and records closing-brace diagnostics and debug locations.
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
- * Source provenance: monolith src/ddc.c lines 13992-15879.
+ * @par Key entry points
+ * process_compound() and gen_statement().
+ *
+ * @par Boundary
+ * gen_statement() is a frontend bridge to AST processing and MIR capture, not
+ * a legacy body emitter. AST modules own statement structure and metadata;
+ * selected MIR candidates alone provide production function bodies.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_stmt_fast.c
+++ b/src/dcc/dcc_stmt_fast.c
@@ -1,13 +1,17 @@
-/*
- * dcc_stmt_fast.c - in-place increment/decrement address-form emit helper.
+/**
+ * @file dcc_stmt_fast.c
+ * @brief Emits an in-place increment or decrement through an HL address.
  *
- * emit_incdec_addr emits an in-place ++/-- on the lvalue whose address is
- * already in HL, sized for the operand type: a single inc/dec (hl) for bytes,
- * or a multi-byte ripple with early-out for 16- and 32-bit operands. Called by
- * the AST emitter when lowering pre/post increment and decrement.
+ * @par Role
+ * Updates byte, 16-bit, or 32-bit lvalues with compact Z80 sequences, using
+ * carry/borrow ripple and early exits for multi-byte objects.
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
- * Source provenance: monolith src/ddc.c lines 12418-13127.
+ * @par Key entry points
+ * emit_incdec_addr().
+ *
+ * @par Boundary
+ * Callers resolve the lvalue, type, and pre/post value semantics. This target
+ * helper neither analyzes statements nor selects a production MIR candidate.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_symbols.c
+++ b/src/dcc/dcc_symbols.c
@@ -1,13 +1,22 @@
-/*
- * dcc_symbols.c - symbol tables and symbol-access code generation.
+/**
+ * @file dcc_symbols.c
+ * @brief Owns symbol lookup, scopes, linkage bookkeeping, and symbol access.
  *
- * Lookup/allocation of locals, parameters and globals; the string-literal
- * pool; EXTRN bookkeeping (emit_extrn_if_needed/emit_deferred_extrns); and the
- * code that loads/stores a symbol's address or value (frame-relative or direct
- * for globals), including post-increment/decrement fast paths.
+ * @par Role
+ * Allocates globals, locals, parameters, temporaries, and strings; manages
+ * block and for-init renames plus VLA scope/fixup state; tracks deferred
+ * EXTRNs and runtime calls; and supplies frame/global address, load, store,
+ * sizeof, and offsetof helpers.
  *
- * MODULE: compiled as its own translation unit.
- * Source provenance: monolith src/ddc.c lines 3829-4801.
+ * @par Key entry points
+ * find_sym(), add_global(), add_local_alloc(), enter_scope(), leave_scope(),
+ * emit_extrn_if_needed(), emit_runtime_call(), emit_load_sym_addr(), and
+ * sizeof_parse_primary_type().
+ *
+ * @par Boundary
+ * dcc_state.c stores shared tables, dcc_asmname.c maps target spellings, and
+ * dcc_types.c owns type construction. Low-level access helpers here do not
+ * choose production function-body candidates; MIR does.
  */
 
 #include "dcc.h"

--- a/src/dcc/dcc_types.c
+++ b/src/dcc/dcc_types.c
@@ -1,14 +1,20 @@
-/*
- * dcc_types.c - type system and aggregate/typedef parsing.
+/**
+ * @file dcc_types.c
+ * @brief Implements the target type model and aggregate/type-name parsing.
  *
- * Base-type and declarator parsing (parse_base_type/parse_type), struct/union
- * and typedef tables, bitfield layout, type sizing/promotion/arithmetic
- * helpers, and enum-constant lookup. find_enum_const() is relocated here from
- * the monolith's declaration block (its only caller is the global-init parser).
+ * @par Role
+ * Encodes size and pointer-depth operations, array dimensions and strides,
+ * target-size checks, struct/union and bitfield layout, typedef and enum
+ * lookup, qualifiers, base types, declarators, and abstract type names.
  *
- * MODULE: compiled as its own translation unit; shared declarations are in dcc.h.
- * Source provenance: monolith src/ddc.c line 467-474 (find_enum_const) then
- * lines 2872-3559.
+ * @par Key entry points
+ * type_size(), type_ptr_depth(), parse_base_type(), parse_type(),
+ * parse_type_name_decl(), parse_struct_definition(), and find_field_def().
+ *
+ * @par Boundary
+ * Function declarators are completed by dcc_expr.c and dcc_func.c; typed
+ * constant evaluation lives in dcc_fold.c and dcc_constexpr.c. This module
+ * defines types and emits no function-body code.
  */
 
 #include "dcc.h"

--- a/src/dccmake/dccmake.c
+++ b/src/dccmake/dccmake.c
@@ -1,8 +1,20 @@
-/*
- * dccmake - small build driver for the dcc CP/M pipeline.
+/**
+ * @file dccmake.c
+ * @brief Drives complete dcc builds of CP/M applications.
  *
- * Pipeline:
- *   dcc -> optional dccpeep -> ntvcm M80 -> dccrtlstrip -> ntvcm M80 -> ntvcm L80
+ * @par Role
+ * Reads dccmake.txt and command-line settings, validates CP/M names, compiles
+ * one or more C sources to .MAC, optionally optimizes them, assembles the
+ * application and reduced runtime, and links the final .COM plus requested
+ * listing, symbol, and debug artifacts.
+ *
+ * @par Key entry points
+ * main() loads configuration; run_build() invokes each pipeline stage.
+ *
+ * @par Boundary
+ * dcc and dccpeep produce application assembly, dccrtlstrip selects runtime
+ * blocks, and m80c/M80 plus l80c/L80 assemble and link. This driver configures
+ * and invokes those tools but does not implement their transformations.
  */
 /* CLOCK_MONOTONIC/clock_gettime (used by now_ms() below) are POSIX, not
  * plain C11 - glibc only declares them if a feature-test macro requesting

--- a/src/dccpeep/dccpeep.c
+++ b/src/dccpeep/dccpeep.c
@@ -1,9 +1,20 @@
-/*
- * dccpeep.c - fixed-point peephole optimizer for dcc-generated Z80/M80 assembly.
+/**
+ * @file dccpeep.c
+ * @brief Orchestrates dcc's Z80/M80 peephole optimizer.
  *
- * main() preserves the order of convergent, post-convergence, size-mode, and
- * final-cleanup passes. Individual passes return nonzero when they rewrite the
- * shared line program declared in dccpeep_internal.h.
+ * @par Role
+ * Owns command-line handling, pass statistics, the fixed-point,
+ * post-convergence, size-mode, and final-cleanup schedule, plus the core
+ * transformations and register-claim queries not split into focused modules.
+ *
+ * @par Key entry points
+ * main() reads an assembly file, runs the ordered pass pipeline, and writes
+ * the settled line program.
+ *
+ * @par Boundary
+ * peep_lines.c owns line storage and I/O; the peep_* analysis modules and
+ * peep_pass_* families own their focused contracts. Pass ordering remains
+ * solely in this file.
  */
 #include "dccpeep_internal.h"
 

--- a/src/dccpeep/dccpeep_internal.h
+++ b/src/dccpeep/dccpeep_internal.h
@@ -1,7 +1,31 @@
-/* dccpeep_internal.h - private line-program contract for dccpeep modules.
+/**
+ * @file dccpeep_internal.h
+ * @brief Defines the private line-program and pass contract for dccpeep.
  *
- * Passes may mutate only through this API: user-assembly entries are opaque,
- * and the scheduler in dccpeep.c remains the sole owner of pass ordering.
+ * @par Role
+ * Declares shared options, statistics, line/effect/CFG representations,
+ * mutation transactions, parsing and analysis helpers, and pass entry points.
+ *
+ * @par Module map
+ * - dccpeep.c: CLI, pass scheduling, core rewrites, and register claims.
+ * - peep_lines.c: line ownership, opaque user assembly, mutation, and I/O.
+ * - peep_parse.c: exact Z80/M80 text parsers and formatters.
+ * - peep_analyze.c: lightweight register and function safety queries.
+ * - peep_control_flow.c: label, jump, function, and loop-bound queries.
+ * - peep_effects.c: cached line classification and machine effects.
+ * - peep_dataflow.c: versioned CFG, basic blocks, and liveness.
+ * - peep_frame_alloc.c: analysis-only frame-slot promotion census.
+ * - peep_pass_once.c: ordered single-scan local rewrites.
+ * - peep_pass_control_flow.c: label and branch rewrite passes.
+ * - peep_pass_inline_temp.c: tagged inline-temporary spill rewrites.
+ * - peep_pass_loops.c: loop-scoped register promotion.
+ * - peep_pass_minmax.c: exact board-game and minimax rewrites.
+ * - peep_pass_stubs.c: size-mode shared-helper factoring.
+ * - peep_pass_final.c: terminal relaxation and dead-state cleanup.
+ *
+ * @par Boundary
+ * This header is private to dccpeep. Passes mutate only through the line API,
+ * user-assembly entries remain opaque, and dccpeep.c alone orders passes.
  */
 #ifndef DCCPEEP_INTERNAL_H
 #define DCCPEEP_INTERNAL_H

--- a/src/dccpeep/peep_analyze.c
+++ b/src/dccpeep/peep_analyze.c
@@ -1,4 +1,21 @@
-/* peep_analyze.c - shared register and function-bound safety analysis. */
+/**
+ * @file peep_analyze.c
+ * @brief Provides lightweight conservative safety queries over assembly text.
+ *
+ * @par Role
+ * Detects register-pair clobbers and textual register uses, wraps indexed
+ * function-bound lookup, and records local function labels used to prevent
+ * unsafe register borrowing across calls.
+ *
+ * @par Key entry points
+ * line_clobbers_bc(), line_touches_reg_pair(), find_function_bounds(),
+ * find_function_bounds_any(), and scan_local_func_labels().
+ *
+ * @par Boundary
+ * This module does not build structured effects, CFGs, or liveness; those
+ * belong to peep_effects.c and peep_dataflow.c. Unrecognized text is treated
+ * conservatively by each query.
+ */
 #include "dccpeep_internal.h"
 
 #define MAX_LOCAL_FUNC_LABELS 8192

--- a/src/dccpeep/peep_control_flow.c
+++ b/src/dccpeep/peep_control_flow.c
@@ -1,7 +1,20 @@
-/* peep_control_flow.c - shared labels, jumps, and conservative reachability.
+/**
+ * @file peep_control_flow.c
+ * @brief Indexes labels and functions for conservative control-flow queries.
  *
- * This module owns textual branch/label parsing and bounded control-flow
- * queries used by multiple pass families. Unknown syntax remains conservative.
+ * @par Role
+ * Owns textual label and jump parsing, versioned label/function indexes,
+ * function-bound lookup, bounded label searches, and loop-body reachability
+ * checks shared by multiple pass families.
+ *
+ * @par Key entry points
+ * jump_target(), jump_target_any(), peep_indexed_function_bounds(),
+ * find_label_line_in_range(), and loop_body_internal_labels_safe().
+ *
+ * @par Boundary
+ * peep_dataflow.c owns CFG construction and liveness, while
+ * peep_pass_control_flow.c owns label and branch rewrites. Unknown branch
+ * syntax remains conservative here.
  */
 #include "dccpeep_internal.h"
 

--- a/src/dccpeep/peep_dataflow.c
+++ b/src/dccpeep/peep_dataflow.c
@@ -1,4 +1,20 @@
-/* peep_dataflow.c - versioned CFG, basic blocks, and backwards liveness. */
+/**
+ * @file peep_dataflow.c
+ * @brief Builds dccpeep's versioned CFG and backward liveness solution.
+ *
+ * @par Role
+ * Derives per-function successors and basic blocks, then solves register and
+ * flag liveness against the current line-program version for safety queries.
+ *
+ * @par Key entry points
+ * peep_flow_line(), peep_basic_block(), peep_basic_block_count(),
+ * peep_registers_dead_after(), and peep_flags_dead_after().
+ *
+ * @par Boundary
+ * peep_effects.c classifies individual instructions and
+ * peep_control_flow.c owns shared textual label indexes. This module never
+ * mutates the line program, and unknown effects remain fully live.
+ */
 #include "dccpeep_internal.h"
 
 #define PEEP_ALL_REGISTERS ((1u << 10) - 1u)

--- a/src/dccpeep/peep_effects.c
+++ b/src/dccpeep/peep_effects.c
@@ -1,7 +1,19 @@
-/* peep_effects.c - cached structured line classification and effects.
+/**
+ * @file peep_effects.c
+ * @brief Classifies lines and caches conservative machine effects.
  *
- * Recognized instructions receive conservative register/flag summaries.
- * Unknown instructions remain explicitly unsafe rather than being guessed.
+ * @par Role
+ * Splits recognized Z80/M80 instructions into operands and records register,
+ * flag, memory, opcode, and control-flow effects for the current line-program
+ * version.
+ *
+ * @par Key entry points
+ * peep_line_info() lazily returns the structured classification for one line.
+ *
+ * @par Boundary
+ * peep_dataflow.c consumes these summaries to build liveness. Unknown
+ * instructions and user assembly remain explicitly opaque, and this module
+ * never rewrites source lines.
  */
 #include "dccpeep_internal.h"
 

--- a/src/dccpeep/peep_frame_alloc.c
+++ b/src/dccpeep/peep_frame_alloc.c
@@ -1,21 +1,19 @@
-/* peep_frame_alloc.c - machine-level frame-slot value analysis.
+/**
+ * @file peep_frame_alloc.c
+ * @brief Measures promotion opportunities for surviving IX frame slots.
  *
- * dcc's `(ix+n)` frame slots are virtual registers that have been eagerly
- * spilled. This module discovers the subset whose surviving post-convergence
- * machine code proves can be promoted back into a physical register.
+ * @par Role
+ * Runs an analysis-only post-convergence census over byte-slot definitions
+ * and loads, using basic-block scans, function reaching definitions, effects,
+ * and liveness to estimate safe BC/DE promotion spans and cycle savings.
  *
- * Phase 1 is analysis-only and deliberately basic-block scoped. A slot value
- * starts at a direct store to `(ix+n)`, has one reaching definition by
- * construction inside the block, and ends at the last direct load before the
- * next store. Calls, opaque instructions, labels and control transfers are
- * block boundaries through the existing CFG, so nothing here guesses across
- * control-flow joins. The report is emitted only under -fstats and changes no
- * program text.
+ * @par Key entry points
+ * peep_frame_alloc_analyze() emits aggregate statistics and optional candidate
+ * detail without changing program text.
  *
- * This first answers the question the source-level heuristics could not:
- * after every structural peephole pass has run, how much real frame traffic is
- * still present in spans where BC or DE is genuinely dead? Only if that census
- * is material should rewriting be enabled.
+ * @par Boundary
+ * This module measures opportunities but performs no allocation or rewrite.
+ * peep_effects.c and peep_dataflow.c own the machine facts it consumes.
  */
 #include "dccpeep_internal.h"
 

--- a/src/dccpeep/peep_lines.c
+++ b/src/dccpeep/peep_lines.c
@@ -1,4 +1,20 @@
-/* peep_lines.c - dccpeep line storage, mutation, and file I/O. */
+/**
+ * @file peep_lines.c
+ * @brief Owns dccpeep's mutable line program and assembly file I/O.
+ *
+ * @par Role
+ * Allocates and frees line text, preserves user-assembly text behind opaque
+ * placeholders, tracks program versions and edit statistics, provides
+ * transactional mutations, and reads and writes normalized assembly files.
+ *
+ * @par Key entry points
+ * peep_context_init(), peep_edit_begin(), replace1(), delete_n(),
+ * insert_line(), read_file(), and write_file().
+ *
+ * @par Boundary
+ * Passes must mutate through this API and cannot rewrite opaque user assembly.
+ * Parsing, effects, dataflow, and pass scheduling belong to other modules.
+ */
 #include "dccpeep_internal.h"
 
 char *lines[MAX_LINES];

--- a/src/dccpeep/peep_parse.c
+++ b/src/dccpeep/peep_parse.c
@@ -1,4 +1,20 @@
-/* peep_parse.c - stateless Z80/M80 instruction parsers and formatters. */
+/**
+ * @file peep_parse.c
+ * @brief Provides parsers and formatters for emitted Z80/M80 text shapes.
+ *
+ * @par Role
+ * Recognizes and formats exact jump, immediate, IX-frame, register-pair, and
+ * symbol operand forms shared by peephole passes.
+ *
+ * @par Key entry points
+ * The parse_*() and peep_parse_*() helpers declared in
+ * dccpeep_internal.h, together with peep_make_*() formatters.
+ *
+ * @par Boundary
+ * These helpers neither own nor mutate the line program and do not infer
+ * effects or control flow. Unsupported or ambiguous syntax simply fails to
+ * match.
+ */
 #include "dccpeep_internal.h"
 
 int parse_ld_hl_imm(const char *s, char *val, size_t val_size)

--- a/src/dccpeep/peep_pass_control_flow.c
+++ b/src/dccpeep/peep_pass_control_flow.c
@@ -1,7 +1,19 @@
-/* peep_pass_control_flow.c - label and branch rewrite passes.
+/**
+ * @file peep_pass_control_flow.c
+ * @brief Implements label and branch simplification passes.
  *
- * These passes remove dead/adjacent labels, thread or shortcut branches,
- * and collapse jumps to plain returns.
+ * @par Role
+ * Collapses adjacent labels, removes unreferenced labels when safe, folds
+ * branch-over-jump shapes, threads and shortcuts jump targets, and replaces
+ * jumps to plain returns.
+ *
+ * @par Key entry points
+ * pass_labels(), pass_branch_over_jump(), pass_jump_thread(),
+ * pass_cond_skip_shortcut(), and pass_jp_to_plain_ret().
+ *
+ * @par Boundary
+ * peep_control_flow.c owns shared label indexes and textual branch queries;
+ * this module owns only rewrites. dccpeep.c decides when they run.
  */
 #include "dccpeep_internal.h"
 

--- a/src/dccpeep/peep_pass_final.c
+++ b/src/dccpeep/peep_pass_final.c
@@ -1,7 +1,21 @@
-/* peep_pass_final.c - terminal relaxation and cleanup passes.
+/**
+ * @file peep_pass_final.c
+ * @brief Implements post-convergence and terminal cleanup passes.
  *
- * These rewrites run after fixed-point and size-mode passes so their address
- * estimates and dead-load decisions see the final instruction stream.
+ * @par Role
+ * Uses the settled instruction stream to fold constant sign extension,
+ * remove dead register loads, epilogue pops, and carry clears, widen tiny
+ * local-allocation rewrites, and relax safely in-range JP instructions to JR.
+ *
+ * @par Key entry points
+ * pass_jp_to_jr(), pass_fold_const_sign_extend(),
+ * pass_elim_dead_register_loads(), pass_elim_redundant_carry_clear(), and
+ * pass_local_alloc_wide().
+ *
+ * @par Boundary
+ * These passes depend on converged shapes, final code size, effects, or
+ * liveness and therefore run only at dedicated sites in dccpeep.c; they do
+ * not own phase ordering or general fixed-point optimization.
  */
 #include "dccpeep_internal.h"
 

--- a/src/dccpeep/peep_pass_inline_temp.c
+++ b/src/dccpeep/peep_pass_inline_temp.c
@@ -1,7 +1,19 @@
-/* peep_pass_inline_temp.c - compiler-tagged temporary spill rewrites.
+/**
+ * @file peep_pass_inline_temp.c
+ * @brief Rewrites compiler-tagged inline-temporary spills.
  *
- * These passes consume dcc inline-temporary markers, replace safe memory
- * spills with register/stack forms, then remove any surviving markers.
+ * @par Role
+ * Consumes dcc inline-temporary markers, proves safe register-bank or stack
+ * substitutions for their memory spills, applies those rewrites, and removes
+ * markers that survive optimization.
+ *
+ * @par Key entry points
+ * pass_inline_temp_spill_to_stack() and pass_remove_inline_temp_markers().
+ *
+ * @par Boundary
+ * This module acts only on compiler-emitted marker contracts; it does not
+ * discover arbitrary spills. dccpeep.c controls rewrite and marker-removal
+ * ordering.
  */
 #include "dccpeep_internal.h"
 

--- a/src/dccpeep/peep_pass_loops.c
+++ b/src/dccpeep/peep_pass_loops.c
@@ -1,8 +1,18 @@
-/* peep_pass_loops.c - loop-scoped registerization passes.
+/**
+ * @file peep_pass_loops.c
+ * @brief Promotes proven loop variables and bounds into registers.
  *
- * These passes promote proven byte/word loop variables into BC, C, E, or
- * IYL. Register-specific rewrites remain separate; only their exact shared
- * proof helpers live in this module.
+ * @par Role
+ * Matches exact byte and word loop shapes, proves slot, escape, call, and
+ * register-ownership safety, then promotes counters or bounds into BC, C, E,
+ * or IYL for the loop's live interval.
+ *
+ * @par Key entry points
+ * The pass_*_to_reg_*() loop passes declared in dccpeep_internal.h.
+ *
+ * @par Boundary
+ * This is pattern-specific loop registerization, not general frame allocation.
+ * dccpeep.c owns pass order and the opt-in gate for undocumented IYL forms.
  */
 #include "dccpeep_internal.h"
 

--- a/src/dccpeep/peep_pass_minmax.c
+++ b/src/dccpeep/peep_pass_minmax.c
@@ -1,9 +1,20 @@
-/* peep_pass_minmax.c - application-specific board/game passes.
+/**
+ * @file peep_pass_minmax.c
+ * @brief Optimizes exact board-game and minimax assembly idioms.
  *
- * These passes target patterns emitted by the bundled ttt/chess sample
- * programs (the _MinMax, _FindSolution, board, winner, and posn-function
- * idioms). They are opt-in by pattern match: each declines unless it finds
- * the exact application shape, so they are inert on ordinary programs.
+ * @par Role
+ * Implements the bundled ttt/chess pattern family for position functions,
+ * MinMax/FindSolution frames and calls, board-address reuse, winner checks,
+ * byte returns, and register caches.
+ *
+ * @par Key entry points
+ * pass_posfunc_b_cache(), the pass_minmax_*() family,
+ * pass_winner_check_dec_a(), and pass_global_board_const_offsets().
+ *
+ * @par Boundary
+ * Rewrites require exact application symbols, function context, or narrowly
+ * emitted shapes, so unrelated programs remain inert. General loop, branch,
+ * and local-pattern passes belong to their dedicated modules.
  */
 #include "dccpeep_internal.h"
 

--- a/src/dccpeep/peep_pass_once.c
+++ b/src/dccpeep/peep_pass_once.c
@@ -1,9 +1,20 @@
-/* peep_pass_once.c - the single-scan micro-pattern dispatcher.
+/**
+ * @file peep_pass_once.c
+ * @brief Dispatches ordered local peephole patterns in one line scan.
  *
- * pass_once() walks the line program once, trying a fixed ordered list of
- * small local rewrites (the try_*_at helpers) at each position. It is the
- * highest-volume pass in the fixpoint loop; all of its helpers are private
- * to this file and invoked only from pass_once itself.
+ * @par Role
+ * Walks the line program once and applies a fixed-priority set of private
+ * try_*_at() rewrites for boolean materialization, comparisons, stack and
+ * allocation sequences, redundant jumps, and other short local shapes.
+ *
+ * @par Key entry points
+ * pass_once() runs the scan; local_alloc_hl_result_dead() exposes the shared
+ * safety proof used by terminal local-allocation cleanup.
+ *
+ * @par Boundary
+ * The try_*_at() helpers are private and one invocation is only one scan.
+ * dccpeep.c provides fixed-point repetition and ordering against other pass
+ * families.
  */
 #include "dccpeep_internal.h"
 

--- a/src/dccpeep/peep_pass_stubs.c
+++ b/src/dccpeep/peep_pass_stubs.c
@@ -1,7 +1,20 @@
-/* peep_pass_stubs.c - size-oriented shared-helper rewrites.
+/**
+ * @file peep_pass_stubs.c
+ * @brief Factors repeated instruction sequences through shared size helpers.
  *
- * These passes run after fixed-point optimization. Their order remains in
- * dccpeep.c because later passes consume forms produced by earlier ones.
+ * @par Role
+ * Replaces exact frame, local, argument, static-load, comparison, bitwise,
+ * and sign-extension sequences with calls or jumps to shared runtime helpers,
+ * adding the required external declarations.
+ *
+ * @par Key entry points
+ * pass_shared_frame_stubs(), pass_lvar_stubs(), pass_svar_stubs(),
+ * pass_larg_stubs(), and the remaining pass_*_stub() helpers.
+ *
+ * @par Boundary
+ * These are size-mode, post-convergence rewrites. dccpeep.c owns their order
+ * because later stub passes consume forms produced by earlier ones; runtime
+ * helper implementations live outside dccpeep.
  */
 #include "dccpeep_internal.h"
 

--- a/src/dccrtlstrip/dccrtlstrip.c
+++ b/src/dccrtlstrip/dccrtlstrip.c
@@ -1,13 +1,20 @@
-/*
- * dccrtlstrip.c - conservative pre-link reducer for dccrtl.mac
+/**
+ * @file dccrtlstrip.c
+ * @brief Produces a conservative per-application subset of DCCRTL.MAC.
  *
- * Usage:
- *   dccrtlstrip [-k symbol ...] -r dccrtl.mac -o rtlmin.mac app.mac [app2.mac ...]
+ * @par Role
+ * Reads the full runtime, one or more application .MAC files, and optional
+ * explicit roots; groups runtime text around PUBLIC entry points, follows
+ * assembly references to a fixed point, and writes RTLMIN.MAC with required
+ * preludes, aliases, data, and filtered PUBLIC directives.
  *
- * This version treats PUBLIC directives as runtime block boundaries, not
- * arbitrary labels.  That is important for routines like _printf whose body
- * contains private labels/data such as __pf_run, pf_sink, etc.  Splitting on
- * every label can keep only the entry stub and strip the real body.
+ * @par Key entry points
+ * main(), build_blocks(), scan_app(), mark_reachable(), and write_output().
+ *
+ * @par Boundary
+ * Runs after dcc/dccpeep emit application assembly and before M80/m80c
+ * assembles the selected runtime. It performs conservative textual
+ * reachability analysis, not assembly or linking.
  */
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/l80c/l80c.c
+++ b/src/l80c/l80c.c
@@ -1,52 +1,21 @@
-/*
-* l80c.c - portable, host-native LINK-80-compatible linker.
-*
-* Companion to m80c: where m80c assembles .MAC to LINK-80-compatible .REL
-* on the host (unbounded memory instead of CP/M 64K tables), l80c links
-* those .REL files into a CP/M .COM image on the host too. The real
-* l80.com still runs as a CP/M program under the ntvcm emulator, so its
-* own symbol/relocation workspace is bounded by that emulated 64K - large
-* nopeep builds can exhaust it well before the target program itself would
-* not fit. l80c removes that host-side ceiling.
-*
-* REL bitstream format (reverse-engineered from src/m80c/m80c.c's writer,
-* which this file mirrors byte-for-byte):
-*
-*   Top-level items, decoded from a bitstream (MSB-first within each byte):
-*     0                          -> literal byte for the current segment
-*     1 00 cccc                  -> special item, code cccc (0-15)
-*     1 tt <16-bit value>        -> link value of type tt (1=CODE,2=DATA,3=COMM),
-*                                    a relocatable value stored at the current
-*                                    location in the current segment
-*
-*   Special item codes actually emitted by m80c (and consumed here):
-*     2  name                    module name
-*     0  name                    entry symbol preview (informational; skipped)
-*    10  type,value               data (DSEG) segment size
-*    13  type,value               code (CSEG) segment size
-*    11  type,value               set location counter (type selects the
-*                                  active segment for subsequent byte/link items)
-*     7  type,value,name          define public symbol
-*     6  type,value,name          external reference chain head
-*    14  type,value               end module (byte-aligns afterward)
-*    15  (none)                   end file
-*
-* EXTRN references are threaded as a backward linked list through the
-* code/data stream itself: each reference's 2-byte slot holds the *previous*
-* reference's location (as an ordinary CODE/DATA link value, so the generic
-* relocation pass below turns it into an absolute address for free); the
-* first reference in a chain is written as literal 0x00,0x00 (never
-* fixed up, so it remains 0 - the walk terminator, since address 0 is never
-* a valid CP/M code/data target).
-*
-* Scope: CSEG/DSEG only (this toolchain's generated code never emits ASEG
-* as a distinct segment or COMMON blocks - confirmed empirically against
-* DCCRTL.MAC and every test's generated .MAC). Anything else is a hard,
-* loud error rather than a silent miscompile.
-*
-* Build:
-*   cc -std=c89 -Wall -Wextra -O2 -o l80c l80c.c
-*/
+/**
+ * @file l80c.c
+ * @brief Links dcc LINK-80 modules into host-produced CP/M .COM images.
+ *
+ * @par Role
+ * Reads M80-compatible .REL bitstreams, lays out each module's CSEG and DSEG,
+ * relocates link values, resolves PUBLIC symbols and EXTRN chains, and writes
+ * a padded .COM image plus a linked .SYM map. Optional per-module .SYM files
+ * contribute relocated local symbols.
+ *
+ * @par Key entry points
+ * main(), load_rel_file(), load_module_syms(), and sym_define().
+ *
+ * @par Boundary
+ * Complements m80c and replaces emulated L80 for normal dccmake builds,
+ * avoiding L80's CP/M workspace ceiling. It accepts the CSEG/DSEG records used
+ * by this toolchain and rejects unsupported ASEG, COMMON, or unknown records.
+ */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/m80c/m80c.c
+++ b/src/m80c/m80c.c
@@ -1,32 +1,22 @@
-/* RELFIX29: emit M80 location-counter records for trailing DS/ORG gaps too. */
-/* RELFIX17: add indexed BIT/RES/SET b,(IX/IY+d); prior fixes through RELFIX16. */
-/*
-* m80clone.c - portable C89, deliberately conservative clone of Microsoft M80
-*
-* This is a clean-room implementation scaffold aimed at building large CP/M
-* Z80/8080 assembly files on modern hosts and emitting LINK-80 compatible REL.
-*
-* RELFIX5 drop 2026-06-28: fixes LD A,(addr)/LD (addr),A absolute memory forms so they are not misassembled as immediate
-* loads; also treats . as the current location counter in expressions.
-* Status in this drop:
-*   - two-pass assembler, unbounded host memory instead of CP/M 64K tables
-*   - M80-style command line: obj,prn=source /Z /I /L /R /H /O /X /M
-*   - labels, public labels via FOO::, PUBLIC/ENTRY, EXTRN/EXT, NAME/TITLE
-*   - EQU, SET, ORG, ASEG/CSEG/DSEG, DB/DEFB, DW/DEFW, DS/DEFS, END
-*   - .RADIX, IF/ELSE/ENDIF/IFE/IFNDEF/IFDEF
-*   - 8080 opcodes plus a useful Z80 core: IX/IY indexed loads, CB/ED prefix
-*     ops, JR/DJNZ, EXX, LDI/R/D, CPI/R/D, IN/OUT forms, IM, RST, relative tests
-*   - PRN listing and SYM symbol listing
-*   - REL bitstream writer with module name, public definitions, program size,
-*     data bytes, program/data relative words, end-module and end-file items
-*
-* Not yet complete M80: macro bodies (MACRO/REPT/IRP/IRPC/LOCAL/EXITM), .COMMENT,
-* cross-reference .CRF, all listing controls, and some obscure expression forms.
-* The structure is intentionally table-free and easy to extend.
-*
-* Build:
-*   cc -std=c89 -Wall -Wextra -O2 -o m80clone m80clone.c
-*/
+/**
+ * @file m80c.c
+ * @brief Implements dcc's host-native, LINK-80-compatible M80 assembler.
+ *
+ * @par Role
+ * Two-pass assembles M80-style .MAC source with the 8080/Z80 instructions,
+ * directives, conditionals, relocations, and debug markers used by dcc. It
+ * emits LINK-80 .REL plus requested .PRN and .SYM files, source .DBG data, and
+ * per-module .LNK size metadata.
+ *
+ * @par Key entry points
+ * main(), parse_cmd(), assemble_pass(), write_rel(), write_sym(), and
+ * write_debug().
+ *
+ * @par Boundary
+ * Consumes assembly from dcc/dccpeep or dccrtlstrip; l80c or L80 owns final
+ * layout and linking. This clean-room implementation deliberately covers the
+ * M80 surface used by the dcc toolchain rather than every historical feature.
+ */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
## Summary
- add concise Doxygen file headers to the 50 remaining production C/header modules under `src/`
- cover compiler core, preprocessor, peephole optimizer, standalone tools, and shipped sample applications
- describe each module's role, key entry points, and subsystem boundary for agent-friendly navigation
- expand the `dcc-project` and `mir-migration` skills from AST/MIR-only guidance to every maintained `src` C/header module

Together with merged PRs #152 and #153, all 83 maintained `src/**/*.{c,h}` files now follow the convention.

## Validation
- `pwsh ./scripts/build-dcc.ps1`
- documentation coverage: 83/83 files contain matching `@file`, `@brief`, and `@par Role`
- `git diff --check`
