### PR TITLE
Enhance documentation and symbol tables for standard libraries

### DIFF
--- a/.github/skills/dcc-cpm-z80/SKILL.md
+++ b/.github/skills/dcc-cpm-z80/SKILL.md
@@ -206,7 +206,7 @@ build so you rarely call the stages directly (get each tool's own flags with
   to link the final `.COM`. Set `dcc-use-emulated-m80=true` to assemble with
   Microsoft's `M80` under `ntvcm` instead.
 
-**Build/run one program** (compile → peephole → strip runtime → m80c → L80):
+**Build/run one program** (compile → peephole → m80c → strip runtime → m80c → L80):
 
 ```sh
 dccmake foo.c dcc-output=FOO dcc-peep=true   # foo.c -> build/FOO.COM

--- a/.github/skills/dcc-project/SKILL.md
+++ b/.github/skills/dcc-project/SKILL.md
@@ -9,7 +9,7 @@ argument-hint: 'Describe the dcc toolchain task'
 dcc is a cross toolchain. Host programs emit Z80 assembly and CP/M 2.2
 executables:
 
-`dcc -> dccpeep (optional) -> dccrtlstrip -> m80c -> l80c -> ntvcm`
+`dcc -> dccpeep (optional) -> m80c -> dccrtlstrip -> m80c -> l80c -> ntvcm`
 
 Production function bodies are generated from MIR only. AST processing after
 parsing is metadata-only; legacy body emission, capture/replay, and speculative

--- a/.github/skills/mkdocs-stdlib-docs/SKILL.md
+++ b/.github/skills/mkdocs-stdlib-docs/SKILL.md
@@ -76,11 +76,14 @@ For new library hooks, prefer the same pattern with the uppercase header stem:
 <!-- ERRNO-SYMBOL-TABLE: all -->
 <!-- FLOAT-SYMBOL-TABLE: all -->
 <!-- LIMITS-SYMBOL-TABLE: all -->
+<!-- LOCALE-SYMBOL-TABLE: all -->
 <!-- SETJMP-SYMBOL-TABLE: all -->
+<!-- SIGNAL-SYMBOL-TABLE: all -->
 <!-- STDARG-SYMBOL-TABLE: all -->
 <!-- STDBOOL-SYMBOL-TABLE: all -->
 <!-- STDDEF-SYMBOL-TABLE: all -->
 <!-- STDINT-SYMBOL-TABLE: all -->
+<!-- TIME-SYMBOL-TABLE: all -->
 ```
 
 Marker behavior should be consistent across libraries:

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -83,5 +83,5 @@ symbol tables from documented declarations. Use markers such as
 `<!-- STDIO-SYMBOL-TABLE: all -->` to include symbols in header order, or
 `<!-- MATH-SYMBOL-TABLE: all sorted -->` when an alphabetical symbol table reads
 better. Other standard-library pages use the same hook with prefixes such as
-`STDLIB`, `STRING`, `CTYPE`, `ASSERT`, `ERRNO`, `FLOAT`, `LIMITS`, `SETJMP`,
-`STDARG`, `STDBOOL`, `STDDEF`, `STDINT`, and `TIME`.
+`STDLIB`, `STRING`, `CTYPE`, `ASSERT`, `ERRNO`, `FLOAT`, `LIMITS`, `LOCALE`,
+`SETJMP`, `SIGNAL`, `STDARG`, `STDBOOL`, `STDDEF`, `STDINT`, and `TIME`.

--- a/docs/docs/en/10-system-and-cpm.md
+++ b/docs/docs/en/10-system-and-cpm.md
@@ -60,7 +60,7 @@ nonzero high byte in `whence`, leaving the old position unchanged. Successful
     FCB/DMA core. The first file call links that core; additional file calls are
     nearly free. See the [appendix](appendix/01-dccrtlstrip.md).
 
-## `dirent.h` — directory enumeration
+## `dirent.h` — directory enumeration {#dirent-directory-enumeration}
 
 Include `dirent.h`. CP/M has no subdirectories, so this enumerates files on the
 selected drive.
@@ -263,7 +263,7 @@ than relying on either outcome. See `tests/trenamex.c`.
 (case-insensitive) followed by `:` is parsed into the FCB's drive byte, and the
 rest of the name follows normal 8.3 rules. There is no directory/path concept
 beyond this single-letter drive prefix — CP/M has no subdirectories at all (see
-[`dirent.h`](#direnth--directory-enumeration) above).
+[`dirent.h`](#dirent-directory-enumeration) above).
 
 ### 8.3 filenames and truncation collisions
 

--- a/docs/docs/en/appendix/00-architecture.md
+++ b/docs/docs/en/appendix/00-architecture.md
@@ -281,13 +281,13 @@ graph TB
 | Group | Modules | Responsibility |
 | --- | --- | --- |
 | Shared | `dcc.h`, `dcc_state.c`, subsystem `*_internal.h` files | Target model, shared contracts, and lifecycle-owned compiler state |
-| Front end | `dcc.c`, `dcc_preproc.c`, `dcc_pp_expr.c`, `dcc_func.c`, `dcc_stmt.c`, `dcc_diag_emit.c` | Driver, preprocessing/lexing, declarations/statements, frame scan, and diagnostics |
-| Types / symbols | `dcc_types.c`, `dcc_symbols.c`, `dcc_constexpr.c`, `dcc_fold.c` | Type system, symbol tables, constant-expression evaluation, constant folding |
-| Typed AST / metadata | `dcc_ast.c`, `dcc_ast_build.c`, `dcc_ast_gen*.c`, `dcc_ast_metadata.c`, `dcc_ast_stmt_meta.c` | Transient typed trees, semantic classifiers, and non-emitting declaration/scope replay |
+| Front end | `dcc.c`, `dcc_preproc.c`, `dcc_pp_expr.c`, `dcc_func.c`, `dcc_stmt.c`, `dcc_diag_emit.c`, `dcc_global_scan.c` | Driver, preprocessing/lexing, declarations/statements, conservative global-use prepass, frame scan, and diagnostics |
+| Types / symbols | `dcc_types.c`, `dcc_symbols.c`, `dcc_constexpr.c`, `dcc_fold.c`, `dcc_asmname.c` | Type system, symbol tables, constant evaluation/folding, and M80-safe assembly-name mapping |
+| Typed AST / metadata | `dcc_ast.c`, `dcc_ast_build.c`, `dcc_ast_gen*.c`, `dcc_ast_metadata.c`, `dcc_ast_stmt_meta.c`, `dcc_licm.c` | Transient typed trees, semantic classifiers, and non-emitting LICM/CSE planning and declaration/scope replay |
 | Compatibility helpers | `dcc_expr.c`, `dcc_ops.c`, `dcc_cmp.c`, `dcc_assign.c`, `dcc_decl.c`, `dcc_stmt_fast.c`, `dcc_array_narrow.c` | Shared initializer/type behavior and conservative source proofs; not a production body emitter |
-| MIR core | `dcc_mir.c`, `dcc_mir_emit_common.c`, `dcc_mir_target.c`, `dcc_mir_schedule.c` | Persistent IR, metadata repair, CFG/verifier, liveness, target constraints, common emission |
+| MIR core | `dcc_mir.c`, `dcc_mir_emit_common.c`, `dcc_mir_target.c`, `dcc_mir_schedule.c`, `dcc_mir_stream.c` | Persistent IR, metadata repair, CFG/verifier, liveness, target constraints, isolated candidate streams, and common emission |
 | MIR selection | `dcc_mir_select.c`, `dcc_mir_homed_cfg.c`, `dcc_mir_spilled_cfg.c` | Transactional generated candidates, homes/spills, and `mir-v1` selection |
-| Machine schedules | `dcc_mir_machine_emit.c`, `dcc_mir_machine_*.c` | Exact structural matchers and specialized Z80 streams |
+| Machine schedules | `dcc_mir_machine_emit.c` (coordinator), `dcc_mir_machine_*.c` (families) | Exact structural matchers and specialized Z80 streams |
 | Top level / output | `dcc_func.c`, `dcc_global_init.c`, `dcc_data.c` | Function/frame parsing, one production metadata/MIR body walk, global initializer recording, deferred static-body placement, and data-section emission |
 
 ### Exact machine-schedule families
@@ -298,14 +298,20 @@ dispatch. Cohesive schedules live in separately compiled families:
 | Family module | Responsibility |
 | --- | --- |
 | `dcc_mir_machine_attention.c` | Matrix, attention, and fixed-point kernels |
+| `dcc_mir_machine_byte_scans.c` | Byte/row scans, fills, copies, hashes, records, and file-line kernels |
+| `dcc_mir_machine_constant_folding.c` | Constant/result flows, result switches, and indexed-member schedules |
+| `dcc_mir_machine_containers.c` | Array, container, stack, comparison, and reduction schedules |
+| `dcc_mir_machine_float_recursion.c` | Floating-point, recursive, tree, and byte-status kernels |
 | `dcc_mir_machine_numeric.c` | Integer, long, fixed-point, and math kernels |
 | `dcc_mir_machine_float_reports.c` | Float reports and checks |
 | `dcc_mir_machine_scanners.c` | Scan, parse, and traversal loops |
 | `dcc_mir_machine_aggregate_checks.c` | Aggregate, array, and struct checks |
+| `dcc_mir_machine_structural_checks.c` | Literal, bitset, sieve, string, structure, and bitfield validations |
 | `dcc_mir_machine_runtime_runners.c` | Runtime, file, and system orchestration |
 | `dcc_mir_machine_interpreter_runners.c` | Interpreter and parser runners |
 | `dcc_mir_machine_call_runners.c` | Call/control orchestration |
 | `dcc_mir_machine_validation_runners.c` | Scope, wide-value, and validation runners |
+| `dcc_mir_machine_wide_records.c` | Wide arithmetic, aggregate updates, and record-oriented schedules |
 | `dcc_mir_machine_endgame.c` | Large final exact schedule families |
 
 Machine families follow a zero-shared-state rule:
@@ -394,10 +400,10 @@ Key design points:
 
 ## The runtime: a block-structured library sized for stripping
 
-The runtime `DCCRTL.MAC` is a single ~19,000-line assembly source, but its
+The runtime `DCCRTL.MAC` is a single roughly 25,000-line assembly source, but its
 *architecture* is what makes the toolchain's "pay only for what you use"
 property possible. Rather than one monolithic blob, the runtime is written as
-**~280 parsed blocks** around `public` entry points and shared preludes. A
+hundreds of parsed blocks around `public` entry points and shared preludes. A
 program never links the whole library — `dccrtlstrip` keeps only the blocks the
 application actually references (the mark-and-sweep details are in the companion
 appendix [*Runtime optimization*](01-dccrtlstrip.md)). The architectural
@@ -405,8 +411,8 @@ consequence is that **every routine has a well-defined, measurable size cost**.
 
 ```mermaid
 flowchart TB
-    subgraph RT["DCCRTL.MAC (~19,000 lines, ~280 parsed blocks)"]
-      BASE["always-present baseline<br/>~297 lines, 7 blocks<br/>(start, argv/console, heap, exit)"]
+    subgraph RT["DCCRTL.MAC (block-structured runtime)"]
+      BASE["always-present baseline<br/>(start, argv/console, heap, exit)"]
         IO["stdio blocks<br/>printf, file I/O core"]
         MEM["memory blocks<br/>malloc/free/realloc"]
         LONG["32-bit long blocks"]
@@ -435,7 +441,7 @@ The gap between the two is the whole story of the runtime's size architecture: a
 small `self` with a large `marginal` means the routine sits on top of a big
 shared substrate (the file-I/O core, or the float arithmetic core).
 
-### The always-present baseline (~297 lines)
+### The always-present baseline
 
 Seven blocks are always linked because they are reachable from the forced
 `start` root: program entry and heap/BSS setup, the command-tail `argv` builder
@@ -490,10 +496,11 @@ the runtime and rebuilding the docs is all that is needed to refresh them.
 - Machine-dependent optimization is split out into **`dccpeep`**, a
   fixpoint peephole optimizer over the assembly text, with separate time (`-Ot`)
   and size (`-Os`) strategies.
-- The runtime `DCCRTL.MAC` is **block-structured** (~280 parsed blocks over a
-  ~297-line baseline), so every routine has a measurable
+- The runtime `DCCRTL.MAC` is **block-structured** into hundreds of public
+  blocks, so every routine has a measurable
   `self`/`marginal` size cost and `dccrtlstrip` can link only the blocks a
-  program references.
+  program references. The exact current totals are generated on the
+  [runtime size page](02-runtime-sizes.md).
 - The back half of the pipeline uses native **`m80c`**/**`l80c`** (or
   Microsoft **`M80`**/**`L80`** under `ntvcm`) for assembly and linking - a
   shared LINK-80-compatible `.REL` object format that DCC C Compiler consumes

--- a/docs/docs/en/appendix/01-dccrtlstrip.md
+++ b/docs/docs/en/appendix/01-dccrtlstrip.md
@@ -1,10 +1,26 @@
 # Appendix: runtime optimization
 
-`DCCRTL.MAC` is a single ~19,000-line runtime, but most programs use only a
+`DCCRTL.MAC` is a single roughly 25,000-line runtime, but most programs use only a
 fraction of it. The normal DCC C Compiler build flow runs `dccrtlstrip` before the final
 L80 link to remove unreferenced routines. This appendix explains how it decides
 what to keep and what each library feature costs in code size once its
 transitive dependencies are linked.
+
+## Direct usage
+
+The normal build helpers invoke `dccrtlstrip` automatically. To run it directly:
+
+```sh
+dccrtlstrip [-k symbol]... -r DCCRTL.MAC -o RTLMIN.MAC app.mac [app2.mac ...]
+```
+
+| Option or argument | Purpose |
+| --- | --- |
+| `-r <file>` | Full runtime source to analyze |
+| `-o <file>` | Reduced runtime file to write |
+| `-k <symbol>` | Keep an explicit runtime root; repeat for additional symbols |
+| `-root <symbol>` | Alias for `-k` |
+| `app.mac ...` | One or more application assembly modules to scan for runtime references |
 
 ## How `dccrtlstrip` decides what to keep
 

--- a/docs/docs/en/appendix/03-utilities.md
+++ b/docs/docs/en/appendix/03-utilities.md
@@ -29,8 +29,9 @@ dcc-ma <name> [mode] [options]
 ```
 
 - `<name>` — Test app name (e.g., `triangle`, `sieve`, `ttt`)
-- `[mode]` — Build mode: `full` (both builds, default), `fast` (optimized), or
-  `nopeep` (unoptimized)
+- `[mode]` — Build mode: `full` (both builds), `fast` (optimized), or `nopeep`
+  (unoptimized). The shell driver defaults to `fast`; the PowerShell driver
+  defaults to `full`.
 
 ### Build Driver Examples
 
@@ -56,19 +57,29 @@ dcc-ma cobint --mode fast --build-dir mybuild
 
 | Parameter | Default | Purpose |
 | --------- | ------- | ------- |
-| `-Name` | (required) | App name without `.c` extension |
-| `-Mode` | `full` | Build mode: `full`, `fast`, or `nopeep` |
-| `-BuildDir` | `build` | Build directory for artifacts |
-| `-Emulator` | `ntvcm` | Emulator command for CP/M tools |
+| `-Name` / positional name | (required) | App name without `.c` extension |
+| `-Mode` / `--mode` | `fast` (shell), `full` (PowerShell) | Build mode: `full`, `fast`, or `nopeep` |
+| `-SourcePath` / `--source-path` | Search by name | Explicit C source path |
+| `-BuildDir` / `--build-dir` | `build` | Build directory for artifacts |
+| `-Emulator` / `--emulator` | `ntvcm` | Emulator command for CP/M tools |
+| `-UseEmulatedM80` / `--emulated-m80` | off | Assemble with M80.COM under `ntvcm` instead of native `m80c` |
+| `-UseEmulatedL80` / `--emulated-l80` | off | Link with L80.COM under `ntvcm` instead of native `l80c` |
+
+The wrapper accepts only the parameters above. Use `dccmake` directly for
+project settings such as debug builds, per-format overrides, and multi-module
+input lists.
 
 ### Environment Variables
 
 - `DCC_STACK_SIZE` — C stack reserve in bytes; when unset, `dcc` uses its default
 - `DCC_FORCE_STACK_CHECK` — Force `-fstack-check` on all builds
 - `DCC_FLOATIO` — Set to `1` to force `%f` support on every `printf`-family call
-- `DCC_NO_FLOATIO` — Set to `1` to force `%f` support off on every `printf`-family call
 - `DCC_LONGIO` — Set to `1` to force long-format support on every `printf`-family call
-- `DCC_NO_LONGIO` — Set to `1` to force long-format support off on every `printf`-family call
+- `DCC_ALLOW_UNDOCUMENTED_Z80` — Shell driver only: set to `1` to allow
+  dccpeep passes that use the Z80's undocumented IYH/IYL opcodes; with
+  `dccmake`, use `dcc-allow-undocumented-z80=true`
+- `DCC_USE_EMULATED_M80`, `DCC_USE_EMULATED_L80` — Set to `1` to select the
+  real CP/M assembler or linker under `ntvcm`
 - `DCC_ARGS` — Extra whitespace-separated `dcc` options such as `-DNAME=1 -UOLD`
 - `NTVCM_ARGS` — Extra whitespace-separated `ntvcm` options such as `-p -s:4000000`
 - `DCC_HOME` — DCC C Compiler package/install root; used to find `include/`, `lib/`, and CP/M tools
@@ -207,12 +218,20 @@ dccmake dcc-peep=false
 | `dcc-no-floatio` | `false` | Force `%f` support off even for matching literals or the non-literal fallback |
 | `dcc-flongio` | `false` | Force long-format support on every `printf`-family call when true; literal formats are normally detected per call |
 | `dcc-no-longio` | `false` | Force long-format support off even for matching literals or the non-literal fallback |
+| `dcc-hexio` | `false` | Force `%x`/`%X` support on every `printf`-family call |
+| `dcc-no-hexio` | `false` | Force `%x`/`%X` support off, even for matching formats |
+| `dcc-octio` | `false` | Force `%o` support on every `printf`-family call |
+| `dcc-no-octio` | `false` | Force `%o` support off, even for matching formats |
 | `dcc-stack-bytes` | `512` | Stack reserve passed to `dcc` with `-stack` |
 | `dcc-stack-check` | Environment/default | Pass `-fstack-check` to `dcc` |
+| `dcc-no-narrow` | `false` | Pass `-fno-narrow` to disable byte-narrowing passes |
+| `dcc-debug` | `false` | Emit source-level debug metadata; requires native `m80c` |
 | `dcc-include-directory` | Auto-adds `.` when standard headers are in the current directory | Comma-separated include directories; `dcc-include` is an alias |
 | `dcc-define` | none | Comma-separated `NAME[=value]` entries passed to `dcc` as `-D`; `dcc-defines` is an alias |
 | `dcc-undefine` | none | Comma-separated names passed to `dcc` as `-U`; `dcc-undefines` is an alias |
 | `dcc-peep` | `true` | Run `dccpeep` after compiling each `.MAC` file |
+| `dcc-peep-debug` | `false` | Run `dccpeep` even in a debug build; optimized source-line locations may be unreliable |
+| `dcc-allow-undocumented-z80` | `false` | Pass `-fundocumented-z80` to `dccpeep` |
 | `dcc-build-dir` | `build` | Artifact directory |
 | `dcc-runtime` | `DCC_RUNTIME`, local `DCCRTL.MAC`, or `DCCRTL.MAC` | Runtime source passed to `dccrtlstrip` |
 | `dcc-tool` | `DCC`, local `dcc`, or `dcc` | DCC compiler command |
@@ -226,12 +245,19 @@ dccmake dcc-peep=false
 | `l80c-tool` | `L80C`, local `l80c`, or `l80c` | Native host linker command (default, no `ntvcm`) |
 | `dcc-use-emulated-l80` | `false` | Link with real `L80.COM` under `ntvcm` instead of native `l80c` |
 
-With all four float/long settings at their default `false`, `dccmake` passes no
-formatted-I/O override to dcc and adds no forced keep root to `dccrtlstrip`.
-dcc therefore performs its normal per-call format detection. In particular,
-`dcc-floatio=false` and `dcc-flongio=false` are neutral; use
-`dcc-no-floatio=true` or `dcc-no-longio=true` only when support must be forced
-off.
+`dccmake` initializes its Boolean settings from the matching environment
+variables before reading `dccmake.txt`: `DCC_FLOATIO`, `DCC_NO_FLOATIO`,
+`DCC_LONGIO`, `DCC_NO_LONGIO`, `DCC_HEXIO`, `DCC_NO_HEXIO`, `DCC_OCTIO`,
+`DCC_NO_OCTIO`, `DCC_FORCE_STACK_CHECK`, `DCC_NO_NARROW`, `DCC_DEBUG`,
+`DCC_PEEP_DEBUG`, `DCC_ALLOW_UNDOCUMENTED_Z80`, `DCC_USE_EMULATED_M80`, and
+`DCC_USE_EMULATED_L80`. File settings and then command-line settings override
+those defaults.
+
+With all formatted-I/O settings at their default `false`, `dccmake` passes no
+override to dcc and adds no forced keep root to `dccrtlstrip`. dcc therefore
+performs its normal per-call detection for float, long, hexadecimal, and octal
+formats. The force-on settings are neutral when false; use a `dcc-no-*io`
+setting only when that format support must be forced off.
 
 Source input basenames and the output name must be CP/M 8.3-clean. For example,
 `module1.c` is valid, but a generated module output base longer than eight
@@ -245,8 +271,16 @@ characters is not.
 | `-fno-floatio` | `dcc-no-floatio=true` |
 | `-fl`, `-flongio` | `dcc-flongio=true` |
 | `-fno-longio` | `dcc-no-longio=true` |
+| `-fhexio` | `dcc-hexio=true` |
+| `-fno-hexio` | `dcc-no-hexio=true` |
+| `-foctio` | `dcc-octio=true` |
+| `-fno-octio` | `dcc-no-octio=true` |
 | `-s <bytes>`, `-stack <bytes>`, `-stack=<bytes>` | `dcc-stack-bytes=<bytes>` |
 | `-fstack-check` | `dcc-stack-check=true` |
+| `-fno-narrow` | `dcc-no-narrow=true` |
+| `-g` | `dcc-debug=true` |
+| `-femulated-m80` | `dcc-use-emulated-m80=true` |
+| `-femulated-l80` | `dcc-use-emulated-l80=true` |
 | `-I <dir>`, `-Idir` | Add an include directory |
 | `-D <name>[=value]`, `-Dname=value` | Pass a define to `dcc` |
 | `-U <name>`, `-Uname` | Pass an undefine to `dcc` |
@@ -254,6 +288,22 @@ characters is not.
 
 `-c` and `-module` are rejected because `dccmake` decides module mode from the
 input order.
+
+## Peephole Optimizer (`dccpeep`)
+
+`dccmake` runs `dccpeep` after compilation when `dcc-peep=true`. It can also be
+invoked directly:
+
+```sh
+dccpeep [-Ot|-Os] [-fundocumented-z80] [-fstats] input.mac output.mac
+```
+
+| Option | Purpose |
+| ------ | ------- |
+| `-Ot` | Optimize for execution time (default) |
+| `-Os` | Optimize for code size |
+| `-fundocumented-z80` | Allow passes that use undocumented Z80 opcodes |
+| `-fstats` | Print optimization statistics |
 
 ## Test Suite Runner (`runall.ps1`)
 
@@ -263,19 +313,26 @@ runtime arguments, stack sizes, and optional DCC C Compiler build flags.
 
 Runs in parallel by default:
 
-- Each app builds in its own `build/<app>/` subdirectory so concurrent builds
-  don't clobber shared artifacts.
-- The whole run is isolated under a per-invocation `build/run-<pid>/` folder that
-  is removed automatically on exit; pass `-KeepBuild` to retain it for debugging.
-- A live `[ n/total] PASS/FAIL` status prints as each app completes.
+- Each app builds in its own directory below a per-invocation
+  `<build-root>/run-<pid>/` folder, so concurrent builds do not clobber shared
+  artifacts.
+- The per-invocation folder is removed automatically on exit; pass `-KeepBuild`
+  to retain it. On Linux, the build root defaults to `/dev/shm/dcc-runall` when
+  available; elsewhere it defaults to `build`.
+- Failures print as each app completes. PASS lines are suppressed by default;
+  pass `-FailuresOnly:$false` to show every result.
 - Use `-Serial` to fall back to sequential builds in the shared `build/`
   directory.
 - Pass `-Extended` to also run the imported c-testsuite single-exec corpus
   (via `runall-extended.ps1`) after the main suite.
 - The lightweight stack-overflow guard (`-fstack-check`) is **on by default**;
   pass `-NoStackCheck` to build without it.
-- Pass `-Report` to append per-app run time and `.COM` size measurements to a
-  CSV report. Report mode implies `-NoStackCheck`.
+- Z80 cycle counts and `.COM` sizes are checked against
+  `tests/perf_baselines.csv` by default, with no separate benchmark pass. Use
+  `-NoPerfCheck` to skip this check or `-UpdatePerfBaseline` after an intentional
+  measured change.
+- Pass `-Report` to append cycles, `.COM` sizes, and clock-normalized times to a
+  historical CSV report. Report mode implies `-NoStackCheck`.
 
 ### Test Runner Usage
 
@@ -297,9 +354,13 @@ With no options, the suite runs in parallel, enables `-fstack-check`, and uses
 ./scripts/runall.ps1 -Emulator altair
 ./scripts/runall.ps1 -Mode fast            # optimized build only
 ./scripts/runall.ps1 -Mode nopeep          # unoptimized build only
+./scripts/runall.ps1 -Apps tprintf,tlong   # selected apps only
+./scripts/runall.ps1 -FailFast             # stop dispatching after a failure
+./scripts/runall.ps1 -FailuresOnly:$false  # include PASS lines
 ./scripts/runall.ps1 -Extended             # also run extended c-testsuite
-./scripts/runall.ps1 -KeepBuild            # keep build/run-<pid>/ for debugging
+./scripts/runall.ps1 -KeepBuild            # keep the per-run build folder
 ./scripts/runall.ps1 -Report               # also append perf_results.csv
+./scripts/runall.ps1 -Mode full -UpdatePerfBaseline
 ```
 
 ### Build Modes
@@ -321,17 +382,29 @@ The `-Mode` parameter selects which optimization pass(es) to build and verify.
 | --------- | ------- | ------- |
 | `-Emulator` | `ntvcm` | Emulator command for running .COM files |
 | `-NoStackCheck` | (off) | Disable `-fstack-check` (the guard is ON by default) |
+| `-UseEmulatedM80` | (off) | Assemble with M80.COM under `ntvcm` instead of native `m80c` |
+| `-UseEmulatedL80` | (off) | Link with L80.COM under `ntvcm` instead of native `l80c` |
 | `-BuildDir` | `build` | Build directory for artifacts |
+| `-NoRamDisk` | (off) | On Linux, disable the automatic `/dev/shm/dcc-runall` build root |
 | `-BaselineDir` | `tests/baselines` | Directory of per-app `<app>.txt` baselines |
 | `-Mode` | `fast` | Build mode: `fast` (optimized), `nopeep` (unoptimized), or `full` |
+| `-Apps` | all tests | Comma-separated app names to run |
+| `-RunTimeout` | `60` | Per-build and per-emulator-run timeout in seconds |
 | `-Help` | (off) | Show help text and exit without building or running tests |
 | `-Extended` | (off) | Also run the extended c-testsuite corpus after the main suite |
 | `-Serial` | (off) | Run sequentially instead of the default parallel mode |
 | `-ThrottleLimit` | CPU core count | Max concurrent apps in parallel mode |
-| `-KeepBuild` | (off) | Keep the per-invocation `build/run-<pid>/` folder instead of removing it on exit (parallel mode) |
-| `-Report` | (off) | Append per-app execution time and `.COM` size metrics to a CSV report; implies `-NoStackCheck` |
+| `-KeepBuild` | (off) | Keep the per-invocation run folder instead of removing it on exit (parallel mode) |
+| `-FailFast` | (off) | Stop dispatching new apps after the first correctness or performance failure |
+| `-FailuresOnly` | on | Suppress PASS lines; pass `-FailuresOnly:$false` for full output |
+| `-Report` | (off) | Append cycle, normalized-time, and `.COM` size metrics to a CSV report; implies `-NoStackCheck` |
 | `-ReportFile` | `perf_results.csv` | CSV path used by `-Report` |
-| `-ReportClockHz` | `1000000000` | ntvcm clock speed used for measured app runs in report mode; set to `0` for full-speed report runs |
+| `-ReportClockHz` | `400000000` | Nominal clock used to derive report milliseconds from Z80 cycles; does not throttle execution |
+| `-NoPerfCheck` | (off) | Skip the default cycle-count and `.COM` size regression check |
+| `-UpdatePerfBaseline` | (off) | Update checked performance columns for the modes built by this run |
+| `-PerfBaselineFile` | `tests/perf_baselines.csv` | Checked cycle-count and `.COM` size baseline |
+| `-NarrowDiff` | (off) | Compare normal and `-fno-narrow` runs to detect narrowing behavior changes |
+| `-TimingBreakdown` | (off) | Print suite-phase and aggregate build-pipeline timing percentages |
 
 ### Output
 
@@ -379,6 +452,7 @@ host-only skip settings.
 ./scripts/validate-unit-test.ps1              # validate every runnable test
 ./scripts/validate-unit-test.ps1 -App tprintf # validate one test app
 ./scripts/validate-unit-test.ps1 -CC clang    # use clang on Linux/macOS
+./scripts/validate-unit-test.ps1 -Serial      # sequential fallback
 ./scripts/validate-unit-test.ps1 -Help        # show help and exit
 ```
 
@@ -391,6 +465,8 @@ host-only skip settings.
 | `-CC` | platform default | C compiler override on macOS/Linux; ignored on Windows |
 | `-App` | all tests | Validate one test app, without the `.c` extension |
 | `-RunTimeout` | `10` | Seconds to allow each host executable to run |
+| `-Serial` | (off) | Run sequentially instead of the default parallel mode |
+| `-ThrottleLimit` | CPU core count | Max concurrent apps in parallel mode |
 | `-Help` | (off) | Show help text and exit without building or running tests |
 
 ### Linux 32-bit Validation
@@ -441,7 +517,14 @@ one test, keyed by `name`:
 ```json
 {
   "apps": [
-    { "name": "<app>", "args": "<string>", "stdin": "<string>", "stack_size": <int>, "dcc_args": "<string>", "dcc_floatio": <bool>, "dcc_longio": <bool>, "ignore": <bool> }
+    {
+      "name": "<app>",
+      "args": "<string>",
+      "fixtures": ["<file>"],
+      "extra_scenarios": [
+        { "suffix": "<name>", "args": "<string>", "fixtures": ["<file>"] }
+      ]
+    }
   ]
 }
 ```
@@ -455,32 +538,50 @@ one test, keyed by `name`:
 | `dcc_args` | string | no | `""` | Extra DCC C Compiler build arguments passed through `dccmake` (for example `-DNAME=1 -UOLD`) |
 | `dcc_floatio` | boolean | no | environment/default | True forces `-ffloatio`; false leaves per-call auto-detection active for this app |
 | `dcc_longio` | boolean | no | environment/default | True forces `-flongio`; false leaves per-call auto-detection active for this app |
+| `fixtures` | string array | no | `[]` | Files from `tests/` copied into the app build directory under uppercase CP/M names |
+| `extra_scenarios` | object array | no | `[]` | Additional argument/input/fixture scenarios run against the same built `.COM` |
 | `ignore` | boolean | no | `false` | When `true`, the test is skipped entirely (not built or run) |
+| `perf_ignore` | boolean | no | `false` | Exclude nondeterministic apps from cycle-count regression checks |
+| `narrow_diff_ignore` | boolean | no | `false` | Exclude layout-sensitive apps from `-NarrowDiff` |
+| `host` | boolean | no | `false` | Skip ordinary host validation; with the 32-bit requirement below, allow only the Linux `-m32` path |
+| `requires-32bit-linux-host-compiler` | boolean | no | `false` | With `host: true`, allow host validation only when Linux GCC's probed `-m32` mode is active |
+| `requires-non-msvc-host-compiler` | boolean | no | `false` | Skip host validation under MSVC |
+| `requires-non-macos-host-compiler` | boolean | no | `false` | Skip host validation on macOS |
+| `host-cflags` | string | no | `""` | Replace the default GCC/Clang flags for this app's host build |
 
-Entries with none of the optional properties have no effect, so an app only
-appears here if it overrides at least one default.
+Each `extra_scenarios` object accepts a required `suffix` plus optional `args`,
+`stdin`, and `fixtures`. It reuses the primary `.COM` and compares output with
+`tests/baselines/<app>_<suffix>.txt`. Entries with none of the optional
+properties have no effect, so an app only appears here if it overrides at least
+one default.
 
 ### Example
 
 ```json
 {
   "apps": [
-    { "name": "ttt", "args": "10" },
-    { "name": "pint", "args": "e.pas" },
-    { "name": "tkbd", "stdin": "x" },
-    { "name": "cobint", "args": "e.cob", "stack_size": 1536 },
-    { "name": "triangle", "stack_size": 768 },
-    { "name": "na", "ignore": true },
-    { "name": "tc89fltb", "ignore": true },
-    { "name": "spsmash", "ignore": true }
+    {
+      "name": "pint",
+      "args": "e.pas",
+      "stack_size": 768,
+      "fixtures": ["E.PAS"],
+      "extra_scenarios": [
+        { "suffix": "ttt", "args": "ttt.pas", "fixtures": ["TTT.PAS"] }
+      ]
+    },
+    { "name": "tkbd", "stdin": "x", "perf_ignore": true },
+    { "name": "tstackov", "host": true, "narrow_diff_ignore": true },
+    { "name": "na", "ignore": true }
   ]
 }
 ```
 
 ### Common reasons to add an entry
 
-- **Program reads a data file** — interpreters like `pint`, `cobint`, `forint`
-  take a fixture filename as `args` (e.g. `e.pas`, `e.cob`).
+- **Program reads a data file** — declare it in `fixtures` and pass its CP/M
+  name in `args`; only that app's build directory receives the file.
+- **One binary needs several datasets** — use `extra_scenarios` to rerun the
+  same `.COM` with separate arguments, fixtures, and baselines.
 - **Program reads from stdin** — set `stdin` for tests that require scripted
   keyboard/input text (for example, `tkbd` expects `x`).
 - **Deep recursion** — apps such as `triangle` (768) and `cobint` (1536) need a
@@ -489,6 +590,12 @@ appears here if it overrides at least one default.
 - **Cannot be auto-tested** — set `ignore: true` for interactive programs
   (`na`, an editor that waits for keystrokes), tests that intentionally fail to
   compile (`tc89fltb`), or deliberate stack-smashers (`spsmash`).
+- **Results are inherently nondeterministic** — use `perf_ignore` for timing-
+  or filesystem-sensitive apps, and `narrow_diff_ignore` only when output
+  legitimately depends on stack layout.
+- **Host compiler coverage is conditional** — use the host requirement fields
+  for ABI, compiler, or libc differences; `host-cflags` handles per-test C mode
+  or optimizer requirements.
 
 To change a test's run behavior, edit `tests/_test_overrides.json` and re-run
 the suite. See also `tests/README.md` in the repository for how tests,
@@ -496,13 +603,15 @@ baselines, and this file relate.
 
 ## Performance Reporting (`runall.ps1 -Report`)
 
-`runall.ps1 -Report` collects performance data during the normal verified test
-suite. It appends per-app execution time and `.COM` size metrics to a CSV report,
-while still checking output against the usual baselines.
+`runall.ps1 -Report` appends historical performance data during the normal
+verified suite; it does not add a separate benchmark pass. Every `ntvcm` run
+already uses `-p -s:0`, so execution remains unthrottled while the runner records
+the emulator's host-independent Z80 cycle count and the `.COM` size.
 
-Report mode implies `-NoStackCheck` so timings reflect normal builds. When using
-`ntvcm`, measured app runs use a fixed 1 GHz emulator clock by default; set
-`-ReportClockHz 0` for full-speed report runs.
+Report mode implies `-NoStackCheck`. The `peep_ms` and `nopeep_ms` values are
+derived as `cycles / ReportClockHz * 1000`, using a default nominal clock of
+400 MHz; `ReportClockHz` never changes emulator speed. Set it to `0` to leave
+the derived millisecond fields empty while retaining cycles and sizes.
 
 ```pwsh
 ./scripts/runall.ps1 -Report
@@ -514,27 +623,37 @@ Results are written to `perf_results.csv` by default. **Results append to the
 file**, so each report run adds a new row per app:
 
 ```csv
-machine,utc-timestamp,app,peep_ms,peep_size,nopeep_ms,nopeep_size
-mycomputer,2026-06-16T07:18:39Z,tstring,17000,6400,19000,6912
-mycomputer,2026-06-16T07:18:39Z,sieve,1000,2176,3000,2304
-mycomputer,2026-06-16T07:24:21Z,tstring,17000,6400,17000,6912
-mycomputer,2026-06-16T07:24:21Z,sieve,1000,2176,3000,2304
+machine,os,utc-timestamp,app,peep_ms,peep_cycles,peep_size,nopeep_ms,nopeep_cycles,nopeep_size,clock_hz
+z80-lab,macOS,2026-08-18T12:00:00Z,sieve,0.75,300000,2176,,,,400000000
 ```
 
 **Columns:**
 
 - `machine` — Name of the machine running the benchmark
+- `os` — Host operating-system name
 - `utc-timestamp` — UTC timestamp (ISO 8601 format, e.g., `2026-06-16T07:18:39Z`)
 - `app` — Application name
-- `peep_ms` — Execution time in milliseconds (optimized with dccpeep)
+- `peep_ms` — Clock-normalized milliseconds for the optimized build
+- `peep_cycles` — Z80 cycles reported for the optimized build
 - `peep_size` — Binary size in bytes (optimized)
-- `nopeep_ms` — Execution time in milliseconds (unoptimized)
+- `nopeep_ms` — Clock-normalized milliseconds for the unoptimized build
+- `nopeep_cycles` — Z80 cycles reported for the unoptimized build
 - `nopeep_size` — Binary size in bytes (unoptimized)
+- `clock_hz` — Nominal `ReportClockHz` used for the millisecond calculation
 
 The `-ReportFile` parameter controls the output path. The `-Mode` parameter
 controls which CSV columns are populated: `-Mode full` fills both `peep_*` and
 `nopeep_*`; single-mode runs fill only the selected mode's columns. In the CSV,
 `peep_*` columns hold optimized-build measurements.
+
+### Checked performance baselines
+
+Normal stack-checked runs compare each built mode's cycle count and `.COM` size
+with `tests/perf_baselines.csv`. This check is on by default and uses the same
+execution as output verification. `-NoPerfCheck`, `-NoStackCheck`, and `-Report`
+skip it. After an intentional, verified change, run with
+`-UpdatePerfBaseline`; only the mode columns built by that invocation are
+rewritten.
 
 ## Stack Size Measurement (`stacksize.sh` / `stacksize.bat`)
 

--- a/docs/docs/en/standard-lib/05-stdio.md
+++ b/docs/docs/en/standard-lib/05-stdio.md
@@ -105,7 +105,9 @@ Field width and flags:
 - A positive precision on `printf` `%f` (`%.2f`) controls the number of digits
   after the decimal point. Without a positive precision, `%f` prints six
   fractional digits. `%f` always emits a decimal point.
-- String precision (`%.3s`) is not implemented; `%s` prints the whole string.
+- A precision on `%s` (`%.3s`) limits output to at most that many characters,
+  stopping at NUL first when the string is shorter. `%.0s` emits no characters
+  and does not dereference the string argument.
 
 ```c
 printf("|%6d|%-6d|%.4d|\n", 42, 42, 42);   /* |    42|42    |0042| */

--- a/docs/docs/en/standard-lib/14-string.md
+++ b/docs/docs/en/standard-lib/14-string.md
@@ -9,7 +9,8 @@ Include [`string.h`](14-string.md) for byte-string and raw memory operations.
 ## Runtime model
 
 The string and memory functions operate on byte strings and raw byte buffers.
-`strcoll` is equivalent to `strcmp`; the DCC C Compiler has no locale model.
+In the fixed [`C` locale](17-locale.md), `strcoll` is equivalent to `strcmp`
+and `strxfrm` uses the identity transform.
 
 ## String and memory operations
 

--- a/docs/docs/en/standard-lib/16-signal.md
+++ b/docs/docs/en/standard-lib/16-signal.md
@@ -1,0 +1,23 @@
+# Signal handling (`signal.h`)
+
+Include [`signal.h`](16-signal.md) for signal constants and abnormal program
+termination.
+
+## Types and Macros
+
+<!-- SIGNAL-SYMBOL-TABLE: all -->
+
+The signal numbers and handler constants provide C89 source compatibility.
+CP/M does not install or deliver asynchronous signal handlers.
+
+## Functions
+
+<!-- SIGNAL-FUNCTION-TABLE: all -->
+
+## Runtime model
+
+`signal()` always returns `SIG_ERR`; neither `SIG_DFL`, `SIG_IGN`, nor a
+user-provided handler can be installed on CP/M 2.2.
+
+`raise(SIGABRT)` calls `abort()` and does not return. Raising any other defined
+signal is a no-op that returns zero.

--- a/docs/docs/en/standard-lib/17-locale.md
+++ b/docs/docs/en/standard-lib/17-locale.md
@@ -1,0 +1,25 @@
+# Localization (`locale.h`)
+
+Include [`locale.h`](17-locale.md) for locale categories and fixed-C-locale
+formatting conventions.
+
+## Types and Macros
+
+<!-- LOCALE-SYMBOL-TABLE: all -->
+
+`struct lconv` has the standard C89 numeric and monetary formatting members.
+In DCC's fixed `C` locale, `decimal_point` is `"."`, every other string is
+empty, and every `char` field is `CHAR_MAX` (not applicable).
+
+## Functions
+
+<!-- LOCALE-FUNCTION-TABLE: all -->
+
+## Fixed locale model
+
+The active locale is always `"C"`. `setlocale(category, NULL)` queries it, and
+requesting either `"C"` or the implementation default `""` succeeds and
+returns `"C"`. Any other locale name returns `NULL`. Because every category is
+fixed, `category` does not change the result.
+
+`localeconv()` returns the same static `struct lconv` object on every call.

--- a/docs/docs/hooks/stdlib_tables.py
+++ b/docs/docs/hooks/stdlib_tables.py
@@ -22,8 +22,10 @@ from typing import Dict, Iterable, List, Mapping
 MARKER_RE = re.compile(r"<!--\s*(?P<prefix>[A-Z][A-Z0-9]*)-(?P<kind>FUNCTION|SYMBOL)-TABLE\s*:\s*(?P<names>.*?)\s*-->")
 FUNCTION_RE = re.compile(r"\b(?P<name>[A-Za-z_]\w*)\s*\(")
 DEFINE_RE = re.compile(r"^#\s*define\s+(?P<name>[A-Za-z_]\w*)\b")
+TYPEDEF_FUNCTION_PTR_RE = re.compile(r"^typedef\b.*\(\s*\*\s*(?P<name>[A-Za-z_]\w*)\s*\)\s*\([^;]*\)\s*;")
 TYPEDEF_RE = re.compile(r"^typedef\b.*\b(?P<name>[A-Za-z_]\w*)\s*(?:\[[^\]]*\])?\s*;")
 EXTERN_RE = re.compile(r"^extern\b.*\b(?P<name>[A-Za-z_]\w*)\s*;")
+STRUCT_RE = re.compile(r"^struct\s+(?P<name>[A-Za-z_]\w*)\s*\{")
 
 HEADER_BY_PREFIX: Mapping[str, str] = {
     "STDIO": "stdio.h",
@@ -35,6 +37,8 @@ HEADER_BY_PREFIX: Mapping[str, str] = {
     "ERRNO": "errno.h",
     "FLOAT": "float.h",
     "LIMITS": "limits.h",
+    "LOCALE": "locale.h",
+    "SIGNAL": "signal.h",
     "SETJMP": "setjmp.h",
     "STDARG": "stdarg.h",
     "STDBOOL": "stdbool.h",
@@ -115,7 +119,7 @@ def _extract_doxygen_summary(lines: List[str], start: int) -> tuple[str, int]:
 
 
 def _non_function_symbol_name(declaration: str) -> str:
-    for pattern in (DEFINE_RE, TYPEDEF_RE, EXTERN_RE):
+    for pattern in (DEFINE_RE, TYPEDEF_FUNCTION_PTR_RE, TYPEDEF_RE, EXTERN_RE, STRUCT_RE):
         match = pattern.match(declaration)
         if match:
             return match.group("name")
@@ -192,7 +196,8 @@ def _parse_header_symbols(header: Path) -> Dict[str, DocEntry]:
         name = _non_function_symbol_name(declaration)
         if name:
             if pending_summary:
-                entries[name] = DocEntry(signature=name, summary=pending_summary)
+                signature = f"struct {name}" if STRUCT_RE.match(declaration) else name
+                entries[name] = DocEntry(signature=signature, summary=pending_summary)
             pending_summary = ""
         index += 1
 

--- a/docs/docs/mkdocs.yml
+++ b/docs/docs/mkdocs.yml
@@ -27,8 +27,10 @@ nav:
       - "errno.h: Error reporting": en/standard-lib/02-errno.md
       - "float.h: Floating-point limits": en/standard-lib/03-float.md
       - "limits.h: Integer limits": en/standard-lib/04-limits.md
+      - "locale.h: Localization": en/standard-lib/17-locale.md
       - "math.h: Floating point math": en/standard-lib/08-math.md
       - "setjmp.h: Non-local jumps": en/standard-lib/09-setjmp.md
+      - "signal.h: Signal handling": en/standard-lib/16-signal.md
       - "stdarg.h: Variadic arguments": en/standard-lib/10-stdarg.md
       - "stdbool.h: Boolean type": en/standard-lib/11-stdbool.md
       - "stddef.h: Common definitions": en/standard-lib/12-stddef.md


### PR DESCRIPTION
- Added support for LOCALE and SIGNAL in symbol tables within the documentation.
- Updated README.md to reflect new symbols in the standard library.
- Improved the description and structure of the `dirent.h` section in the system and CPM documentation.
- Enhanced architecture documentation with additional details on the front end and MIR core components.
- Expanded runtime optimization appendix with direct usage instructions for `dccrtlstrip`.
- Updated utilities appendix with detailed build driver options and environment variables.
- Clarified formatted I/O behavior in the stdio documentation.
- Improved string handling documentation to specify locale behavior.
- Introduced new signal handling and localization documentation files.