### PR TITLE
Document CALC module responsibilities

### DIFF
--- a/tests/calc.c
+++ b/tests/calc.c
@@ -1,3 +1,37 @@
+/**
+ * @file calc.c
+ * @brief Expression-calculator front end used as an end-to-end DCC regression.
+ *
+ * @par Scenario
+ * The test runner supplies deterministic command-line expressions that cover
+ * signed 1024-bit integers, decimal arithmetic, division, modulus, powers,
+ * bitwise operations, and equality. With no arguments, the same evaluator is
+ * an interactive CP/M console calculator.
+ *
+ * @par Role
+ * This module owns tokenization, recursive-descent parsing, mixed integer and
+ * decimal dispatch, result formatting, commands, and BDOS console interaction.
+ *
+ * @par Build variants
+ * The portable build leaves Z80_ASM_OPTS undefined:
+ * @code{.sh}
+ * ./dccmake tests/calc.c tests/calc1024.c tests/calcdoub.c \
+ *   dcc-output=CALC
+ * @endcode
+ * The comparison build enables the optional hand-written integer kernels for
+ * every translation unit and uses calcopt.c as the front-end wrapper:
+ * @code{.sh}
+ * ./dccmake tests/calcopt.c tests/calc1024.c tests/calcdoub.c \
+ *   dcc-define=Z80_ASM_OPTS dcc-output=CALCOPT
+ * @endcode
+ * dcc-peep=true or false controls the separate peephole pass for either build;
+ * it does not select between portable C and the Z80 kernels.
+ *
+ * @par Boundary
+ * calc1024 owns integer representation and arithmetic; calcdoub owns decimal
+ * representation and arithmetic. calcopt.c may include this file to build the
+ * identical front end with optional Z80 arithmetic kernels enabled.
+ */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/calc1024.c
+++ b/tests/calc1024.c
@@ -1,3 +1,19 @@
+/**
+ * @file calc1024.c
+ * @brief Signed 1024-bit integer implementation for the CALC regression.
+ *
+ * @par Role
+ * This module implements parsing, formatting, comparison, arithmetic, and
+ * bitwise operations over fixed little-endian arrays of 32-bit limbs. The
+ * portable C path deliberately exercises reusable wide-integer compiler
+ * patterns; Z80_ASM_OPTS selects equivalent hand-written kernels for the
+ * comparison build.
+ *
+ * @par Boundary
+ * The public integer contract is declared in calc1024.h. This layer has no
+ * parser or console responsibilities, and calcdoub builds decimal arithmetic
+ * on top of it.
+ */
 #include "calc1024.h"
 
 #define SIGN_BIT 0x80000000UL

--- a/tests/calc1024.h
+++ b/tests/calc1024.h
@@ -1,3 +1,15 @@
+/**
+ * @file calc1024.h
+ * @brief Public fixed-width integer contract for the CALC modules.
+ *
+ * @par Role
+ * Defines the 1024-bit two's-complement representation and the operations used
+ * by the calculator and decimal layer.
+ *
+ * @par Boundary
+ * Representation size and callable arithmetic belong here; implementation
+ * details and optional Z80 kernels remain private to calc1024.c.
+ */
 #pragma once
 
 #define CALC_INT_WORDS 32

--- a/tests/calcdoub.c
+++ b/tests/calcdoub.c
@@ -1,3 +1,16 @@
+/**
+ * @file calcdoub.c
+ * @brief Decimal coefficient/exponent arithmetic for the CALC regression.
+ *
+ * @par Role
+ * Implements normalized decimal parsing, formatting, comparison, arithmetic,
+ * rounding, and integer powers using a signed CalcInt1024 coefficient and a
+ * decimal exponent. CalcDouble is not the target's native floating type.
+ *
+ * @par Boundary
+ * calc1024 supplies all coefficient arithmetic. This module does not parse
+ * expressions or perform console I/O; calc.c owns those responsibilities.
+ */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/calcdoub.h
+++ b/tests/calcdoub.h
@@ -1,3 +1,15 @@
+/**
+ * @file calcdoub.h
+ * @brief Public decimal-arithmetic contract for the CALC front end.
+ *
+ * @par Role
+ * Defines the coefficient/exponent representation and decimal operations used
+ * for mixed numeric expressions.
+ *
+ * @par Boundary
+ * CalcDouble is implemented by calcdoub.c on top of CalcInt1024; expression
+ * syntax, promotion policy, and user interaction remain in calc.c.
+ */
 #pragma once
 
 #include "calc1024.h"

--- a/tests/calcopt.c
+++ b/tests/calcopt.c
@@ -1,2 +1,14 @@
-/* Build the CALC front end separately with its optional Z80 kernels enabled. */
+/**
+ * @file calcopt.c
+ * @brief Assembly-assisted comparison variant of the CALC regression.
+ *
+ * @par Scenario
+ * Builds the same parser and evaluator as calc.c while enabling the optional
+ * Z80 kernels in calc1024.c, providing a behavioral and performance reference
+ * for the portable generated-code path.
+ *
+ * @par Boundary
+ * This wrapper owns no calculator behavior; all front-end logic remains in
+ * calc.c and all conditional arithmetic kernels remain in calc1024.c.
+ */
 #include "calc.c"


### PR DESCRIPTION
## Summary

- describe the CALC end-to-end regression scenario and interactive CP/M mode
- document ownership boundaries across the parser, 1024-bit integer, decimal, and assembly-assisted wrapper modules
- add exact `dccmake` commands for portable C and `Z80_ASM_OPTS` builds
- clarify that the peephole pass is independent of the optional hand-written Z80 kernels

## Testing

- `DCC_MIR_REQUIRE_COMPLETE=1 DCC_MIR_REQUIRE_EMIT=1 pwsh ./scripts/runall.ps1 -Apps calc,calcopt -Mode full -RunTimeout 30 -FailuresOnly`
- executed both documented `dccmake` commands successfully

Both CALC variants passed all registered peep and no-peep scenarios with no performance regressions.