### PR TITLE
Fix l80c correctness defects

### DIFF
--- a/docs/docs/en/00-vscode-debugging.md
+++ b/docs/docs/en/00-vscode-debugging.md
@@ -20,11 +20,13 @@ Before configuring a project:
 2. Install the [Microsoft C/C++ extensions for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpp-devtools){: target="_blank" }.
 3. Make `dccmake` available on `PATH`, or use its absolute path in the build
    task.
-4. Make sure `dccmake` can find `dcc`, `dccpeep`, `dccrtlstrip`, `m80c`,
+4. Make sure `dccmake` can find `dcc`, `dccpeep`, `dccrtlstrip`,
+   [`m80c`](appendix/03-utilities.md#native-assembler-m80c),
    `DCCRTL.MAC`, and ntvcm as described on [The toolchain](00-setup-toolchain.md)
    page.
 
-Debug metadata requires the native `m80c` assembler. Do not set
+Debug metadata requires the native
+[`m80c`](appendix/03-utilities.md#native-assembler-m80c) assembler. Do not set
 `dcc-use-emulated-m80=true` for a debug build.
 
 ## Add the build task
@@ -197,7 +199,8 @@ multiple application threads.
 ## No-peep debug builds
 
 No-peep is the default and recommended mode for source debugging. `dccmake -g`
-keeps every `;@dcc-line` marker where DCC emitted it, and `m80c` records those
+keeps every `;@dcc-line` marker where DCC emitted it, and
+[`m80c`](appendix/03-utilities.md#native-assembler-m80c) records those
 locations in the `.DBG` file before linking relocates them to final addresses.
 
 In this mode, source breakpoints and source stepping have strong coverage across

--- a/docs/docs/en/02-build-and-link.md
+++ b/docs/docs/en/02-build-and-link.md
@@ -35,37 +35,27 @@ powershell.exe -ExecutionPolicy Bypass -File .\scripts\ma.ps1 foo -Mode nopeep  
 ```
 
 This runs the compiler, the optional `dccpeep` peephole optimizer,
-`dccrtlstrip`, then M80 and L80. Runtime trimming is part of the normal build
-path because it keeps unused library routines out of the final `.COM` file. The
-script resolves each tool from your `PATH` or from the `DCC`, `DCCPEEP`, and
-`DCCRTLSTRIP` environment variables.
+`dccrtlstrip`, [`m80c`](appendix/03-utilities.md#native-assembler-m80c), and
+[`l80c`](appendix/03-utilities.md#native-linker-l80c). Runtime trimming is part
+of the normal build path because it keeps unused library routines out of the
+final `.COM` file. The script resolves each tool from your `PATH` or its
+documented environment-variable override.
 
 The native linker normally uses `/P:100`, CP/M's standard `.COM` load address.
-For fixed-address, overlay, or relocating system programs, `l80c` also supports
-LINK-80-style nonstandard origins and generates the required CP/M entry
-jump/bootstrap. See [Native Linker (`l80c`)](appendix/03-utilities.md#native-linker-l80c)
-for its CLI options, origin layouts, and limitations.
+For fixed-address, overlay, or relocating system programs,
+[`l80c`](appendix/03-utilities.md#native-linker-l80c) also supports LINK-80-style
+nonstandard origins and generates the required CP/M entry jump/bootstrap. Its
+utility reference covers the CLI options, origin layouts, and limitations.
 
 ??? note "The manual pipeline (click to expand)"
 
     For manual builds or custom build systems, the full pipeline for `foo.c` is
-    shown below. `dcc`, `dccpeep`, and `dccrtlstrip` run on the host;
-    `m80.com` and `l80.com` are CP/M programs, so run them through `ntvcm` or
-    another CP/M emulator:
+    shown below. Every build tool runs natively on the host; only the resulting
+    `FOO.COM` needs CP/M or an emulator.
 
     === "Windows"
 
-        Define a CRLF helper using PowerShell/.NET APIs.
-
-        ```powershell
-        function Convert-ToCrlf($Path) {
-            $text = [IO.File]::ReadAllText($Path) -replace "`r?`n", "`r`n"
-            [IO.File]::WriteAllText($Path, $text)
-        }
-        ```
-
-        Compile the C source to M80 assembly, then optionally run the peephole
-        optimizer.
+        Compile and optionally optimize:
 
         ```powershell
         dcc -I C:\path\to\dcc -stack 512 foo.c -o FOO.MAC
@@ -73,47 +63,24 @@ for its CLI options, origin layouts, and limitations.
         Move-Item -Force _PEEPOUT.MAC FOO.MAC
         ```
 
-        Convert the app assembly to CP/M CRLF text and assemble it with M80 under
-        `ntvcm`.
+        Assemble the application:
 
         ```powershell
-        Convert-ToCrlf FOO.MAC
-        ntvcm m80 "=FOO.MAC" /X /O /Z /L
+        m80c "=FOO.MAC" /X /O /Z /L
         ```
 
-        Copy and trim the runtime to only the blocks used by the app.
+        Copy and trim the runtime, then assemble and link:
 
         ```powershell
         Copy-Item C:\path\to\dcc\DCCRTL.MAC DCCRTL.MAC
-        Convert-ToCrlf DCCRTL.MAC
         dccrtlstrip -r DCCRTL.MAC -o RTLMIN.MAC FOO.MAC
+        m80c "=RTLMIN.MAC" /X /O /Z
+        l80c "/P:100,RTLMIN,FOO,FOO/N/E/Y"
         ```
 
-        Convert, assemble, and link the trimmed runtime with the app.
+    === "macOS / Linux"
 
-        ```powershell
-        Convert-ToCrlf RTLMIN.MAC
-        ntvcm m80 "=RTLMIN.MAC" /X /O /Z
-        ntvcm l80 "/P:100,RTLMIN,FOO,FOO/N/E"
-        ```
-
-    === "macOS"
-
-        Define a CRLF helper: prefer `unix2dos` if it is installed, otherwise
-        use Perl (available on macOS).
-
-        ```sh
-        to_crlf() {
-            if command -v unix2dos >/dev/null 2>&1; then
-                unix2dos "$1" >/dev/null 2>&1 || true
-            else
-                perl -0pi -e 's/\r?\n/\r\n/g' "$1"
-            fi
-        }
-        ```
-
-        Compile the C source to M80 assembly, then optionally run the peephole
-        optimizer.
+        Compile and optionally optimize:
 
         ```sh
         dcc -I /path/to/dcc -stack 512 foo.c -o FOO.MAC
@@ -121,180 +88,25 @@ for its CLI options, origin layouts, and limitations.
         mv _PEEPOUT.MAC FOO.MAC
         ```
 
-        Convert the app assembly to CP/M CRLF text and assemble it with M80 under
-        `ntvcm`.
+        Assemble the application, trim and assemble the runtime, then link:
 
         ```sh
-        to_crlf FOO.MAC
-        ntvcm m80 "=FOO.MAC" /X /O /Z /L
-        ```
-
-        Copy and trim the runtime to only the blocks used by the app.
-
-        ```sh
+        m80c "=FOO.MAC" /X /O /Z /L
         cp /path/to/dcc/DCCRTL.MAC DCCRTL.MAC
-        to_crlf DCCRTL.MAC
         dccrtlstrip -r DCCRTL.MAC -o RTLMIN.MAC FOO.MAC
+        m80c "=RTLMIN.MAC" /X /O /Z
+        l80c "/P:100,RTLMIN,FOO,FOO/N/E/Y"
         ```
 
-        Convert, assemble, and link the trimmed runtime with the app.
+    Replace `/path/to/dcc` (or `C:\path\to\dcc`) with the checkout or install
+    directory containing the standard headers and `DCCRTL.MAC`. Native
+    [`m80c`](appendix/03-utilities.md#native-assembler-m80c) accepts normal host
+    line endings; no CP/M text conversion is needed.
 
-        ```sh
-        to_crlf RTLMIN.MAC
-        ntvcm m80 "=RTLMIN.MAC" /X /O /Z
-        ntvcm l80 "/P:100,RTLMIN,FOO,FOO/N/E"
-        ```
-
-    === "Ubuntu"
-
-        Define a CRLF helper: prefer `unix2dos` if it is installed, otherwise
-        use Perl (available on Ubuntu).
-
-        ```sh
-        to_crlf() {
-            if command -v unix2dos >/dev/null 2>&1; then
-                unix2dos "$1" >/dev/null 2>&1 || true
-            else
-                perl -0pi -e 's/\r?\n/\r\n/g' "$1"
-            fi
-        }
-        ```
-
-        Compile the C source to M80 assembly, then optionally run the peephole
-        optimizer.
-
-        ```sh
-        dcc -I /path/to/dcc -stack 512 foo.c -o FOO.MAC
-        dccpeep FOO.MAC _PEEPOUT.MAC
-        mv _PEEPOUT.MAC FOO.MAC
-        ```
-
-        Convert the app assembly to CP/M CRLF text and assemble it with M80 under
-        `ntvcm`.
-
-        ```sh
-        to_crlf FOO.MAC
-        ntvcm m80 "=FOO.MAC" /X /O /Z /L
-        ```
-
-        Copy and trim the runtime to only the blocks used by the app.
-
-        ```sh
-        cp /path/to/dcc/DCCRTL.MAC DCCRTL.MAC
-        to_crlf DCCRTL.MAC
-        dccrtlstrip -r DCCRTL.MAC -o RTLMIN.MAC FOO.MAC
-        ```
-
-        Convert, assemble, and link the trimmed runtime with the app.
-
-        ```sh
-        to_crlf RTLMIN.MAC
-        ntvcm m80 "=RTLMIN.MAC" /X /O /Z
-        ntvcm l80 "/P:100,RTLMIN,FOO,FOO/N/E"
-        ```
-
-    === "Ubuntu ARM64"
-
-        Define a CRLF helper: prefer `unix2dos` if it is installed, otherwise
-        use Perl (available on Ubuntu).
-
-        ```sh
-        to_crlf() {
-            if command -v unix2dos >/dev/null 2>&1; then
-                unix2dos "$1" >/dev/null 2>&1 || true
-            else
-                perl -0pi -e 's/\r?\n/\r\n/g' "$1"
-            fi
-        }
-        ```
-
-        Compile the C source to M80 assembly, then optionally run the peephole
-        optimizer.
-
-        ```sh
-        dcc -I /path/to/dcc -stack 512 foo.c -o FOO.MAC
-        dccpeep FOO.MAC _PEEPOUT.MAC
-        mv _PEEPOUT.MAC FOO.MAC
-        ```
-
-        Convert the app assembly to CP/M CRLF text and assemble it with M80 under
-        `ntvcm`.
-
-        ```sh
-        to_crlf FOO.MAC
-        ntvcm m80 "=FOO.MAC" /X /O /Z /L
-        ```
-
-        Copy and trim the runtime to only the blocks used by the app.
-
-        ```sh
-        cp /path/to/dcc/DCCRTL.MAC DCCRTL.MAC
-        to_crlf DCCRTL.MAC
-        dccrtlstrip -r DCCRTL.MAC -o RTLMIN.MAC FOO.MAC
-        ```
-
-        Convert, assemble, and link the trimmed runtime with the app.
-
-        ```sh
-        to_crlf RTLMIN.MAC
-        ntvcm m80 "=RTLMIN.MAC" /X /O /Z
-        ntvcm l80 "/P:100,RTLMIN,FOO,FOO/N/E"
-        ```
-
-    === "Windows ARM64"
-
-        Define a CRLF helper using PowerShell/.NET APIs.
-
-        ```powershell
-        function Convert-ToCrlf($Path) {
-            $text = [IO.File]::ReadAllText($Path) -replace "`r?`n", "`r`n"
-            [IO.File]::WriteAllText($Path, $text)
-        }
-        ```
-
-        Compile the C source to M80 assembly, then optionally run the peephole
-        optimizer.
-
-        ```powershell
-        dcc -I C:\path\to\dcc -stack 512 foo.c -o FOO.MAC
-        dccpeep FOO.MAC _PEEPOUT.MAC
-        Move-Item -Force _PEEPOUT.MAC FOO.MAC
-        ```
-
-        Convert the app assembly to CP/M CRLF text and assemble it with M80 under
-        `ntvcm`.
-
-        ```powershell
-        Convert-ToCrlf FOO.MAC
-        ntvcm m80 "=FOO.MAC" /X /O /Z /L
-        ```
-
-        Copy and trim the runtime to only the blocks used by the app.
-
-        ```powershell
-        Copy-Item C:\path\to\dcc\DCCRTL.MAC DCCRTL.MAC
-        Convert-ToCrlf DCCRTL.MAC
-        dccrtlstrip -r DCCRTL.MAC -o RTLMIN.MAC FOO.MAC
-        ```
-
-        Convert, assemble, and link the trimmed runtime with the app.
-
-        ```powershell
-        Convert-ToCrlf RTLMIN.MAC
-        ntvcm m80 "=RTLMIN.MAC" /X /O /Z
-        ntvcm l80 "/P:100,RTLMIN,FOO,FOO/N/E"
-        ```
-
-    `scripts/ma.ps1` stages `m80.com` and `l80.com` before invoking `ntvcm`.
-    For a manual build, keep those `.COM` files and `DCCRTL.MAC` in the working
-    directory where you run the pipeline, or adjust the paths to match your
-    layout. Replace `/path/to/dcc` (or `C:\path\to\dcc`) with the DCC C Compiler repo path
-    that contains the standard headers; if you run from the DCC C Compiler repo root, the
-    explicit `-I` is usually unnecessary.
-
-    M80 expects CP/M-style CRLF text files; LF-only files can be misread. The Unix
-    function shown above uses Perl or `unix2dos`; the Windows function uses
-    PowerShell/.NET APIs.
+    To cross-check compatibility with the original Microsoft tools, use
+    `dcc-ma --emulated-m80 --emulated-l80` instead. That optional path stages
+    `M80.COM`/`L80.COM`, converts text to CP/M CRLF, and runs them under
+    `ntvcm`.
 
 ## The compiler invocation
 
@@ -306,7 +118,7 @@ Common options:
 
 | Option | Meaning |
 | --- | --- |
-| `-o file` | Write M80 assembly to `file`; default is `out.mac`, `-` is stdout. |
+| `-o file` | Write [`m80c`](appendix/03-utilities.md#native-assembler-m80c)-compatible assembly to `file`; default is `out.mac`, `-` is stdout. |
 | `-c`, `-module` | Emit a separately compilable module, not a final program translation unit. |
 | `-f`, `-ffloatio` | Force `%f` support on every `printf`-family call. |
 | `-fl`, `-flongio` | Force 32-bit `long` formats on every `printf`-family call. |
@@ -428,7 +240,9 @@ Include the standard headers as usual:
 
 ## Multi-module symbol names
 
-M80 and L80 only keep the **first 6 characters** of a public (external) symbol.
+[`m80c`](appendix/03-utilities.md#native-assembler-m80c) and
+[`l80c`](appendix/03-utilities.md#native-linker-l80c) keep only the **first 6
+characters** of a public (external) symbol.
 DCC C Compiler emits each external C identifier as `_` followed by the name, so the leading
 underscore consumes one of those six characters. The practical rule for any
 program built from more than one `.c` file is:
@@ -454,9 +268,9 @@ assembler name and the 6-character rule does not apply to it.
     6 significant character public symbols (both become '_I_IDX'); rename one
     ```
 
-- **Across different files**, DCC C Compiler cannot see the clash. L80 may report
-  `%Mult. Def. Global`, or — worse — silently bind a call to the wrong
-  definition, so the program links but misbehaves at runtime.
+- **Across different files**, DCC C Compiler cannot see the clash.
+  [`l80c`](appendix/03-utilities.md#native-linker-l80c) reports a multiply
+  defined global rather than silently binding a call to the wrong definition.
 
 ### Fixing collisions
 

--- a/docs/docs/en/02-build-and-link.md
+++ b/docs/docs/en/02-build-and-link.md
@@ -40,6 +40,12 @@ path because it keeps unused library routines out of the final `.COM` file. The
 script resolves each tool from your `PATH` or from the `DCC`, `DCCPEEP`, and
 `DCCRTLSTRIP` environment variables.
 
+The native linker normally uses `/P:100`, CP/M's standard `.COM` load address.
+For fixed-address, overlay, or relocating system programs, `l80c` also supports
+LINK-80-style nonstandard origins and generates the required CP/M entry
+jump/bootstrap. See [Native Linker (`l80c`)](appendix/03-utilities.md#native-linker-l80c)
+for its CLI options, origin layouts, and limitations.
+
 ??? note "The manual pipeline (click to expand)"
 
     For manual builds or custom build systems, the full pipeline for `foo.c` is

--- a/docs/docs/en/appendix/00-architecture.md
+++ b/docs/docs/en/appendix/00-architecture.md
@@ -2,18 +2,24 @@
 
 This appendix describes the DCC C Compiler toolchain: the compiler `dcc`, the peephole
 optimizer `dccpeep`, the runtime size reducer `dccrtlstrip`, and the assembler
-and linker - either the host-native `m80c`/`l80c`, or the Microsoft `M80`/`L80`
-originals running under `ntvcm`.
+and linker - either the host-native
+[`m80c`](03-utilities.md#native-assembler-m80c)/[`l80c`](03-utilities.md#native-linker-l80c),
+or the Microsoft `M80`/`L80` originals running under `ntvcm`.
 
 !!! note "Host-resident tools"
-  `dcc`, `dccpeep`, `dccrtlstrip`, `m80c`, and `l80c` run on Windows, macOS,
-  and Linux. They never run on a Z80. They emit Z80 assembly text and CP/M
+  `dcc`, `dccpeep`, `dccrtlstrip`,
+  [`m80c`](03-utilities.md#native-assembler-m80c), and
+  [`l80c`](03-utilities.md#native-linker-l80c) run on Windows, macOS, and
+  Linux. They never run on a Z80. They emit Z80 assembly text and CP/M
   `.COM` files that run under CP/M-80, for example via the `ntvcm` emulator.
-  `m80c`/`l80c` are clean-room, LINK-80-object-format-compatible
+  [`m80c`](03-utilities.md#native-assembler-m80c)/
+  [`l80c`](03-utilities.md#native-linker-l80c) are clean-room,
+  LINK-80-object-format-compatible
   reimplementations of `M80`/`L80` with unbounded host memory instead of
   CP/M's own 64K tables - large `nopeep` builds can exhaust real `L80`'s own
   in-emulator linking workspace well before the target program itself would
-  not fit; `l80c` has no such ceiling. They are the default; pass
+  not fit; [`l80c`](03-utilities.md#native-linker-l80c) has no such ceiling.
+  They are the default; pass
   `dcc-use-emulated-m80=true`/`dcc-use-emulated-l80=true` to `dccmake` (or
   `--emulated-m80`/`--emulated-l80` to `ma.sh`/`ma.ps1`) to use the real
   `M80.COM`/`L80.COM` under `ntvcm` instead, e.g. to cross-check output.
@@ -33,14 +39,14 @@ flowchart LR
     DCC --> MAC([".MAC assembly"])
     MAC --> PEEP["dccpeep<br/>peephole optimizer"]
     PEEP --> MAC2([".MAC optimized"])
-    MAC2 --> M80A["m80c / M80<br/>assemble"]
+    MAC2 --> M80A["m80c<br/>assemble"]
     RTL([" DCCRTL.MAC<br/>full runtime"]) --> STRIP["dccrtlstrip<br/>dead-block removal"]
     MAC2 -. references .-> STRIP
     STRIP --> RTLMIN([" RTLMIN.MAC<br/>used routines only"])
-    RTLMIN --> M80B["m80c / M80<br/>assemble"]
+    RTLMIN --> M80B["m80c<br/>assemble"]
     M80A --> REL([" app.REL"])
     M80B --> RRTL([" RTLMIN.REL"])
-    REL --> L80["l80c / L80<br/>link"]
+    REL --> L80["l80c<br/>link"]
     RRTL --> L80
     L80 --> COM([".COM executable"])
 ```
@@ -50,8 +56,8 @@ flowchart LR
 | Compile | `dcc` | `.c` | `.MAC` | Parse typed AST, lower and verify MIR, then select Z80/M80 assembly |
 | Optimize | `dccpeep` | `.MAC` | `.MAC` | Local peephole rewriting of the asm |
 | Reduce runtime | `dccrtlstrip` | `DCCRTL.MAC` + app `.MAC` | `RTLMIN.MAC` | Keep only the runtime routines the app references |
-| Assemble | `m80c` or `M80` | `.MAC` | `.REL` | Object code (relocatable); `dccmake` uses native `m80c` by default |
-| Link | `l80c` or `L80` | `.REL` files | `.COM` | Resolve symbols into a CP/M executable; `dccmake` uses native `l80c` by default |
+| Assemble | [`m80c`](03-utilities.md#native-assembler-m80c) | `.MAC` | `.REL` | Object code (relocatable); `dccmake` uses native `m80c` by default |
+| Link | [`l80c`](03-utilities.md#native-linker-l80c) | `.REL` files | `.COM` | Resolve symbols into a CP/M executable; `dccmake` uses native `l80c` by default |
 
 The `dccpeep` stage is optional (`./scripts/ma.ps1 name -Mode nopeep` skips it
 when run from PowerShell in the DCC C Compiler checkout). `dccrtlstrip` runs against the
@@ -501,7 +507,9 @@ the runtime and rebuilding the docs is all that is needed to refresh them.
   `self`/`marginal` size cost and `dccrtlstrip` can link only the blocks a
   program references. The exact current totals are generated on the
   [runtime size page](02-runtime-sizes.md).
-- The back half of the pipeline uses native **`m80c`**/**`l80c`** (or
+- The back half of the pipeline uses native
+  **[`m80c`](03-utilities.md#native-assembler-m80c)**/
+  **[`l80c`](03-utilities.md#native-linker-l80c)** (or
   Microsoft **`M80`**/**`L80`** under `ntvcm`) for assembly and linking - a
   shared LINK-80-compatible `.REL` object format that DCC C Compiler consumes
   as a fixed target rather than needing to invent its own.

--- a/docs/docs/en/appendix/03-utilities.md
+++ b/docs/docs/en/appendix/03-utilities.md
@@ -110,6 +110,73 @@ or environment variables first, then from the local checkout or `PATH`.
 | `m80.com` | CP/M assembler | Real Microsoft assembler; assembles `.MAC` to `.REL` under `ntvcm` when `dcc-use-emulated-m80=true` |
 | `l80.com` | CP/M linker | Real Microsoft linker; links `.REL` files to `.COM` under `ntvcm` when `dcc-use-emulated-l80=true` |
 
+## Native Linker (`l80c`)
+
+`l80c` is the host-native linker used by the normal DCC build pipeline. It
+consumes the LINK-80-compatible `.REL` files produced by `m80c`, resolves
+PUBLIC/EXTRN symbols, relocates CSEG and DSEG values, and writes a CP/M `.COM`
+image plus a linked `.SYM` file. Unlike `L80.COM`, it uses host memory rather
+than CP/M's 64K address space, so large links do not exhaust the linker's own
+workspace.
+
+### l80c CLI usage
+
+```text
+l80c [/P:origin,]module1,module2,...,output/N/E/Y [-o output[.COM]] [-v]
+```
+
+Module and output names conventionally use CP/M uppercase spelling. `.REL` is
+added to module names automatically. Repeating the final module with `/N/E/Y`,
+as in a Microsoft LINK-80 command, does not link it twice.
+
+| Option | Default | Purpose |
+| ------ | ------- | ------- |
+| `/P:<hex-address>` | `100` | Set the linked program origin. The address must fit in 16 bits. |
+| `output/N/E/Y` | Last module | Select the output basename using conventional LINK-80 syntax. `/N`, `/E`, and `/Y` do not otherwise change native non-interactive linking. |
+| `-o <name>` | Output marker or last module | Select the output basename explicitly. Either `APP` or `APP.COM` produces `APP.COM` and `APP.SYM`. |
+| `-v` | off | Print loaded modules, origin, linked size, and output path. |
+
+The normal DCC command is:
+
+```sh
+l80c "/P:100,RTLMIN,FOO,FOO/N/E/Y"
+```
+
+### Program origins
+
+Use `/P:100` for ordinary CP/M applications. CP/M loads a headerless `.COM`
+file at `0100H`, so this origin writes the linked program directly with no
+entry wrapper.
+
+`l80c` also implements LINK-80-compatible nonstandard origins:
+
+- `0101H` or `0102H`: place the program at that address without generating a
+  jump because the program occupies part of LINK-80's `0100H`-`0102H` entry
+  slot.
+- Above `0102H`: put `JP <start-address>` at `0100H`, pad to the requested
+  origin, and place the relocated program there.
+- Below `0100H`: store the payload after the CP/M entry point and add a small
+  8080/Z80-compatible bootstrap that copies it to the linked origin before
+  jumping to the program start.
+
+Nonstandard origins are useful for fixed-address code, overlays or separately
+loaded modules, programs reserving low TPA space for a loader or shared data,
+and system utilities that deliberately relocate or take over the machine.
+High origins remain normal CP/M programs through the generated entry jump.
+Low origins, especially zero, overwrite CP/M low memory and therefore suit only
+specialized programs that do not expect CP/M services to remain intact.
+
+!!! important "Not a bare-metal output mode"
+    `/P:0` still produces a CP/M-loadable `.COM` with an entry/copy bootstrap.
+    It does not emit a raw image beginning at file offset zero. A future
+    bare-metal target should use a separate explicit raw-binary option so its
+    startup, memory map, stack, and runtime assumptions are unambiguous.
+
+Native `l80c` currently supports the CSEG/DSEG REL records used by DCC. It
+rejects ASEG, COMMON, malformed records, undefined externals, duplicate globals,
+and images extending past `FFFFH` rather than guessing and producing a bad
+executable.
+
 ## Build Pipeline Helper (`dccmake`)
 
 `dccmake` is the lower-level build helper used by the test runner and by

--- a/docs/docs/en/appendix/03-utilities.md
+++ b/docs/docs/en/appendix/03-utilities.md
@@ -62,8 +62,8 @@ dcc-ma cobint --mode fast --build-dir mybuild
 | `-SourcePath` / `--source-path` | Search by name | Explicit C source path |
 | `-BuildDir` / `--build-dir` | `build` | Build directory for artifacts |
 | `-Emulator` / `--emulator` | `ntvcm` | Emulator command for CP/M tools |
-| `-UseEmulatedM80` / `--emulated-m80` | off | Assemble with M80.COM under `ntvcm` instead of native `m80c` |
-| `-UseEmulatedL80` / `--emulated-l80` | off | Link with L80.COM under `ntvcm` instead of native `l80c` |
+| `-UseEmulatedM80` / `--emulated-m80` | off | Assemble with M80.COM under `ntvcm` instead of native [`m80c`](#native-assembler-m80c) |
+| `-UseEmulatedL80` / `--emulated-l80` | off | Link with L80.COM under `ntvcm` instead of native [`l80c`](#native-linker-l80c) |
 
 The wrapper accepts only the parameters above. Use `dccmake` directly for
 project settings such as debug builds, per-format overrides, and multi-module
@@ -104,16 +104,59 @@ or environment variables first, then from the local checkout or `PATH`.
 | `dccpeep` | Peephole optimizer | Host command that rewrites generated `.MAC` files when `dcc-peep=true` |
 | `dccrtlstrip` | Runtime stripper | Host command that scans app `.MAC` files and writes a reduced runtime; see [DCCRTL strip appendix](01-dccrtlstrip.md) |
 | `DCCRTL.MAC` | Runtime source | Full CP/M runtime consumed by `dccrtlstrip` |
-| `m80c` | Native assembler | Host command, LINK-80-`.REL`-compatible; default assembler, no `ntvcm` needed |
-| `l80c` | Native linker | Host command, consumes the same `.REL` format; default linker, no `ntvcm` needed |
+| [`m80c`](#native-assembler-m80c) | Native assembler | Host command, LINK-80-`.REL`-compatible; default assembler, no `ntvcm` needed |
+| [`l80c`](#native-linker-l80c) | Native linker | Host command, consumes the same `.REL` format; default linker, no `ntvcm` needed |
 | `ntvcm` | CP/M emulator | Only needed for the real M80/L80 fallback path, and to run the final `.COM` programs |
 | `m80.com` | CP/M assembler | Real Microsoft assembler; assembles `.MAC` to `.REL` under `ntvcm` when `dcc-use-emulated-m80=true` |
 | `l80.com` | CP/M linker | Real Microsoft linker; links `.REL` files to `.COM` under `ntvcm` when `dcc-use-emulated-l80=true` |
 
+## Native Assembler (`m80c`)
+
+`m80c` is the host-native assembler used by the normal DCC build pipeline. It
+accepts the 8080 and Z80 source forms used by DCC, performs two assembly passes,
+and writes LINK-80-compatible `.REL` objects without running Microsoft
+`M80.COM` under an emulator.
+
+### m80c CLI usage
+
+```text
+m80c [rel-output[,listing-output]]=source[.MAC] [options]
+```
+
+An omitted extension defaults to `.MAC`, `.REL`, or `.PRN` as appropriate.
+Use `*` in an output position to suppress that explicit name. Output basenames
+use CP/M-style uppercase spelling.
+
+Common examples:
+
+```sh
+m80c "=FOO.MAC" /X /O /Z /L
+m80c "FOO.REL,FOO.PRN=FOO.MAC" /Z
+m80c "=FOO.MAC" /X /O /Z /L /C
+```
+
+| Option | Default | Purpose |
+| ------ | ------- | ------- |
+| `/Z` | on | Select Z80 mnemonic interpretation. For example, operand-free `CPI` is the Z80 block-compare instruction. |
+| `/I` | off | Select Intel 8080 mnemonic interpretation. For example, `CPI value` is immediate compare. |
+| `/L` | off | Write the `.PRN` assembly listing. |
+| `/R` | when a REL output is named | Request `.REL` object output. |
+| `/O` | off | Request `.REL` object output in the conventional M80 command form. Native listings remain hexadecimal. |
+| `/H` | accepted | Select hexadecimal listing compatibility; hexadecimal is already the native listing format. |
+| `/M` | off | Materialize `DS` storage as zero bytes instead of leaving reserved gaps. |
+| `/C` | off | Write the per-module `.SYM` sidecar used by native [`l80c`](#native-linker-l80c) to preserve relocated local symbols. |
+| `/X` | accepted | Accepted for M80 command compatibility; native `m80c` has no separate cross-reference output mode. |
+
+The assembler always writes `.LNK` segment-size metadata. When DCC source debug
+markers are present, it also writes `.DBG` source/symbol metadata; `/C` is not
+required for `.DBG`. Assembly errors are recorded in the listing when `/L` is
+enabled and cause a nonzero exit status.
+
 ## Native Linker (`l80c`)
 
 `l80c` is the host-native linker used by the normal DCC build pipeline. It
-consumes the LINK-80-compatible `.REL` files produced by `m80c`, resolves
+consumes the LINK-80-compatible `.REL` files produced by
+[`m80c`](#native-assembler-m80c), resolves
 PUBLIC/EXTRN symbols, relocates CSEG and DSEG values, and writes a CP/M `.COM`
 image plus a linked `.SYM` file. Unlike `L80.COM`, it uses host memory rather
 than CP/M's 64K address space, so large links do not exhaust the linker's own
@@ -182,11 +225,13 @@ executable.
 `dccmake` is the lower-level build helper used by the test runner and by
 repeatable local builds. It compiles one or more C source files, optionally runs
 `dccpeep`, strips the runtime with `dccrtlstrip`, then assembles and links with
-native `m80c`/`l80c` by default (or the real M80/L80 under `ntvcm` when
+native [`m80c`](#native-assembler-m80c)/[`l80c`](#native-linker-l80c) by
+default (or the real M80/L80 under `ntvcm` when
 `dcc-use-emulated-m80`/`dcc-use-emulated-l80` is set - real L80 runs inside
 `ntvcm`'s emulated 64K CP/M address space, so its own symbol/relocation
 workspace can run out of memory on large `nopeep` builds well before the
-target program itself would not fit; `l80c` has no such ceiling).
+target program itself would not fit; [`l80c`](#native-linker-l80c) has no such
+ceiling).
 
 Use `dccmake` directly when you want one command that owns the whole DCC C
 Compiler pipeline but still lets you choose the exact source files, output name,
@@ -292,7 +337,7 @@ dccmake dcc-peep=false
 | `dcc-stack-bytes` | `512` | Stack reserve passed to `dcc` with `-stack` |
 | `dcc-stack-check` | Environment/default | Pass `-fstack-check` to `dcc` |
 | `dcc-no-narrow` | `false` | Pass `-fno-narrow` to disable byte-narrowing passes |
-| `dcc-debug` | `false` | Emit source-level debug metadata; requires native `m80c` |
+| `dcc-debug` | `false` | Emit source-level debug metadata; requires native [`m80c`](#native-assembler-m80c) |
 | `dcc-include-directory` | Auto-adds `.` when standard headers are in the current directory | Comma-separated include directories; `dcc-include` is an alias |
 | `dcc-define` | none | Comma-separated `NAME[=value]` entries passed to `dcc` as `-D`; `dcc-defines` is an alias |
 | `dcc-undefine` | none | Comma-separated names passed to `dcc` as `-U`; `dcc-undefines` is an alias |
@@ -306,11 +351,11 @@ dccmake dcc-peep=false
 | `dccrtlstrip-tool` | `DCCRTLSTRIP`, local `dccrtlstrip`, or `dccrtlstrip` | Runtime stripper command |
 | `ntvcm-tool` | `NTVCM` or `ntvcm` | Emulator command used to run M80/L80 (only when either is emulated) |
 | `m80-command` | `M80` or `m80` | CP/M assembler command passed to `ntvcm`; emulated-M80 path only |
-| `m80c-tool` | `M80C`, local `m80c`, or `m80c` | Native host assembler command (default, no `ntvcm`) |
-| `dcc-use-emulated-m80` | `false` | Assemble with real `M80.COM` under `ntvcm` instead of native `m80c` |
+| `m80c-tool` | `M80C`, local `m80c`, or `m80c` | Native host assembler command (default, no `ntvcm`); see [`m80c`](#native-assembler-m80c) |
+| `dcc-use-emulated-m80` | `false` | Assemble with real `M80.COM` under `ntvcm` instead of native [`m80c`](#native-assembler-m80c) |
 | `l80-command` | `L80` or `l80` | CP/M linker command passed to `ntvcm`; emulated-L80 path only |
-| `l80c-tool` | `L80C`, local `l80c`, or `l80c` | Native host linker command (default, no `ntvcm`) |
-| `dcc-use-emulated-l80` | `false` | Link with real `L80.COM` under `ntvcm` instead of native `l80c` |
+| `l80c-tool` | `L80C`, local `l80c`, or `l80c` | Native host linker command (default, no `ntvcm`); see [`l80c`](#native-linker-l80c) |
+| `dcc-use-emulated-l80` | `false` | Link with real `L80.COM` under `ntvcm` instead of native [`l80c`](#native-linker-l80c) |
 
 `dccmake` initializes its Boolean settings from the matching environment
 variables before reading `dccmake.txt`: `DCC_FLOATIO`, `DCC_NO_FLOATIO`,
@@ -449,8 +494,8 @@ The `-Mode` parameter selects which optimization pass(es) to build and verify.
 | --------- | ------- | ------- |
 | `-Emulator` | `ntvcm` | Emulator command for running .COM files |
 | `-NoStackCheck` | (off) | Disable `-fstack-check` (the guard is ON by default) |
-| `-UseEmulatedM80` | (off) | Assemble with M80.COM under `ntvcm` instead of native `m80c` |
-| `-UseEmulatedL80` | (off) | Link with L80.COM under `ntvcm` instead of native `l80c` |
+| `-UseEmulatedM80` | (off) | Assemble with M80.COM under `ntvcm` instead of native [`m80c`](#native-assembler-m80c) |
+| `-UseEmulatedL80` | (off) | Link with L80.COM under `ntvcm` instead of native [`l80c`](#native-linker-l80c) |
 | `-BuildDir` | `build` | Build directory for artifacts |
 | `-NoRamDisk` | (off) | On Linux, disable the automatic `/dev/shm/dcc-runall` build root |
 | `-BaselineDir` | `tests/baselines` | Directory of per-app `<app>.txt` baselines |

--- a/scripts/tests/test_l80c_correctness.py
+++ b/scripts/tests/test_l80c_correctness.py
@@ -121,11 +121,64 @@ class L80cCorrectnessTests(unittest.TestCase):
             bytes([0x21, 0x00, 0x01, 0xC9]),
         )
 
-    def test_nonstandard_origin_is_rejected(self):
-        self.assemble("ORIGIN", "\tCSEG\n\tRET\n\tEND\n")
-        result = self.link("/P:200,ORIGIN")
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("CP/M .COM programs load at 0100", result.stderr)
+    def test_high_origin_inserts_start_jump_and_padding(self):
+        self.assemble(
+            "HIGH",
+            "\tCSEG\n\tNOP\nSTART:\n\tRET\n\tEND START\n",
+        )
+        result = self.link("/P:200,HIGH", "-o", "HIGH")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        image = (self.workspace / "HIGH.COM").read_bytes()
+        self.assertEqual(image[:3], bytes([0xC3, 0x01, 0x02]))
+        self.assertEqual(image[3:0x100], bytes(0xFD))
+        self.assertEqual(image[0x100:0x102], bytes([0x00, 0xC9]))
+
+    def test_zero_origin_uses_copy_bootstrap(self):
+        self.assemble(
+            "ZERO",
+            "\tCSEG\nSTART:\n\tLD C,0\n\tJP 5\n\tEND START\n",
+        )
+        result = self.link("/P:0,ZERO", "-o", "ZERO")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        image = (self.workspace / "ZERO.COM").read_bytes()
+        self.assertEqual(image[:3], bytes([0xC3, 0x08, 0x01]))
+        self.assertEqual(image[3:8], bytes([0x0E, 0x00, 0xC3, 0x05, 0x00]))
+        self.assertEqual(
+            image[8:30],
+            bytes(
+                [
+                    0x21,
+                    0x03,
+                    0x01,
+                    0x11,
+                    0x00,
+                    0x00,
+                    0x01,
+                    0x05,
+                    0x00,
+                    0x7E,
+                    0x12,
+                    0x23,
+                    0x13,
+                    0x0B,
+                    0x78,
+                    0xB1,
+                    0xC2,
+                    0x11,
+                    0x01,
+                    0xC3,
+                    0x00,
+                    0x00,
+                ]
+            ),
+        )
+
+    def test_origin_inside_entry_slot_suppresses_jump(self):
+        self.assemble("ENTRY101", "\tCSEG\n\tRET\n\tEND\n")
+        result = self.link("/P:101,ENTRY101", "-o", "ENTRY101")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        image = (self.workspace / "ENTRY101.COM").read_bytes()
+        self.assertEqual(image[:2], bytes([0x00, 0xC9]))
 
     def test_invalid_origin_is_rejected(self):
         self.assemble("BADORG", "\tCSEG\n\tRET\n\tEND\n")

--- a/scripts/tests/test_l80c_correctness.py
+++ b/scripts/tests/test_l80c_correctness.py
@@ -1,0 +1,177 @@
+import os
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUILD_DIR = REPO_ROOT / "build"
+CC = shutil.which("clang") or shutil.which("gcc")
+
+
+@unittest.skipUnless(CC, "host C compiler is required")
+class L80cCorrectnessTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workspace = BUILD_DIR / ("test-l80c-correctness-%d" % os.getpid())
+        cls.workspace.mkdir(parents=True, exist_ok=True)
+        cls.m80c = cls.workspace / "m80c"
+        cls.l80c = cls.workspace / "l80c"
+        subprocess.run(
+            [
+                CC,
+                "-std=c89",
+                "-O2",
+                str(REPO_ROOT / "src" / "m80c" / "m80c.c"),
+                "-o",
+                str(cls.m80c),
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+        )
+        subprocess.run(
+            [
+                CC,
+                "-std=c89",
+                "-O2",
+                str(REPO_ROOT / "src" / "l80c" / "l80c.c"),
+                "-o",
+                str(cls.l80c),
+            ],
+            check=True,
+            cwd=REPO_ROOT,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.workspace, ignore_errors=True)
+
+    def assemble(self, name, source):
+        (self.workspace / (name + ".MAC")).write_text(source)
+        result = subprocess.run(
+            [str(self.m80c), "=" + name + ".MAC", "/X", "/O", "/Z"],
+            cwd=self.workspace,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def link(self, command, *args):
+        return subprocess.run(
+            [str(self.l80c), command] + list(args),
+            cwd=self.workspace,
+            text=True,
+            capture_output=True,
+        )
+
+    @staticmethod
+    def malformed_rel(cseg_size, code_lc, link_value=False):
+        bits = []
+
+        def put(value, width):
+            bits.extend((value >> shift) & 1 for shift in range(width - 1, -1, -1))
+
+        def value(value_type, number):
+            put(value_type, 2)
+            put(number & 0xFF, 8)
+            put((number >> 8) & 0xFF, 8)
+
+        def name(text):
+            put(len(text), 3)
+            for character in text:
+                put(ord(character), 8)
+
+        def special(code, value_type=None, number=0, relname=None):
+            put(1, 1)
+            put(0, 2)
+            put(code, 4)
+            if value_type is not None:
+                value(value_type, number)
+            if relname is not None:
+                name(relname)
+
+        special(2, relname="BAD")
+        special(10, 0, 0)
+        special(13, 1, cseg_size)
+        special(11, 1, code_lc)
+        if link_value:
+            put(1, 1)
+            value(1, 0)
+        else:
+            put(0, 1)
+            put(0xAA, 8)
+
+        while len(bits) % 8:
+            bits.append(0)
+        return bytes(
+            sum(bits[index + bit] << (7 - bit) for bit in range(8))
+            for index in range(0, len(bits), 8)
+        )
+
+    def test_standard_origin_links_relocated_code(self):
+        self.assemble(
+            "BASIC",
+            "\tCSEG\n\tPUBLIC START\nSTART:\n\tLD HL,START\n\tRET\n\tEND START\n",
+        )
+        result = self.link("/P:100,BASIC", "-o", "BASIC")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(
+            (self.workspace / "BASIC.COM").read_bytes()[:4],
+            bytes([0x21, 0x00, 0x01, 0xC9]),
+        )
+
+    def test_nonstandard_origin_is_rejected(self):
+        self.assemble("ORIGIN", "\tCSEG\n\tRET\n\tEND\n")
+        result = self.link("/P:200,ORIGIN")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("CP/M .COM programs load at 0100", result.stderr)
+
+    def test_invalid_origin_is_rejected(self):
+        self.assemble("BADORG", "\tCSEG\n\tRET\n\tEND\n")
+        result = self.link("/P:nothex,BADORG")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("invalid origin", result.stderr)
+
+    def test_rel_data_cannot_exceed_declared_segment(self):
+        (self.workspace / "BAD.REL").write_bytes(
+            self.malformed_rel(1, 1)
+        )
+        result = self.link("/P:100,BAD")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("code range 1..2 out of bounds", result.stderr)
+
+    def test_rel_link_value_must_fit_declared_segment(self):
+        (self.workspace / "BADLINK.REL").write_bytes(
+            self.malformed_rel(1, 0, link_value=True)
+        )
+        result = self.link("/P:100,BADLINK")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("link range 0..2 out of bounds", result.stderr)
+
+    def test_rel_location_counter_must_fit_declared_segment(self):
+        (self.workspace / "BADLC.REL").write_bytes(
+            self.malformed_rel(1, 2)
+        )
+        result = self.link("/P:100,BADLC")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("code LC range 2..2 out of bounds", result.stderr)
+
+    def test_com_suffix_is_not_duplicated(self):
+        self.assemble("SUFFIX", "\tCSEG\n\tRET\n\tEND\n")
+        result = self.link("/P:100,SUFFIX", "-o", "NAMED.COM")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue((self.workspace / "NAMED.COM").is_file())
+        self.assertTrue((self.workspace / "NAMED.SYM").is_file())
+        self.assertFalse((self.workspace / "NAMED.COM.COM").exists())
+        self.assertFalse((self.workspace / "NAMED.COM.SYM").exists())
+
+        result = self.link("/P:100,SUFFIX,MARKED.COM/N/E/Y")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue((self.workspace / "MARKED.COM").is_file())
+        self.assertTrue((self.workspace / "MARKED.SYM").is_file())
+        self.assertFalse((self.workspace / "MARKED.COM.COM").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_m80c_correctness.py
+++ b/scripts/tests/test_m80c_correctness.py
@@ -58,7 +58,7 @@ class M80cCorrectnessTests(unittest.TestCase):
 
     def linked_bytes(self, name):
         subprocess.run(
-            [str(self.l80c), "/P:0," + name, "-o", name],
+            [str(self.l80c), "/P:100," + name, "-o", name],
             cwd=self.workspace,
             text=True,
             capture_output=True,

--- a/src/l80c/l80c.c
+++ b/src/l80c/l80c.c
@@ -14,13 +14,15 @@
  * @par Boundary
  * Complements m80c and replaces emulated L80 for normal dccmake builds,
  * avoiding L80's CP/M workspace ceiling. It accepts the CSEG/DSEG records used
- * by this toolchain and rejects unsupported ASEG, COMMON, or unknown records.
+ * by this toolchain and rejects unsupported ASEG, COMMON, unknown records, and
+ * non-0100 origins that would require a LINK-80 relocation bootstrap.
  */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include <stdarg.h>
+#include <errno.h>
 
 typedef unsigned char U8;
 typedef unsigned short U16;
@@ -89,6 +91,21 @@ static void bounded_append(char *dst, size_t dst_size, const char *src) {
     if (len > room) len = room;
     memcpy(dst + used, src, len);
     dst[used + len] = 0;
+}
+static int ends_with_com(const char *s) {
+    size_t n = strlen(s);
+    return n >= 4 &&
+        s[n - 4] == '.' &&
+        toupper((unsigned char)s[n - 3]) == 'C' &&
+        toupper((unsigned char)s[n - 2]) == 'O' &&
+        toupper((unsigned char)s[n - 1]) == 'M';
+}
+static void normalize_output_base(char *name) {
+    size_t n = strlen(name);
+    if (ends_with_com(name))
+        name[n - 4] = 0;
+    if (name[0] == 0)
+        die("empty output name");
 }
 
 /* ---------------------------------------------------------------- */
@@ -214,9 +231,12 @@ static void add_fixup(int seg, long off, int type) {
     g_fixups = f;
 }
 
-static void ensure_room(long size, long need, const char *what, const char *modname) {
-    if (need < 0 || need > size)
-        die("module %s: %s offset %ld out of range (segment size %ld)", modname, what, need, size);
+static void ensure_room(long size, long offset, long width,
+                        const char *what, const char *modname) {
+    if (offset < 0 || width < 0 || offset > size || width > size - offset)
+        die("module %s: %s range %ld..%ld out of bounds "
+            "(segment size %ld)", modname, what, offset,
+            offset + width, size);
 }
 
 /* ---------------------------------------------------------------- */
@@ -278,10 +298,12 @@ static void load_rel_file(const char *path) {
         if (lead == 0) {
             int b = (int)bits_in(&r, 8);
             if (cur_seg == SEG_CODE) {
-                ensure_room(m->cseg_size, cur_code_lc, "code", m->name);
+                ensure_room(m->cseg_size, cur_code_lc, 1,
+                            "code", m->name);
                 m->code[cur_code_lc++] = (U8)b;
             } else {
-                ensure_room(m->dseg_size, cur_data_lc, "data", m->name);
+                ensure_room(m->dseg_size, cur_data_lc, 1,
+                            "data", m->name);
                 m->data[cur_data_lc++] = (U8)b;
             }
             continue;
@@ -296,7 +318,8 @@ static void load_rel_file(const char *path) {
                 int seg = cur_seg;
                 long off = (seg == SEG_CODE) ? cur_code_lc : cur_data_lc;
                 U8 *arr;
-                ensure_room(seg == SEG_CODE ? m->cseg_size : m->dseg_size, off, "link", m->name);
+                ensure_room(seg == SEG_CODE ? m->cseg_size : m->dseg_size,
+                            off, 2, "link", m->name);
                 arr = (seg == SEG_CODE) ? m->code : m->data;
                 arr[off] = (U8)(val & 0xff);
                 arr[off + 1] = (U8)((val >> 8) & 0xff);
@@ -358,9 +381,13 @@ static void load_rel_file(const char *path) {
                         if (!have_cseg_size || !have_dseg_size)
                             die("module %s: set-LC item before segment sizes were declared", m->name);
                         if (valtype == T_CODE) {
+                            ensure_room(m->cseg_size, val, 0,
+                                        "code LC", m->name);
                             cur_seg = SEG_CODE;
                             cur_code_lc = val;
                         } else if (valtype == T_DATA) {
+                            ensure_room(m->dseg_size, val, 0,
+                                        "data LC", m->name);
                             cur_seg = SEG_DATA;
                             cur_data_lc = val;
                         } else {
@@ -496,7 +523,7 @@ int main(int argc, char **argv) {
     long origin = 0x100;
     char *modlist[MAXMOD];
     int nmodlist = 0;
-    char outname[MAXNAME + 4];
+    char outname[512];
     int have_outname = 0;
     int i;
     long running;
@@ -514,7 +541,7 @@ int main(int argc, char **argv) {
     outname[0] = 0;
 
     if (argc < 2) {
-        fprintf(stderr, "usage: %s [/P:origin,]module1,module2,...,moduleN[/switches] [-o out.COM] [-v]\n", g_progname);
+        fprintf(stderr, "usage: %s [/P:100,]module1,module2,...,moduleN[/switches] [-o out.COM] [-v]\n", g_progname);
         return 2;
     }
 
@@ -535,7 +562,11 @@ int main(int argc, char **argv) {
         while (tok) {
             if (tok[0] == '/') {
                 if ((tok[1] == 'P' || tok[1] == 'p') && tok[2] == ':') {
-                    origin = strtol(tok + 3, NULL, 16);
+                    char *end;
+                    errno = 0;
+                    origin = strtol(tok + 3, &end, 16);
+                    if (tok[3] == 0 || *end != 0 || errno == ERANGE)
+                        die("invalid origin: %s", tok + 3);
                 }
                 /* other leading switches: ignored */
             } else {
@@ -571,11 +602,14 @@ int main(int argc, char **argv) {
     }
 
     if (nmodlist == 0) die("no modules given");
-    if (origin < 0 || origin >= MAXORIGIN) die("origin out of range");
+    if (origin != 0x100)
+        die("unsupported origin %04lX: CP/M .COM programs load at 0100",
+            origin & 0xffff);
 
     if (!have_outname) {
         bounded_copy(outname, sizeof(outname), modlist[nmodlist - 1]);
     }
+    normalize_output_base(outname);
 
     /* Load every module named on the command line, in order. Module names
        are matched to files by appending .REL (trying both the given case
@@ -709,12 +743,13 @@ int main(int argc, char **argv) {
         }
     }
 
-    /* Emit the .COM image: a flat memory image starting at `origin`,
-       which CP/M always loads at 0x100 - no header. */
+    /* Emit the .COM image: a flat memory image starting at 0x100, where
+       CP/M loads headerless .COM programs. */
     suffix_path(outpath, sizeof(outpath), outname, ".COM");
     outf = fopen(outpath, "wb");
     if (!outf) die("cannot create %s", outpath);
-    if (total_len > 0 && fwrite(image, 1, (size_t)total_len, outf) != (size_t)total_len)
+    if (total_len > 0 &&
+        fwrite(image, 1, (size_t)total_len, outf) != (size_t)total_len)
         die("short write to %s", outpath);
     {
         /* CP/M files are made of 128-byte records; pad with zeros to the
@@ -722,9 +757,12 @@ int main(int argc, char **argv) {
            fine, but a zero-padded tail is the conventional, disk-friendly
            shape and avoids surprises in tools that assume it). */
         long pad = (128 - (total_len % 128)) % 128;
-        while (pad-- > 0) fputc(0, outf);
+        while (pad-- > 0)
+            if (fputc(0, outf) == EOF)
+                die("short write to %s", outpath);
     }
-    fclose(outf);
+    if (fclose(outf) != 0)
+        die("cannot finish writing %s", outpath);
 
     /* .SYM: final linked symbol table, ADDR<TAB>NAME pairs, matching the
        format dccprof.py already parses from real L80's output - now with

--- a/src/l80c/l80c.c
+++ b/src/l80c/l80c.c
@@ -14,8 +14,9 @@
  * @par Boundary
  * Complements m80c and replaces emulated L80 for normal dccmake builds,
  * avoiding L80's CP/M workspace ceiling. It accepts the CSEG/DSEG records used
- * by this toolchain and rejects unsupported ASEG, COMMON, unknown records, and
- * non-0100 origins that would require a LINK-80 relocation bootstrap.
+ * by this toolchain and rejects unsupported ASEG, COMMON, or unknown records.
+ * Nonstandard program origins receive a CP/M entry jump or relocation
+ * bootstrap so the linked image still starts execution at address 0100H.
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -209,6 +210,9 @@ typedef struct {
     long cseg_size, dseg_size;
     U8 *code, *data;
     long cseg_base, dseg_base; /* filled in during layout */
+    int has_start;
+    int start_type;
+    long start_value;
 } Module;
 
 static Module g_modules[MAXMOD];
@@ -419,6 +423,15 @@ static void load_rel_file(const char *path) {
                         break;
                     }
                     case 14:
+                        if (valtype != T_ABS && valtype != T_CODE &&
+                            valtype != T_DATA)
+                            die("module %s: start address has unsupported "
+                                "segment type %d", m->name, valtype);
+                        if (valtype != T_ABS || val != 0) {
+                            m->has_start = 1;
+                            m->start_type = valtype;
+                            m->start_value = val;
+                        }
                         align_in(&r); /* RELFIX20: end-module is followed by a byte-aligned end-file */
                         break;
                     case 15:
@@ -527,7 +540,7 @@ int main(int argc, char **argv) {
     int have_outname = 0;
     int i;
     long running;
-    long total_len;
+    long total_len, output_len, start_address;
     U8 *image;
     PublicSym *p;
     Fixup *mf;
@@ -541,7 +554,7 @@ int main(int argc, char **argv) {
     outname[0] = 0;
 
     if (argc < 2) {
-        fprintf(stderr, "usage: %s [/P:100,]module1,module2,...,moduleN[/switches] [-o out.COM] [-v]\n", g_progname);
+        fprintf(stderr, "usage: %s [/P:origin,]module1,module2,...,moduleN[/switches] [-o out.COM] [-v]\n", g_progname);
         return 2;
     }
 
@@ -602,9 +615,8 @@ int main(int argc, char **argv) {
     }
 
     if (nmodlist == 0) die("no modules given");
-    if (origin != 0x100)
-        die("unsupported origin %04lX: CP/M .COM programs load at 0100",
-            origin & 0xffff);
+    if (origin < 0 || origin >= MAXORIGIN)
+        die("origin out of range");
 
     if (!have_outname) {
         bounded_copy(outname, sizeof(outname), modlist[nmodlist - 1]);
@@ -660,6 +672,20 @@ int main(int argc, char **argv) {
     total_len = running - origin;
     if (total_len <= 0) die("empty program");
     if (origin + total_len > MAXORIGIN) die("program too large: extends past 0xFFFF");
+
+    start_address = origin;
+    for (i = 0; i < g_nmodules; i++) {
+        Module *m = &g_modules[i];
+        if (!m->has_start) continue;
+        if (m->start_type == T_CODE)
+            start_address = m->cseg_base + m->start_value;
+        else if (m->start_type == T_DATA)
+            start_address = m->dseg_base + m->start_value;
+        else
+            start_address = m->start_value;
+    }
+    if (start_address < 0 || start_address >= MAXORIGIN)
+        die("start address out of range");
 
     image = (U8 *)calloc((size_t)total_len, 1);
     if (!image) die("out of memory allocating %ld-byte image", total_len);
@@ -743,20 +769,77 @@ int main(int argc, char **argv) {
         }
     }
 
-    /* Emit the .COM image: a flat memory image starting at 0x100, where
-       CP/M loads headerless .COM programs. */
+    /* Emit a CP/M-loadable image. At or above 0100H, file offsets map
+       directly to memory and a leading JP reaches origins above the three-byte
+       entry slot. Below 0100H, a compact loader after the payload copies it
+       down before transferring control. */
     suffix_path(outpath, sizeof(outpath), outname, ".COM");
     outf = fopen(outpath, "wb");
     if (!outf) die("cannot create %s", outpath);
-    if (total_len > 0 &&
-        fwrite(image, 1, (size_t)total_len, outf) != (size_t)total_len)
-        die("short write to %s", outpath);
+    if (origin >= 0x100) {
+        long prefix = origin - 0x100;
+        if (prefix >= 3) {
+            if (fputc(0xc3, outf) == EOF ||
+                fputc((int)(start_address & 0xff), outf) == EOF ||
+                fputc((int)((start_address >> 8) & 0xff), outf) == EOF)
+                die("short write to %s", outpath);
+            prefix -= 3;
+        }
+        while (prefix-- > 0)
+            if (fputc(0, outf) == EOF)
+                die("short write to %s", outpath);
+        if (fwrite(image, 1, (size_t)total_len, outf) !=
+            (size_t)total_len)
+            die("short write to %s", outpath);
+        output_len = origin - 0x100 + total_len;
+    } else {
+        enum { BOOTSTRAP_SIZE = 22 };
+        long source = 0x103;
+        long loader = source + total_len;
+        long loop = loader + 9;
+        U8 bootstrap[BOOTSTRAP_SIZE];
+
+        output_len = 3 + total_len + BOOTSTRAP_SIZE;
+        if (output_len > 0xff00)
+            die("program too large for a CP/M relocation bootstrap");
+
+        bootstrap[0] = 0x21; /* LD HL,source */
+        bootstrap[1] = (U8)(source & 0xff);
+        bootstrap[2] = (U8)((source >> 8) & 0xff);
+        bootstrap[3] = 0x11; /* LD DE,origin */
+        bootstrap[4] = (U8)(origin & 0xff);
+        bootstrap[5] = (U8)((origin >> 8) & 0xff);
+        bootstrap[6] = 0x01; /* LD BC,length */
+        bootstrap[7] = (U8)(total_len & 0xff);
+        bootstrap[8] = (U8)((total_len >> 8) & 0xff);
+        bootstrap[9] = 0x7e; /* copy: LD A,(HL) */
+        bootstrap[10] = 0x12; /* LD (DE),A */
+        bootstrap[11] = 0x23; /* INC HL */
+        bootstrap[12] = 0x13; /* INC DE */
+        bootstrap[13] = 0x0b; /* DEC BC */
+        bootstrap[14] = 0x78; /* LD A,B */
+        bootstrap[15] = 0xb1; /* OR C */
+        bootstrap[16] = 0xc2; /* JP NZ,copy */
+        bootstrap[17] = (U8)(loop & 0xff);
+        bootstrap[18] = (U8)((loop >> 8) & 0xff);
+        bootstrap[19] = 0xc3; /* JP start */
+        bootstrap[20] = (U8)(start_address & 0xff);
+        bootstrap[21] = (U8)((start_address >> 8) & 0xff);
+
+        if (fputc(0xc3, outf) == EOF ||
+            fputc((int)(loader & 0xff), outf) == EOF ||
+            fputc((int)((loader >> 8) & 0xff), outf) == EOF ||
+            fwrite(image, 1, (size_t)total_len, outf) !=
+                (size_t)total_len ||
+            fwrite(bootstrap, 1, BOOTSTRAP_SIZE, outf) != BOOTSTRAP_SIZE)
+            die("short write to %s", outpath);
+    }
     {
         /* CP/M files are made of 128-byte records; pad with zeros to the
            next boundary (ntvcm and real CP/M both load a non-padded image
            fine, but a zero-padded tail is the conventional, disk-friendly
            shape and avoids surprises in tools that assume it). */
-        long pad = (128 - (total_len % 128)) % 128;
+        long pad = (128 - (output_len % 128)) % 128;
         while (pad-- > 0)
             if (fputc(0, outf) == EOF)
                 die("short write to %s", outpath);


### PR DESCRIPTION
## Summary

Fix confirmed correctness and robustness defects in native `l80c`, add focused REL/linker regression coverage, implement runnable CP/M `.COM` output for nonstandard `/P` origins, and complete the MkDocs reference for both native `m80c` and `l80c`.

The `/P` behavior follows the Microsoft LINK-80 manual: `/P:<address>` sets the program origin, `/N` output inserts a jump to the program start, and that jump is suppressed when the program itself occupies the `0100H–0102H` entry slot. The user-facing toolchain documentation now uses and links the native tools throughout, with Microsoft `M80.COM`/`L80.COM` retained only as an explicitly selected emulated compatibility path.

Authoritative reference: [Microsoft LINK-80 Linking Loader manual](http://www.retroarchive.org/cpm/lang/LINK-80.PDF), especially pages 1-3 and 1-4.

## Fixes

### Reject out-of-bounds REL segment writes

The former `ensure_room()` check accepted `offset == segment_size`. That allowed:

- a literal byte to write one byte beyond an allocated segment;
- a two-byte link value to begin at the final byte or beyond the segment;
- a set-LC record to move the location counter beyond the declared segment and make a later record write out of bounds.

The check is now width-aware and verifies the complete `[offset, offset + width)` range before any write. Set-LC records are validated immediately as zero-width positions.

A crafted REL module reproduced the original literal case as an ASan heap-buffer-overflow in `load_rel_file()`. The same input now exits with a precise segment-range diagnostic and no sanitizer finding.

### Validate `/P:` values completely

`strtol()` was previously called without an end pointer, so values such as `/P:nothex` silently became origin zero. Parsing now rejects empty values, trailing/non-hexadecimal text, overflow, and addresses outside the 16-bit range.

### Support LINK-80-style nonstandard origins

`l80c` previously relocated symbols to the requested `/P` address but always wrote application bytes at file offset zero. Because CP/M loads `.COM` files at `0100H`, any origin other than `0100H` produced an incorrectly mapped executable.

The linker now resolves the program transfer address from END-module records and emits one of three correct layouts:

- **Origin `0100H`:** write the linked image directly, preserving normal dcc output.
- **Origins `0101H–0102H`:** leave the preceding entry-slot bytes empty and place the program at its requested address, matching LINK-80's documented jump-suppression rule.
- **Origins above `0102H`:** emit `JP <start-address>` at `0100H`, pad to the requested origin, and place the relocated image there.
- **Origins below `0100H`, including zero:** emit a compact 8080/Z80-compatible relocation bootstrap. CP/M enters at `0100H`, jumps over the stored payload to the loader, the loader copies the payload down to its linked origin, then jumps to the resolved start address.

Both `/P:200` and `/P:0` images were executed successfully under `ntvcm`.

#### Why use an origin other than `0100H`?

Ordinary CP/M applications should continue using `/P:100`; that is the normal TPA entry address and avoids any wrapper or padding. Nonstandard origins are primarily useful for specialized LINK-80 workflows:

- code that must run at a fixed address;
- overlays or independently loaded modules;
- programs reserving part of the low TPA for a loader, vectors, or shared data;
- system utilities that deliberately relocate or take control of the machine.

An origin above `0100H` remains compatible with CP/M through the entry jump. An origin below `0100H`, especially zero, is inherently specialized because the relocated program overwrites CP/M low memory and generally cannot continue relying on CP/M services. The generated copy bootstrap only makes that requested LINK-80 `.COM` layout executable; it is not a bare-metal output format.

A future bare-metal target should therefore add an explicit raw output mode that writes the already-relocated image without the CP/M entry jump, padding, or copy bootstrap.

### Normalize documented `.COM` output names

The documented `-o NAME.COM` form previously produced `NAME.COM.COM` and `NAME.COM.SYM`. L80-style output markers such as `NAME.COM/N/E/Y` had the same issue.

Output names now remove one case-insensitive `.COM` suffix before creating `NAME.COM` and `NAME.SYM`. Names without the suffix remain unchanged.

### Detect output failures

Padding writes and the final `fclose()` result are now checked, ensuring disk or flush failures cannot be reported as successful links.

## Regression coverage

New `scripts/tests/test_l80c_correctness.py` coverage verifies:

- standard `0100H` linking and relocation;
- high-origin jump generation, END transfer-address resolution, padding, and payload placement;
- exact origin-zero copy-bootstrap bytes and relocation constants;
- jump suppression when the program occupies the `0100H–0102H` entry slot;
- rejection of malformed origin text;
- rejection of literals, link values, and set-LC positions outside declared segments;
- correct `.COM`/`.SYM` naming for `-o NAME.COM` and L80-style output markers.

The existing m80c opcode-byte tests now link at the normal CP/M origin rather than depending on origin zero as an implicit raw-output convention.

## Documentation

The MkDocs utilities reference now includes dedicated native tool sections:

- **`m80c`:** complete command/output syntax; `/Z`, `/I`, `/L`, `/R`, `/O`, `/H`, `/M`, `/C`, and `/X`; generated `.REL`, `.PRN`, `.SYM`, `.DBG`, and `.LNK` artifacts; and Intel-versus-Z80 mnemonic behavior.
- **`l80c`:** command syntax and `/P`, output-marker, `-o`, and `-v`; standard and nonstandard CP/M origin layouts; practical fixed-address/overlay/loader use cases; the `/P:0` versus future bare-metal distinction; supported REL segments; and explicit error cases.

Tool references across the architecture, build/link, and VS Code debugging pages now hyperlink to those full utility sections. The manual build pipeline uses native `m80c`/`l80c`; Microsoft `M80.COM`/`L80.COM` remain documented only as the explicitly selected emulated compatibility path.

A strict MkDocs build passes.

## Compatibility notes

- The production dcc pipeline and ordinary CP/M applications should use `/P:100`; their generated program bytes and behavior are unchanged.
- High origins are CP/M-compatible through the generated entry jump; low origins deliberately overwrite CP/M low memory and are suitable only for specialized takeover/relocation programs.
- CP/M uppercase module-name assumptions are unchanged.
- COMMON and ASEG remain outside native `l80c`'s documented scope.
- Bare-metal raw binaries remain a separate future output mode; the new jump/bootstrap logic is specifically for executable CP/M `.COM` files.

## Validation

- Focused l80c correctness tests: **9 passed**
- Repository Python tests: **59 passed**
- High- and zero-origin bootstrap execution under `ntvcm`: passed
- Strict C89 warning build: passed
- ASan/UBSan malformed-REL reproduction: rejected cleanly without memory misuse
- Canonical all-tool build: passed
- Full stack-check application suite: **404 passed, 12 skipped**
- Diagnostics and dccpeep fixtures: passed
- Performance regressions: **0**
- `git diff --check`: passed


