### PR TITLE
Add timer and interrupt I/O adapter examples

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,6 +20,30 @@
             },
             "launchCompleteCommand": "exec-continue",
             "externalConsole": false
+        },
+        {
+            "name": "DCC CP/M: Debug active C file with example I/O adapter",
+            "type": "cppdbg",
+            "request": "launch",
+            "preLaunchTask": "Prepare active DCC C file for debugging",
+            "program": "${workspaceFolder}/build/DCCDEBUG.COM",
+            "cwd": "${workspaceFolder}/build",
+            "MIMode": "gdb",
+            "miDebuggerPath": "${workspaceFolder}/dcc-debug-host",
+            "miDebuggerArgs": "--interpreter=mi --io-adapter \"${workspaceFolder}/libdcc-debug-io-adapter-example.dylib\"",
+            "linux": {
+                "miDebuggerArgs": "--interpreter=mi --io-adapter \"${workspaceFolder}/libdcc-debug-io-adapter-example.so\""
+            },
+            "windows": {
+                "miDebuggerPath": "${workspaceFolder}/dcc-debug-host.exe",
+                "miDebuggerArgs": "--interpreter=mi --io-adapter \"${workspaceFolder}/dcc-debug-io-adapter-example.dll\""
+            },
+            "targetArchitecture": "x86",
+            "sourceFileMap": {
+                "tests": "${workspaceFolder}/tests"
+            },
+            "launchCompleteCommand": "exec-continue",
+            "externalConsole": false
         }
     ]
 }

--- a/docs/docs/en/00-debug-host.md
+++ b/docs/docs/en/00-debug-host.md
@@ -2,8 +2,8 @@
 
 `dcc-debug-host` is DCC's full-system GDB/MI backend. It boots a real 63K
 CP/M 2.2 image and executes CCP, BDOS, BIOS, disk-controller, and Z80 code.
-Unlike a BDOS shim, it preserves the disk and console behavior seen by a
-program on the target runtime.
+It preserves the disk and console behavior seen by a program on the target
+runtime.
 
 The source project is under `src/dcc_debug_host`. The normal cross-platform
 DCC build includes the host and example I/O adapter:
@@ -87,9 +87,9 @@ Adapters that use interrupts register providers through the supplied host
 services. Optional poll functions execute on the emulator thread. The adapter
 does not link against debugger internals.
 
-## ABI v2 terminal pipeline
+## I/O adapter terminal pipeline
 
-ABI v2 adds two optional callbacks:
+The I/O adapter includes two optional callbacks:
 
 ```c
 size_t (*terminal_input)(
@@ -135,12 +135,24 @@ sequences, but target-specific translation remains adapter policy.
 example. It includes:
 
 - ABI and structure-size validation;
-- required no-op port callbacks;
+- three 16-bit millisecond timers on ports 24 through 29;
+- a one-byte seconds timer on port 30;
+- a periodic maskable-interrupt timer on port 52;
+- portable C11 timekeeping for Windows, Linux, and macOS;
 - a `close` callback;
 - ordinary-byte pass-through;
 - ANSI cursor parsing across split callback invocations;
 - sample cursor-to-CP/M-control-key translation; and
 - a 30 ms standalone-Escape timeout implemented with `terminal_poll`.
+
+The [timer-port client example](12-examples.md#waiting-for-an-io-adapter-timer)
+shows the CP/M side using `inp` and `outp`. Its source is included directly from
+the adapter example directory so the documentation stays synchronized with the
+buildable program.
+
+The [periodic-interrupt example](12-examples.md#handling-periodic-io-adapter-interrupts)
+uses port 52, installs a Z80 interrupt mode 1 assembly wrapper, and calls a
+minimal C handler for each tick.
 
 Build and test only the example:
 

--- a/docs/docs/en/00-vscode-debugging.md
+++ b/docs/docs/en/00-vscode-debugging.md
@@ -11,8 +11,7 @@ build. Optimized debug builds are also available for defects that reproduce
 only after peephole optimization, with the limitations described below.
 
 See [Debugger host and I/O adapters](00-debug-host.md) for the full-system
-architecture, target terminal, dynamic I/O adapter, and ABI v2 terminal
-pipeline.
+architecture, target terminal, dynamic I/O adapter, and terminal pipeline.
 
 ![DCC source debugging in VS Code with a breakpoint, local variables, Z80 registers, call stack, and debug controls](images/source-debugging.png)
 
@@ -56,6 +55,158 @@ Debug metadata requires the native
 
 Source and output names must also satisfy CP/M 8.3 naming rules. In particular,
 `dcc-output` is at most eight characters and has no extension.
+
+## Add debugging to a project
+
+A project needs three configuration files in addition to its C sources:
+
+```text
+my-project/
+├── .vscode/
+│   ├── launch.json
+│   └── tasks.json
+├── dccmake.txt
+├── main.c
+└── module.c
+```
+
+Build DCC once with `scripts/build-dcc.ps1`, then set `DCC_DIR` in the
+environment inherited by VS Code to the DCC repository directory. For example,
+on macOS or Linux:
+
+```sh
+export DCC_DIR="$HOME/GitHub/dcc"
+code my-project
+```
+
+In PowerShell on Windows:
+
+```powershell
+$env:DCC_DIR = "C:\GitHub\dcc"
+code my-project
+```
+
+### Add `dccmake.txt`
+
+This example builds two translation units as `build/PROGRAM.COM` and writes the
+matching metadata as `build/PROGRAM.DBG`:
+
+```text
+dcc-input=main.c,module.c
+dcc-output=PROGRAM
+dcc-build-dir=build
+dcc-stack-bytes=1024
+```
+
+Replace the source list, output name, and stack size with the project's actual
+values. The output name must fit CP/M's eight-character basename limit.
+
+### Add `.vscode/tasks.json`
+
+The build task runs `dccmake -g` from the project root. `dccmake` reads the
+adjacent `dccmake.txt` and generates both required debug artifacts:
+
+```json
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build DCC program for debugging",
+      "type": "shell",
+      "command": "${env:DCC_DIR}/dccmake",
+      "args": ["-g"],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": []
+    }
+  ]
+}
+```
+
+### Add `.vscode/launch.json`
+
+The launch configuration points VS Code at the `.COM` file and uses
+`dcc-debug-host` as its GDB/MI executable. Keep `program` synchronized with
+`dcc-output` in `dccmake.txt`:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "DCC CP/M: Debug PROGRAM",
+      "type": "cppdbg",
+      "request": "launch",
+      "preLaunchTask": "Build DCC program for debugging",
+      "program": "${workspaceFolder}/build/PROGRAM.COM",
+      "cwd": "${workspaceFolder}/build",
+      "MIMode": "gdb",
+      "miDebuggerPath": "${env:DCC_DIR}/dcc-debug-host",
+      "miDebuggerArgs": "--interpreter=mi",
+      "windows": {
+        "miDebuggerPath": "${env:DCC_DIR}/dcc-debug-host.exe"
+      },
+      "targetArchitecture": "x86",
+      "sourceFileMap": {
+        "${workspaceFolder}/build": "${workspaceFolder}"
+      },
+      "launchCompleteCommand": "exec-continue",
+      "externalConsole": false
+    }
+  ]
+}
+```
+
+`sourceFileMap` maps paths reported relative to the `.COM` directory back to
+the project root. It also handles source subdirectories: a recorded `src/foo.c`
+resolves through `build/src/foo.c` and maps to `src/foo.c` in the project.
+
+Select **DCC CP/M: Debug PROGRAM** in **Run and Debug**, set a source
+breakpoint, and press **F5**.
+
+### What happens after F5
+
+1. VS Code runs the pre-launch task, and `dccmake -g` creates a matched `.COM`
+   and `.DBG` pair.
+2. The C/C++ extension starts `dcc-debug-host` and communicates with it using
+   GDB/MI. No separate GDB installation is used.
+3. The host boots its CP/M 2.2 system, stages the selected program on its
+   disposable B: drive, and launches it at the normal CP/M transient-program
+   address.
+4. The host translates VS Code breakpoints, stepping, variable requests,
+   memory access, and disassembly requests through the linked `.DBG` metadata.
+5. Program output appears in the Debug Console. On normal exit, the program
+   returns to CP/M and the debug session reports completion.
+
+The `.COM` contains the executable Z80 program; the `.DBG` sidecar is debugger
+metadata and is not copied to CP/M hardware. Both files must remain adjacent
+and come from the same build.
+
+### Use an I/O adapter
+
+An I/O adapter is optional. It supplies machine-specific ports, terminal
+translation, or interrupt sources that are not part of generic CP/M. The normal
+DCC build publishes an example adapter beside `dcc-debug-host`. Replace the
+launch configuration's `miDebuggerArgs` and Windows override with:
+
+```json
+"miDebuggerArgs": "--interpreter=mi --io-adapter \"${env:DCC_DIR}/libdcc-debug-io-adapter-example.dylib\"",
+"linux": {
+  "miDebuggerArgs": "--interpreter=mi --io-adapter \"${env:DCC_DIR}/libdcc-debug-io-adapter-example.so\""
+},
+"windows": {
+  "miDebuggerPath": "${env:DCC_DIR}/dcc-debug-host.exe",
+  "miDebuggerArgs": "--interpreter=mi --io-adapter \"${env:DCC_DIR}/dcc-debug-io-adapter-example.dll\""
+}
+```
+
+The example adapter provides polling timers and a periodic interrupt source;
+see the [timer](12-examples.md#waiting-for-an-io-adapter-timer) and
+[interrupt](12-examples.md#handling-periodic-io-adapter-interrupts) programs.
+For a custom adapter, substitute its shared-library path and add `--env-file`
+if that adapter consumes project configuration. See
+[Debugger host and I/O adapters](00-debug-host.md) for the adapter contract.
 
 ## Configure the project build
 

--- a/docs/docs/en/12-examples.md
+++ b/docs/docs/en/12-examples.md
@@ -86,3 +86,54 @@ detaching it from the stream. This snippet is pulled verbatim from the
 `tests/tbufex.c` regression test, so the documented code is exactly what is
 built and run by the suite.
 
+## Waiting for an I/O-adapter timer
+
+The example debugger I/O adapter provides a 16-bit millisecond timer on ports
+24 and 25. Write the delay's high byte to port 24, then its low byte to port 25
+to start the timer. Reading either port returns 1 while it is running and 0
+after it expires.
+
+```c
+--8<-- "src/dcc_debug_host/examples/io_adapter/timer.c:example"
+```
+
+This program requires `dcc-debug-host` with the example I/O adapter loaded;
+ordinary emulators need an equivalent device on those ports. The source lives
+beside the adapter and builds with:
+
+```sh
+./dccmake src/dcc_debug_host/examples/io_adapter/timer.c dcc-output=TIMER
+```
+
+See [Direct port I/O](10-system-and-cpm.md#direct-port-io) for the `inp` and
+`outp` runtime contract.
+
+## Handling periodic I/O-adapter interrupts
+
+The example adapter also provides a periodic maskable-interrupt source on port
+52. Writing a value from 1 through 255 selects that many interrupts per second;
+writing zero disables the source and clears pending requests. Reading the port
+returns the configured rate.
+
+This example installs a Z80 interrupt mode 1 vector at `0038H`, waits with
+`HALT`, counts 50 interrupts at 10 Hz in a C function, then disables the source
+and restores CP/M's original vector:
+
+```c
+--8<-- "src/dcc_debug_host/examples/io_adapter/dccint.c:example"
+```
+
+The assembly wrapper preserves both Z80 register sets before calling C. The C
+handler only updates memory: interrupt code must not call BDOS, perform console
+I/O, allocate memory, or use other non-reentrant runtime services.
+
+Build the source with debug metadata using:
+
+```sh
+./dccmake -g src/dcc_debug_host/examples/io_adapter/dccint.c \
+  dcc-output=DCCINT
+```
+
+Run `DCCINT.COM` under `dcc-debug-host` with the example I/O adapter loaded.
+It counts for five seconds, prints `C handler count: 50`, restores the vector, and
+returns normally to CP/M.

--- a/docs/docs/en/appendix/00-architecture.md
+++ b/docs/docs/en/appendix/00-architecture.md
@@ -34,21 +34,20 @@ A single `.c` file becomes a CP/M `.COM` executable through a short pipeline.
 Each stage has one job and hands a text or object file to the next:
 
 ```mermaid
-flowchart LR
-    SRC([".c source"]) --> DCC["dcc<br/>C front end<br/>AST -> MIR -> Z80 asm"]
-    DCC --> MAC([".MAC assembly"])
-    MAC --> PEEP["dccpeep<br/>peephole optimizer"]
-    PEEP --> MAC2([".MAC optimized"])
-    MAC2 --> M80A["m80c<br/>assemble"]
-    RTL([" DCCRTL.MAC<br/>full runtime"]) --> STRIP["dccrtlstrip<br/>dead-block removal"]
-    MAC2 -. references .-> STRIP
-    STRIP --> RTLMIN([" RTLMIN.MAC<br/>used routines only"])
-    RTLMIN --> M80B["m80c<br/>assemble"]
-    M80A --> REL([" app.REL"])
-    M80B --> RRTL([" RTLMIN.REL"])
-    REL --> L80["l80c<br/>link"]
-    RRTL --> L80
-    L80 --> COM([".COM executable"])
+flowchart TB
+  SRC["C source"] --> DCC["dcc<br/>AST → MIR → Z80 assembly"]
+  DCC --> PEEP["dccpeep<br/>optional assembly optimization"]
+  PEEP --> APPASM["m80c<br/>assemble application"]
+  APPASM --> APPREL["app.REL"]
+
+  RTL["DCCRTL.MAC<br/>full runtime"] --> STRIP["dccrtlstrip<br/>keep referenced routines"]
+  PEEP -. runtime references .-> STRIP
+  STRIP --> RTLASM["m80c<br/>assemble reduced runtime"]
+  RTLASM --> RTLREL["RTLMIN.REL"]
+
+  APPREL --> LINK["l80c<br/>link application + runtime"]
+  RTLREL --> LINK
+  LINK --> COM["CP/M .COM executable"]
 ```
 
 | Stage | Tool | Input | Output | Role |
@@ -75,19 +74,18 @@ Top-level declarations, global initializers, strings, and data/BSS placement
 remain table-driven because they are not function-body instructions.
 
 ```mermaid
-flowchart LR
-    SRC([".c source"]) --> PP["preprocessor + lexer"]
-    PPX["dcc_pp_expr.c<br/>#if / #elif"] -. evaluates .-> PP
-    PP --> PARSE["recursive-descent parser"]
-    PARSE --> AST["typed statement AST<br/>(transient arena)"]
-    AST --> LOWER["MIR lowering +<br/>metadata recording"]
-    LOWER --> REPAIR["deferred metadata repair<br/>and canonicalization"]
-    REPAIR --> VERIFY["CFG + verifier<br/>liveness + object promotion"]
-    VERIFY --> ALLOC["baseline register homes<br/>+ spill slots"]
-    ALLOC --> SELECT["exact-schedule priority;<br/>generated candidate selection"]
-    SELECT -- exact match --> ASM
-    SELECT -- exact declines --> CALLOC["candidate-specific homes,<br/>spills + mir-v1 cost"]
-    CALLOC --> ASM(["selected .MAC body"])
+flowchart TB
+  SRC["C source"] --> FRONT["Front end<br/>preprocess, parse, build typed AST"]
+  FRONT --> MIR["Persistent MIR<br/>lower statements and record metadata"]
+  MIR --> ANALYZE["Analyze MIR<br/>repair, verify, build CFG, solve liveness,<br/>promote objects, plan baseline allocation"]
+  ANALYZE --> SELECT["Select generated Z80 candidate<br/>try exact structural schedules first"]
+
+  SELECT -- exact match --> ASM["Selected .MAC function body"]
+  SELECT -- exact declines --> GENERAL["Build generated alternatives<br/>rollout, homed, regional, spilled"]
+  GENERAL --> COST["Choose alternative<br/>candidate-specific allocation + mir-v1"]
+  COST --> ASM
+
+  ANALYZE -. optional reports .-> SHADOW["Diagnostic shadow models<br/>target constraints + sparse schedule"]
 ```
 
 | Classic phase | DCC C Compiler implementation |

--- a/docs/docs/en/appendix/00-architecture.md
+++ b/docs/docs/en/appendix/00-architecture.md
@@ -83,9 +83,11 @@ flowchart LR
     AST --> LOWER["MIR lowering +<br/>metadata recording"]
     LOWER --> REPAIR["deferred metadata repair<br/>and canonicalization"]
     REPAIR --> VERIFY["CFG + verifier<br/>liveness + object promotion"]
-    VERIFY --> ALLOC["register homes + spills<br/>Z80 constraints"]
-    ALLOC --> SELECT["generated candidate<br/>selection + mir-v1 cost"]
-    SELECT --> ASM(["selected .MAC body"])
+    VERIFY --> ALLOC["baseline register homes<br/>+ spill slots"]
+    ALLOC --> SELECT["exact-schedule priority;<br/>generated candidate selection"]
+    SELECT -- exact match --> ASM
+    SELECT -- exact declines --> CALLOC["candidate-specific homes,<br/>spills + mir-v1 cost"]
+    CALLOC --> ASM(["selected .MAC body"])
 ```
 
 | Classic phase | DCC C Compiler implementation |
@@ -93,9 +95,9 @@ flowchart LR
 | Preprocessing / lexical analysis | Integrated macro engine and `next_token` lexer in `dcc_preproc.c`; `dcc_pp_expr.c` evaluates conditional directives |
 | Parsing | Recursive descent builds typed AST nodes against live symbol/type tables |
 | Intermediate representation | Persistent per-function MIR with virtual values, typed memory, calls, labels, branches, PHIs, VLA operations, and aggregate copies |
-| MIR analysis | Deferred metadata repair, CFG construction, verification, object promotion, liveness, target constraints, register homes, and spill-slot planning |
-| Instruction selection | Exact machine schedules plus general homed, hybrid/regional, and spilled CFG candidates |
-| Profitability | `mir-v1` compares generated candidates using machine instructions/bytes, helper/frame/spill costs, moves, branches, and loop weighting |
+| MIR analysis | Deferred metadata repair, CFG construction, verification, object promotion, liveness, baseline register homes, and spill-slot planning |
+| Instruction selection | Priority exact machine schedules, followed by general rollout, homed, hybrid/regional, and spilled CFG candidates |
+| Profitability | After exact scheduling declines, `mir-v1` compares generated alternatives using machine instructions/bytes, helper/frame/spill costs, moves, branches, and loop weighting |
 | Machine-dependent cleanup | Standalone `dccpeep` fixpoint optimization over the selected assembly |
 
 ### Transient AST, persistent MIR
@@ -145,16 +147,27 @@ Call-crossing ordinary values may use only IY. Fixed Z80 operand/result
 registers are boundary constraints, so the emitter inserts moves rather than
 precoloring a value for its whole lifetime.
 
+Verification computes a baseline allocation and retains its liveness matrices
+for selection. Candidate construction may then derive and measure a different
+allocation plan: lazy-parameter and regional candidates, for example, save the
+baseline homes and spills, recompute them for that candidate, and restore the
+baseline before the next attempt.
+
 ### Generated-only candidate selection
 
 Every candidate writes to its own temporary stream. A declining selector cannot
-leave partial text in the next candidate. Production then chooses among:
+leave partial text in the next candidate. Production first tries:
 
 - exact `scheduled-machine-cfg` kernels with complete structural proofs;
+- the compact `general-rollout` scalar DAG for eligible straight-line functions;
 - `homed-scalar-cfg`, including hybrid and regional-home variants;
 - the general `spilled-scalar-cfg` emitter.
 
-The `mir-v1` policy compares only generated MIR candidates.
+An accepted exact schedule has priority. When exact scheduling declines, the
+selector establishes a complete generated incumbent from the rollout or general
+CFG candidates, then `mir-v1` may compare that incumbent with homed,
+lazy-parameter, hybrid, regional, and spilled variants. The policy compares
+only generated MIR candidates.
 `DCC_MIR_REQUIRE_COMPLETE=1` and `DCC_MIR_REQUIRE_EMIT=1` are the strict
 semantic and generated-output boundaries.
 
@@ -251,12 +264,12 @@ graph TB
 
     subgraph MIR["Persistent function MIR"]
       CORE["dcc_mir.c<br/>lowering + repair + verifier"]
-      COMMON["dcc_mir_emit_common.c<br/>shared value emission"]
-      TARGET["dcc_mir_target.c / dcc_mir_schedule.c<br/>Z80 constraints + scheduling"]
+      SHADOW["dcc_mir_target.c / dcc_mir_schedule.c<br/>diagnostic shadow models"]
     end
 
     subgraph BACK["Generated back ends"]
-      SELECT["dcc_mir_select.c<br/>candidate transaction + mir-v1"]
+      SELECT["dcc_mir_select.c<br/>priority, rollout + mir-v1"]
+      COMMON["dcc_mir_emit_common.c<br/>scalar DAG + shared emission"]
       HOMED["dcc_mir_homed_cfg.c<br/>homed / hybrid / regional"]
       SPILLED["dcc_mir_spilled_cfg.c<br/>general spilled CFG"]
       MACHINE["dcc_mir_machine_*.c<br/>exact structural schedules"]
@@ -272,12 +285,15 @@ graph TB
     SEM --> BUILD
     NODES -.storage and typed nodes.-> BUILD
     META -.declarations / scopes / VLA events.-> CORE
-    CORE --> TARGET --> SELECT
-    COMMON --> HOMED
-    COMMON --> SPILLED
+    CORE --> SELECT
+    CORE -. diagnostic reports .-> SHADOW
+    SELECT --> COMMON
     SELECT --> HOMED
     SELECT --> SPILLED
     SELECT --> MACHINE
+    HOMED -. shared operations .-> COMMON
+    SPILLED -. shared operations .-> COMMON
+    COMMON --> ASM
     HOMED --> ASM
     SPILLED --> ASM
     MACHINE --> ASM
@@ -291,8 +307,9 @@ graph TB
 | Types / symbols | `dcc_types.c`, `dcc_symbols.c`, `dcc_constexpr.c`, `dcc_fold.c`, `dcc_asmname.c` | Type system, symbol tables, constant evaluation/folding, and M80-safe assembly-name mapping |
 | Typed AST / metadata | `dcc_ast.c`, `dcc_ast_build.c`, `dcc_ast_gen*.c`, `dcc_ast_metadata.c`, `dcc_ast_stmt_meta.c`, `dcc_licm.c` | Transient typed trees, semantic classifiers, and non-emitting LICM/CSE planning and declaration/scope replay |
 | Compatibility helpers | `dcc_expr.c`, `dcc_ops.c`, `dcc_cmp.c`, `dcc_assign.c`, `dcc_decl.c`, `dcc_stmt_fast.c`, `dcc_array_narrow.c` | Shared initializer/type behavior and conservative source proofs; not a production body emitter |
-| MIR core | `dcc_mir.c`, `dcc_mir_emit_common.c`, `dcc_mir_target.c`, `dcc_mir_schedule.c`, `dcc_mir_stream.c` | Persistent IR, metadata repair, CFG/verifier, liveness, target constraints, isolated candidate streams, and common emission |
-| MIR selection | `dcc_mir_select.c`, `dcc_mir_homed_cfg.c`, `dcc_mir_spilled_cfg.c` | Transactional generated candidates, homes/spills, and `mir-v1` selection |
+| MIR core | `dcc_mir.c`, `dcc_mir_stream.c` | Persistent IR, metadata repair, CFG/verifier, liveness, baseline allocation, and isolated candidate streams |
+| MIR emission / selection | `dcc_mir_select.c`, `dcc_mir_emit_common.c`, `dcc_mir_homed_cfg.c`, `dcc_mir_spilled_cfg.c` | Exact-schedule priority, scalar DAG rollout, transactional generated candidates, candidate-specific homes/spills, shared emission, and `mir-v1` selection |
+| Diagnostic shadow models | `dcc_mir_target.c`, `dcc_mir_schedule.c` | Optional Z80 constraint and sparse-schedule reports; these modules do not select production candidates or emit Z80 |
 | Machine schedules | `dcc_mir_machine_emit.c` (coordinator), `dcc_mir_machine_*.c` (families) | Exact structural matchers and specialized Z80 streams |
 | Top level / output | `dcc_func.c`, `dcc_global_init.c`, `dcc_data.c` | Function/frame parsing, one production metadata/MIR body walk, global initializer recording, deferred static-body placement, and data-section emission |
 
@@ -497,8 +514,9 @@ the runtime and rebuilding the docs is all that is needed to refresh them.
 - MIR owns CFG, PHIs, virtual values, object promotion, liveness, register
   homes, spills, target constraints, and generated candidate selection.
 - Production function assembly comes only from MIR.
-- Exact machine families and general homed/spilled CFG emitters compete under
-  the generated-only `mir-v1` cost policy.
+- Structurally proven exact machine schedules have priority. When they decline,
+  general rollout and homed/spilled CFG candidates are selected from generated
+  streams, with `mir-v1` arbitrating eligible alternatives.
 - Machine-dependent optimization is split out into **`dccpeep`**, a
   fixpoint peephole optimizer over the assembly text, with separate time (`-Ot`)
   and size (`-Os`) strategies.

--- a/src/dcc_debug_host/examples/io_adapter/README.md
+++ b/src/dcc_debug_host/examples/io_adapter/README.md
@@ -1,16 +1,45 @@
 # I/O Adapter Example
 
-This directory contains a minimal ABI v2 shared library for `dcc-debug-host`.
-It demonstrates a terminal input pipeline without assigning any emulated I/O
-ports.
+This directory contains a portable shared library for `dcc-debug-host`. It
+demonstrates emulated timer ports and a terminal input pipeline.
 
 The example:
 
+- provides three 16-bit millisecond timers on ports 24/25, 26/27, and 28/29;
+- provides a one-byte seconds timer on port 30;
+- provides a periodic maskable-interrupt timer on port 52;
+- returns 1 while a timer is running and 0 when it expires or is not set;
 - passes ordinary terminal bytes through unchanged;
 - buffers ANSI escape sequences across callback invocations;
 - translates arrow keys to sample CP/M control bytes;
 - uses `terminal_poll` to emit a standalone Escape after 30 ms; and
-- provides the required port and close callbacks.
+- provides the required close callback.
+
+For each millisecond timer, write the delay's high byte to the even port, then
+write its low byte to the odd port to start it. Write a delay in seconds directly
+to port 30. The implementation uses only C11 time facilities so the same source
+builds on Windows, Linux, and macOS. Unmapped port reads return zero and writes
+are ignored.
+
+The adjacent `timer.c` is a CP/M client for timer 0. Build it from the repository
+root with:
+
+```sh
+./dccmake src/dcc_debug_host/examples/io_adapter/timer.c dcc-output=TIMER
+```
+
+The adjacent `dccint.c`, adapted from the Altair DCCINT application, installs a
+Z80 interrupt mode 1 wrapper and counts 50 interrupts from port 52. Build it
+with:
+
+```sh
+./dccmake -g src/dcc_debug_host/examples/io_adapter/dccint.c \
+  dcc-output=DCCINT
+```
+
+Write a rate from 1 through 255 to port 52 to start the interrupt timer. Write
+zero to disable it and clear pending requests; reading port 52 returns the
+configured rate.
 
 The arrow mapping is example policy, not part of the debugger ABI. Replace the
 values in `process_terminal_byte()` with the bytes expected by your target.

--- a/src/dcc_debug_host/examples/io_adapter/dcc_debug_io_adapter_example.c
+++ b/src/dcc_debug_host/examples/io_adapter/dcc_debug_io_adapter_example.c
@@ -2,9 +2,13 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 #define ESCAPE_GRACE_MS 30u
 #define CONTROL_KEY(character) ((uint8_t)((character) & 0x1f))
+#define MILLISECOND_TIMER_COUNT 3
+#define INTERRUPT_TIMER_PORT 52
+#define INTERRUPT_DATA_BUS 0xff
 
 typedef enum terminal_state
 {
@@ -17,22 +21,117 @@ typedef struct example_context
 {
     terminal_state_t terminal_state;
     uint64_t escape_start_ms;
+    uint16_t timer_delays[MILLISECOND_TIMER_COUNT];
+    uint64_t timer_targets[MILLISECOND_TIMER_COUNT];
+    uint64_t seconds_timer_target;
+    dcc_debug_io_host_services_t host;
+    dcc_debug_io_interrupt_id_t interrupt_id;
+    uint8_t interrupt_rate;
+    uint64_t interrupt_target_us;
 } example_context_t;
 
 static example_context_t example_context;
 
+static uint64_t elapsed_us(void)
+{
+    struct timespec now;
+
+    if (timespec_get(&now, TIME_UTC) != TIME_UTC)
+        return 0;
+    return (uint64_t)now.tv_sec * 1000000u + (uint64_t)now.tv_nsec / 1000u;
+}
+
+static uint64_t elapsed_ms(void)
+{
+    return elapsed_us() / 1000u;
+}
+
+static void example_interrupt_poll(void *context)
+{
+    example_context_t *example = (example_context_t *)context;
+    uint64_t now_us;
+
+    if (example == NULL || example->interrupt_rate == 0)
+        return;
+    now_us = elapsed_us();
+    if (now_us >= example->interrupt_target_us)
+    {
+        example->host.raise_interrupt(example->host.context,
+                                      example->interrupt_id);
+        example->interrupt_target_us =
+            now_us + 1000000u / example->interrupt_rate;
+    }
+}
+
+static int timer_index(uint8_t port)
+{
+    if (port < 24 || port > 29)
+        return -1;
+    return (port - 24) / 2;
+}
+
 static uint8_t example_port_input(void *context, uint8_t port)
 {
-    (void)context;
-    (void)port;
+    example_context_t *example = (example_context_t *)context;
+    uint64_t *target;
+    int index;
+
+    if (example == NULL)
+        return 0;
+    if (port == INTERRUPT_TIMER_PORT)
+        return example->interrupt_rate;
+    index = timer_index(port);
+    if (index >= 0)
+        target = &example->timer_targets[index];
+    else if (port == 30)
+        target = &example->seconds_timer_target;
+    else
+        return 0;
+
+    if (*target != 0 && elapsed_ms() < *target)
+        return 1;
+    *target = 0;
     return 0;
 }
 
 static void example_port_output(void *context, uint8_t port, uint8_t data)
 {
-    (void)context;
-    (void)port;
-    (void)data;
+    example_context_t *example = (example_context_t *)context;
+    int index;
+
+    if (example == NULL)
+        return;
+    if (port == INTERRUPT_TIMER_PORT)
+    {
+        example->host.clear_interrupt(example->host.context,
+                                      example->interrupt_id);
+        example->interrupt_rate = data;
+        example->interrupt_target_us = data == 0
+            ? 0
+            : elapsed_us() + 1000000u / data;
+        return;
+    }
+    index = timer_index(port);
+    if (index >= 0)
+    {
+        if ((port & 1u) == 0)
+        {
+            example->timer_delays[index] =
+                (uint16_t)((example->timer_delays[index] & 0x00ffu) |
+                           ((uint16_t)data << 8));
+        }
+        else
+        {
+            example->timer_delays[index] =
+                (uint16_t)((example->timer_delays[index] & 0xff00u) | data);
+            example->timer_targets[index] =
+                elapsed_ms() + example->timer_delays[index];
+        }
+    }
+    else if (port == 30)
+    {
+        example->seconds_timer_target = elapsed_ms() + (uint64_t)data * 1000u;
+    }
 }
 
 static uint8_t process_terminal_byte(example_context_t *context,
@@ -126,8 +225,13 @@ static size_t example_terminal_poll(
 
 static void example_close(void *context)
 {
-    if (context != NULL)
-        memset(context, 0, sizeof(example_context));
+    example_context_t *example = (example_context_t *)context;
+
+    if (example == NULL)
+        return;
+    example->host.clear_interrupt(example->host.context,
+                                  example->interrupt_id);
+    memset(example, 0, sizeof(*example));
 }
 
 static void set_error(char *error, size_t error_size, const char *message)
@@ -153,8 +257,25 @@ int dcc_debug_io_adapter_init(const dcc_debug_io_adapter_config_t *config,
         set_error(error, error_size, "unsupported I/O adapter ABI version");
         return 0;
     }
+    if (config->host.register_interrupt == NULL ||
+        config->host.raise_interrupt == NULL ||
+        config->host.clear_interrupt == NULL)
+    {
+        set_error(error, error_size, "interrupt host services are required");
+        return 0;
+    }
 
     memset(&example_context, 0, sizeof(example_context));
+    example_context.host = config->host;
+    if (!config->host.register_interrupt(
+            config->host.context, INTERRUPT_DATA_BUS,
+            example_interrupt_poll, &example_context,
+            &example_context.interrupt_id))
+    {
+        set_error(error, error_size, "cannot register interrupt timer");
+        memset(&example_context, 0, sizeof(example_context));
+        return 0;
+    }
     memset(adapter, 0, sizeof(*adapter));
     adapter->abi_version = DCC_DEBUG_IO_ADAPTER_ABI_VERSION;
     adapter->struct_size = sizeof(*adapter);

--- a/src/dcc_debug_host/examples/io_adapter/dcc_debug_io_adapter_example_test.c
+++ b/src/dcc_debug_host/examples/io_adapter/dcc_debug_io_adapter_example_test.c
@@ -3,27 +3,100 @@
 #include <assert.h>
 #include <string.h>
 
+typedef struct test_host
+{
+    dcc_debug_io_interrupt_poll_fn poll;
+    void *poll_context;
+    unsigned int raise_count;
+    unsigned int clear_count;
+    uint8_t data_bus;
+} test_host_t;
+
+static int register_interrupt(void *context, uint8_t data_bus,
+                              dcc_debug_io_interrupt_poll_fn poll,
+                              void *poll_context,
+                              dcc_debug_io_interrupt_id_t *interrupt_id)
+{
+    test_host_t *host = (test_host_t *)context;
+
+    host->poll = poll;
+    host->poll_context = poll_context;
+    host->data_bus = data_bus;
+    *interrupt_id = 7;
+    return 1;
+}
+
+static void raise_interrupt(void *context,
+                            dcc_debug_io_interrupt_id_t interrupt_id)
+{
+    test_host_t *host = (test_host_t *)context;
+
+    assert(interrupt_id == 7);
+    host->raise_count++;
+}
+
+static void clear_interrupt(void *context,
+                            dcc_debug_io_interrupt_id_t interrupt_id)
+{
+    test_host_t *host = (test_host_t *)context;
+
+    assert(interrupt_id == 7);
+    host->clear_count++;
+}
+
 int main(void)
 {
     dcc_debug_io_adapter_config_t config;
     dcc_debug_io_adapter_t adapter;
+    test_host_t host;
     uint8_t output[8];
     char error[128];
+    unsigned long attempt;
     static const uint8_t left_arrow[] = {0x1b, '[', 'D'};
     static const uint8_t ordinary[] = {'A', 'B'};
 
     memset(&config, 0, sizeof(config));
+    memset(&host, 0, sizeof(host));
     config.abi_version = DCC_DEBUG_IO_ADAPTER_ABI_VERSION;
     config.struct_size = sizeof(config);
     config.host.abi_version = DCC_DEBUG_IO_ADAPTER_ABI_VERSION;
     config.host.struct_size = sizeof(config.host);
+    config.host.context = &host;
+    config.host.register_interrupt = register_interrupt;
+    config.host.raise_interrupt = raise_interrupt;
+    config.host.clear_interrupt = clear_interrupt;
 
     assert(dcc_debug_io_adapter_init(&config, &adapter, error, sizeof(error)));
+    assert(host.poll != NULL);
+    assert(host.poll_context != NULL);
+    assert(host.data_bus == 0xff);
     assert(adapter.input != NULL);
     assert(adapter.output != NULL);
     assert(adapter.close != NULL);
     assert(adapter.terminal_input != NULL);
     assert(adapter.terminal_poll != NULL);
+
+    adapter.output(adapter.context, 24, 0xff);
+    adapter.output(adapter.context, 25, 0xff);
+    assert(adapter.input(adapter.context, 24) == 1);
+    assert(adapter.input(adapter.context, 25) == 1);
+
+    adapter.output(adapter.context, 26, 0);
+    adapter.output(adapter.context, 27, 0);
+    assert(adapter.input(adapter.context, 26) == 0);
+
+    adapter.output(adapter.context, 30, 255);
+    assert(adapter.input(adapter.context, 30) == 1);
+    assert(adapter.input(adapter.context, 99) == 0);
+
+    adapter.output(adapter.context, 52, 255);
+    assert(adapter.input(adapter.context, 52) == 255);
+    for (attempt = 0; attempt < 10000000UL && host.raise_count == 0; ++attempt)
+        host.poll(host.poll_context);
+    assert(host.raise_count != 0);
+    adapter.output(adapter.context, 52, 0);
+    assert(adapter.input(adapter.context, 52) == 0);
+    assert(host.clear_count == 2);
 
     assert(adapter.terminal_input(adapter.context, ordinary, sizeof(ordinary),
                                   output, sizeof(output), 50) == 2);
@@ -45,5 +118,6 @@ int main(void)
     assert(output[0] == 0x1b);
 
     adapter.close(adapter.context);
+    assert(host.clear_count == 3);
     return 0;
 }

--- a/src/dcc_debug_host/examples/io_adapter/dccint.c
+++ b/src/dcc_debug_host/examples/io_adapter/dccint.c
@@ -1,0 +1,167 @@
+/**
+ * @file dccint.c
+ * @brief Mixed DCC C and Z80 assembly interrupt timer example.
+ *
+ * @par Role
+ * Installs an IM 1 wrapper and counts periodic port-52 interrupts in C.
+ *
+ * @par Boundary
+ * Requires an emulator or I/O adapter that provides the Altair interrupt
+ * timer on port 52. The C handler must not call non-reentrant services.
+ *
+ * @par Origin
+ * Adapted from esp32-altair-8800/Apps/DCCINT/DCCINT.C.
+ */
+
+/* --8<-- [start:example] */
+#include <stdio.h>
+
+#define TARGET_TICKS 50
+
+volatile unsigned int irq_ticks;
+
+extern void irq_install(volatile unsigned int *counter, void (*handler)(void));
+extern void irq_wait(void);
+extern unsigned int irq_count(void);
+extern void irq_remove(void);
+
+void irq_tick(void)
+{
+    irq_ticks++;
+}
+
+#asm
+        public  _irq_install
+        public  _irq_wait
+        public  _irq_count
+        public  _irq_remove
+
+INTVEC  equ     0038h
+INTPORT equ     52
+
+; Save CP/M's vector and bind the C state passed through the normal dcc ABI:
+; IX+4/5 = counter pointer, IX+6/7 = handler function pointer.
+_irq_install:
+        di
+        push    ix
+        ld      ix,0
+        add     ix,sp
+        ld      l,(ix+4)
+        ld      h,(ix+5)
+        ld      (irq_counter),hl
+        ld      l,(ix+6)
+        ld      h,(ix+7)
+        ld      (irq_call+1),hl
+        pop     ix
+
+        ld      a,(INTVEC)
+        ld      (irq_old),a
+        ld      a,(INTVEC+1)
+        ld      (irq_old+1),a
+        ld      a,(INTVEC+2)
+        ld      (irq_old+2),a
+
+        ld      a,0c3h
+        ld      (INTVEC),a
+        ld      hl,irq_isr
+        ld      (INTVEC+1),hl
+
+        im      1
+        ld      a,10
+        out     (INTPORT),a
+        ei
+        ret
+
+; Sleep until the next accepted interrupt. The ISR resumes after HALT.
+_irq_wait:
+        halt
+        ret
+
+; Return an atomic 16-bit snapshot in HL using the normal dcc return ABI.
+_irq_count:
+        di
+        ld      hl,(irq_counter)
+        ld      e,(hl)
+        inc     hl
+        ld      d,(hl)
+        ex      de,hl
+        ei
+        ret
+
+; Stop the source before restoring CP/M's original three vector bytes.
+_irq_remove:
+        di
+        xor     a
+        out     (INTPORT),a
+        ld      a,(irq_old)
+        ld      (INTVEC),a
+        ld      a,(irq_old+1)
+        ld      (INTVEC+1),a
+        ld      a,(irq_old+2)
+        ld      (INTVEC+2),a
+        ret
+
+; Preserve all visible Z80 register sets before entering ordinary C.
+irq_isr:
+        push    af
+        push    bc
+        push    de
+        push    hl
+        push    ix
+        push    iy
+
+        ex      af,af'
+        push    af
+        ex      af,af'
+        exx
+        push    bc
+        push    de
+        push    hl
+        exx
+
+irq_call:
+        call    0000h
+
+        exx
+        pop     hl
+        pop     de
+        pop     bc
+        exx
+        ex      af,af'
+        pop     af
+        ex      af,af'
+
+        pop     iy
+        pop     ix
+        pop     hl
+        pop     de
+        pop     bc
+        pop     af
+        ei
+        reti
+
+irq_counter:
+        dw      0
+irq_old:
+        ds      3
+#endasm
+
+int main(void)
+{
+    unsigned int count;
+
+    irq_ticks = 0;
+    printf("DCC C + Z80 interrupt example\n");
+    printf("Counting %u timer interrupts at 10 Hz...\n", TARGET_TICKS);
+
+    irq_install(&irq_ticks, irq_tick);
+    do {
+        irq_wait();
+        count = irq_count();
+    } while (count < TARGET_TICKS);
+    irq_remove();
+
+    printf("C handler count: %u\n", count);
+    return count == TARGET_TICKS ? 0 : 1;
+}
+/* --8<-- [end:example] */

--- a/src/dcc_debug_host/examples/io_adapter/timer.c
+++ b/src/dcc_debug_host/examples/io_adapter/timer.c
@@ -1,0 +1,34 @@
+/**
+ * @file timer.c
+ * @brief CP/M client for the example debugger adapter's timer ports.
+ *
+ * @par Role
+ * Demonstrates starting and polling a 16-bit millisecond timer with inp/outp.
+ *
+ * @par Boundary
+ * Requires dcc-debug-host to load the example I/O adapter.
+ */
+
+/* --8<-- [start:example] */
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TIMER_0_HIGH 24
+#define TIMER_0_LOW  25
+
+static void start_timer(unsigned delay_ms)
+{
+    outp(TIMER_0_HIGH, delay_ms >> 8);
+    outp(TIMER_0_LOW, delay_ms & 0xff);
+}
+
+int main(void)
+{
+    puts("Waiting for one second...");
+    start_timer(1000U);
+    while (inp(TIMER_0_LOW) != 0)
+        ;
+    puts("Timer expired.");
+    return 0;
+}
+/* --8<-- [end:example] */


### PR DESCRIPTION
## Summary

- extend the example debugger I/O adapter with portable polling timers on ports 24-30 and a periodic maskable-interrupt provider on port 52
- add buildable CP/M timer and mixed DCC C/Z80 interrupt clients, with focused adapter coverage and an end-to-end DCCINT run
- add a cross-platform VS Code launch configuration and document how external projects configure and use dcc-debug-host
- expand MkDocs with source-backed timer/interrupt examples and clarify the debugger host and adapter documentation
- align the AST/MIR architecture guide with exact-schedule priority, general rollout, candidate-specific allocation, and diagnostic-only shadow scheduling

## Validation

- `pwsh ./scripts/build-dcc.ps1`
- `cmake --build build/dcc_debug_host_tests --parallel`
- `ctest --test-dir build/dcc_debug_host_tests --output-on-failure` (10/10 passed)
- `./dccmake src/dcc_debug_host/examples/io_adapter/timer.c dcc-output=TIMER`
- `./dccmake -g src/dcc_debug_host/examples/io_adapter/dccint.c dcc-output=DCCINT`
- original `esp32-altair-8800/Apps/DCCINT` completed 50 interrupts at 10 Hz under dcc-debug-host with exit code 0
- `/tmp/dcc-docs-mkdocs-venv/bin/mkdocs build --strict`
- `python3 -m json.tool .vscode/launch.json`