### PR TITLE
Fix compound literal frame shifts and unsafe loop promotion

### DIFF
--- a/src/dcc/dcc_mir_spilled_cfg.c
+++ b/src/dcc/dcc_mir_spilled_cfg.c
@@ -15161,7 +15161,7 @@ static int mir_compound_address_needs_frame_shift(
     if (insn->name[0] != '\0' &&
         mir_declared_location(insn->name, &type, &storage, &offset))
         return storage == SC_LOCAL;
-    return insn->name[0] == '\0' && insn->immediate < 0;
+    return insn->immediate < 0;
 }
 
 static void mir_shift_frame_for_iy_register(int begin)

--- a/src/dccpeep/peep_pass_loops.c
+++ b/src/dccpeep/peep_pass_loops.c
@@ -746,9 +746,10 @@ int pass_byte_loop_var_to_reg_c(void)
             strip_peep_comment_lower_copy(t, lines[j]);
             sprintf(off_txt, "(ix%d)", off);
             if (strstr(t, off_txt) != NULL) {
-                if (strncmp(t, "ld (ix", 6) != 0)
+                if (strncmp(t, "ld (ix", 6) != 0) {
                     bad = 1;
-                break;
+                    break;
+                }
             }
         }
         if (bad)

--- a/tests/dccpeep/byte-loop-post-load.expected.mac
+++ b/tests/dccpeep/byte-loop-post-load.expected.mac
@@ -1,0 +1,26 @@
+	cseg
+
+	public _checksum
+_checksum:
+	push ix
+	ld ix,0
+	add ix,sp
+	dec sp
+	jp nz,LALT
+	ld (ix-1),l
+LLOOP:
+	ld l,(ix-1)
+	ld h,0
+	inc hl
+	ld (ix-1),l
+	jp nc,LEXIT
+	jp LLOOP
+LALT:
+	ld (ix-1),l
+LEXIT:
+	ld l,(ix-1)
+	ld h,0
+	ld sp,ix
+	pop ix
+	ret
+	end

--- a/tests/dccpeep/byte-loop-post-load.in.mac
+++ b/tests/dccpeep/byte-loop-post-load.in.mac
@@ -1,0 +1,26 @@
+cseg
+
+public _checksum
+_checksum:
+push ix
+ld ix,0
+add ix,sp
+dec sp
+jp nz,LALT
+ld (ix-1),l
+LLOOP:
+ld l,(ix-1)
+ld h,0
+inc hl
+ld (ix-1),l
+jp nc,LEXIT
+jp LLOOP
+LALT:
+ld (ix-1),l
+LEXIT:
+ld l,(ix-1)
+ld h,0
+ld sp,ix
+pop ix
+ret
+end


### PR DESCRIPTION
## Summary

Fix two correctness defects exposed by the complete generated C test suite:

- Shift unresolved hidden compound-literal frame addresses when MIR reserves IY.
- Decline byte-loop register promotion when any frame-slot load remains after the loop backedge.
- Add a focused dccpeep golden fixture for the post-loop-load control-flow case.

## Problem

The generated suite initially reported 1,797 passes and 3 failures out of 1,800 runs:

- `batch11/c9903 [fast]`
- `batch11/c9903 [nopeep]`
- `batch11/c1133 [fast]`

Clang produced the expected outputs:

- `c9903 vec=5,2`
- `c1133 msg=15,00`

DCC produced unstable stack-derived values for the second `Vec2` member in both `c9903` modes, while optimized `c1133` produced `msg=00,00`.

## Root causes

### Compound literal frame shift

When MIR selected an IY home, `mir_shift_frame_for_iy_register()` shifted declared locals and recognized compound addresses by two bytes. Hidden named compound literals can be removed from the object table and are not present in the declared-symbol table. The fallback only classified unnamed negative compound addresses as local, so named `#clit` addresses remained unshifted and overlapped shifted ordinary locals.

The fallback now treats every unresolved negative `MIR_COMPOUND_ADDRESS` offset as a frame-local address. Global compound addresses are resolved through object/declaration storage and do not use negative frame offsets.

### Byte-loop register promotion

`pass_byte_loop_var_to_reg_c()` checked references after the selected backedge but stopped at the first reference. An alternate control-flow path could store the slot before a later exit-path load. The pass accepted the first store, promoted loop-carried values into C, removed their frame stores, and left the exit path reading stale frame memory.

The safety scan now examines every post-backedge reference and rejects promotion if any load remains. Post-backedge stores remain permitted, preserving safe opportunities while avoiding an unsupported dominance assumption.

## Regression test

`byte-loop-post-load` models the failing control flow with:

- a loop-carried byte frame slot;
- an alternate-path store after the textual backedge; and
- an exit-path load after that store.

The golden output asserts that the unsafe `byte_loop_var_c` rewrite is declined. The fixture runner also verifies optimizer idempotence.

## Validation

- Canonical toolchain build: passed
- Focused `c9903`, fast and nopeep: passed with `vec=5,2`
- Focused `c1133`, fast: passed with `msg=15,00`
- Generated batch 11 full matrix: 200 passed, 0 failed
- Complete generated suite, fast and nopeep: 1,800 passed, 0 failed
- dccpeep golden fixtures: 51 passed, 0 failed
- Editor diagnostics: clean
- `git diff --check`: clean

No performance baselines were changed; these are correctness fixes and the checked workloads did not report a baseline change.