### PR TITLE
Preserve volatile pointer effects and fix deferred pointer indexing

### DIFF
--- a/scripts/run-mir-clobber-tests.ps1
+++ b/scripts/run-mir-clobber-tests.ps1
@@ -442,6 +442,18 @@ try {
                 @{ Function = "vmember"; Loads = 3; Volatile = 3; Width = 1 },
                 @{ Function = "vmword"; Loads = 2; Volatile = 2; Width = 1 },
                 @{ Function = "vnested"; Loads = 3; Volatile = 3; Width = 1 },
+                @{ Function = "vindirect"; Loads = 6; Volatile = 3; ByteVolatile = 3 },
+                @{ Function = "vtypedef"; Loads = 6; Volatile = 3; ByteVolatile = 3 },
+                @{ Function = "vold"; Loads = 6; Volatile = 3; ByteVolatile = 3 },
+                @{ Function = "vglobal"; Loads = 6; Volatile = 3; ByteVolatile = 3 },
+                @{ Function = "vlocal"; Loads = 6; Volatile = 3; ByteVolatile = 3 },
+                @{ Function = "vpfield"; Loads = 6; Volatile = 3; ByteVolatile = 3 },
+                @{ Function = "vdfield"; Loads = 9; Volatile = 3; ByteVolatile = 3 },
+                @{ Function = "vchange"; Loads = 6; Volatile = 3; ByteVolatile = 0 },
+                @{ Function = "vboth"; Loads = 6; Volatile = 6; ByteVolatile = 3 },
+                @{ Function = "vstatic"; Loads = 6; Volatile = 3; ByteVolatile = 3 },
+                @{ Function = "nlocal"; Loads = 2; Volatile = 0 },
+                @{ Function = "nindirect"; Loads = 6; Volatile = 0 },
                 @{ Function = "nmember"; Loads = 1; Volatile = 0; Width = 1 },
                 @{ Function = "nmword"; Loads = 1; Volatile = 0; Width = 2 },
                 @{ Function = "vmstore"; Loads = 2; Volatile = 2; Width = 1; Opcode = "storeind" }
@@ -480,10 +492,19 @@ try {
                 throw "$function has $volatileLoads volatile MIR loads, " +
                     "expected $($expectation.Volatile):`n$($body.Value)"
             }
-            $correctWidth = [regex]::Matches($body.Value,
-                "\b$opcode\b[^\r\n]*\bmem=$($expectation.Width)v?\b").Count
-            if ($correctWidth -ne $loads) {
-                throw "$function has an incorrect memory access width:`n$($body.Value)"
+            if ($expectation.Width) {
+                $correctWidth = [regex]::Matches($body.Value,
+                    "\b$opcode\b[^\r\n]*\bmem=$($expectation.Width)v?\b").Count
+                if ($correctWidth -ne $loads) {
+                    throw "$function has an incorrect memory access width:`n$($body.Value)"
+                }
+            }
+            if ($expectation.ContainsKey("ByteVolatile")) {
+                $volatileBytes = [regex]::Matches($body.Value,
+                    "\b$opcode\b[^\r\n]*\bmem=1v\b").Count
+                if ($volatileBytes -ne $expectation.ByteVolatile) {
+                    throw "$function has incorrect pointer-level volatility:`n$($body.Value)"
+                }
             }
         }
     }

--- a/scripts/run-mir-clobber-tests.ps1
+++ b/scripts/run-mir-clobber-tests.ps1
@@ -255,6 +255,14 @@ function Assert-ForcedRegionalSafe(
 $fixtureRoot = Join-Path $repoRoot "tests/mir-clobber"
 $caseDefinitions = @(
     [pscustomobject]@{
+        Name = "aliasmem"
+        Sources = @(Join-Path $fixtureRoot "aliasmem.c")
+        Defines = @()
+        Expected = @("MIR alias failures=0")
+        Exit = 0
+        DebugModes = @("true", "lines")
+    },
+    [pscustomobject]@{
         Name = "domloop"
         Sources = @(Join-Path $fixtureRoot "domloop.c")
         Defines = @()
@@ -419,11 +427,34 @@ try {
     Set-ProcessEnvironment "DCC_MIR_MACHINE_REPORT" "1"
     Set-ProcessEnvironment "DCC_MIR_SELECT_REPORT" "1"
 
-    if ($Cases.Count -eq 0 -or "semantics" -in $Cases) {
+    foreach ($proofCase in @(
+        @{
+            Name = "semantics"; Source = "semfix.c"
+            Expectations = @(
+                @{ Function = "vread"; Loads = 3; Volatile = 3; Width = 1 },
+                @{ Function = "vword"; Loads = 2; Volatile = 2; Width = 1 },
+                @{ Function = "nread"; Loads = 1; Volatile = 0; Width = 1 }
+            )
+        },
+        @{
+            Name = "aliasmem"; Source = "aliasmem.c"
+            Expectations = @(
+                @{ Function = "vmember"; Loads = 3; Volatile = 3; Width = 1 },
+                @{ Function = "vmword"; Loads = 2; Volatile = 2; Width = 1 },
+                @{ Function = "vnested"; Loads = 3; Volatile = 3; Width = 1 },
+                @{ Function = "nmember"; Loads = 1; Volatile = 0; Width = 1 },
+                @{ Function = "nmword"; Loads = 1; Volatile = 0; Width = 2 },
+                @{ Function = "vmstore"; Loads = 2; Volatile = 2; Width = 1; Opcode = "storeind" }
+            )
+        }
+    )) {
+        if ($Cases.Count -gt 0 -and $proofCase.Name -notin $Cases) {
+            continue
+        }
         Set-ProcessEnvironment "DCC_MIR_REPORT" "1"
         try {
             $proof = Invoke-WithTimeout (Join-Path $repoRoot "dcc") @(
-                "-c", (Join-Path $fixtureRoot "semfix.c"),
+                "-c", (Join-Path $fixtureRoot $proofCase.Source),
                 "-o", (Join-Path $tempRoot "SEMANTIC.MAC")
             ) $repoRoot 60
         } finally {
@@ -431,26 +462,28 @@ try {
                 $savedEnvironment["DCC_MIR_REPORT"], "Process")
         }
         if ($proof.TimedOut -or $proof.ExitCode -ne 0) {
-            throw "MIR semantics proof failed:`n$($proof.Output)"
+            throw "MIR $($proofCase.Name) proof failed:`n$($proof.Output)"
         }
-        foreach ($expectation in @(
-            @{ Function = "vread"; Loads = 3; Volatile = 3 },
-            @{ Function = "vword"; Loads = 2; Volatile = 2 },
-            @{ Function = "nread"; Loads = 1; Volatile = 0 }
-        )) {
+        foreach ($expectation in $proofCase.Expectations) {
             $function = $expectation.Function
+            $opcode = if ($expectation.Opcode) { $expectation.Opcode } else { "loadind" }
             $body = [regex]::Match($proof.Output,
                 "(?s); MIR function=$function .*?; MIR summary function=$function ")
-            $loads = [regex]::Matches($body.Value, '\bloadind\b').Count
+            $loads = [regex]::Matches($body.Value, "\b$opcode\b").Count
             if (-not $body.Success -or $loads -ne $expectation.Loads) {
                 throw "$function has $loads MIR loads, expected " +
                     "$($expectation.Loads):`n$($body.Value)"
             }
             $volatileLoads = [regex]::Matches(
-                $body.Value, '\bloadind\b[^\r\n]*\bmem=\d+v\b').Count
+                $body.Value, "\b$opcode\b[^\r\n]*\bmem=\d+v\b").Count
             if ($volatileLoads -ne $expectation.Volatile) {
                 throw "$function has $volatileLoads volatile MIR loads, " +
                     "expected $($expectation.Volatile):`n$($body.Value)"
+            }
+            $correctWidth = [regex]::Matches($body.Value,
+                "\b$opcode\b[^\r\n]*\bmem=$($expectation.Width)v?\b").Count
+            if ($correctWidth -ne $loads) {
+                throw "$function has an incorrect memory access width:`n$($body.Value)"
             }
         }
     }

--- a/src/dcc/dcc.h
+++ b/src/dcc/dcc.h
@@ -281,6 +281,7 @@ typedef struct DeclState {
     int is_const;
     int is_volatile;
     int pointee_is_volatile;
+    unsigned int pointee_volatile_mask;
     int is_register;
 } DeclState;
 
@@ -353,6 +354,7 @@ struct Sym {
     int is_volatile; /* object declared with the volatile qualifier: access-
                       * contracting fast paths must decline for it */
     int pointee_is_volatile; /* immediate pointed-to type is volatile */
+    unsigned int pointee_volatile_mask;
     int is_register; /* object declared with the register qualifier: an MIR
                       * allocation hint copied onto MirObject and consulted by
                       * mir_allocate_registers to bias profitable
@@ -433,6 +435,7 @@ struct TypeDef {
     int type;
     int is_volatile;
     int pointee_is_volatile;
+    unsigned int pointee_volatile_mask;
     int array_len; /* >0 when typedef is an array type, e.g. typedef int T[4] */
     int dim_count;
     int dims[MAX_ARRAY_DIMS];
@@ -447,6 +450,7 @@ struct FieldDef {
     char name[64];
     int type;
     int is_volatile;
+    unsigned int pointee_volatile_mask;
     int offset;
     int size;
     int is_array;
@@ -876,6 +880,7 @@ void add_typedef_name(const char *name, int type, int array_len);
 int parse_base_type(void);
 int is_unsupported_target_type_name(const char *name);
 int parse_type(void);
+void advance_pointer_qualifiers(void);
 void skip_type_name_param_list(void);
 int parse_type_name_decl(int *typep, int *sizep);
 

--- a/src/dcc/dcc_decl.c
+++ b/src/dcc/dcc_decl.c
@@ -1586,6 +1586,7 @@ void gen_local_decl_after_type(int base)
     int type, bytes, arrlen;
     int base_is_volatile;
     int base_pointee_is_volatile;
+    unsigned int base_volatile_mask;
     int total_elems;
     int direct_funcptr;
     int parenthesized_array;
@@ -1599,19 +1600,20 @@ void gen_local_decl_after_type(int base)
 
     base_is_volatile = g_decl.is_volatile;
     base_pointee_is_volatile = g_decl.pointee_is_volatile;
+    base_volatile_mask = g_decl.pointee_volatile_mask;
 
     for (;;) {
         type = base;
         g_decl.is_volatile = base_is_volatile;
         g_decl.pointee_is_volatile = base_pointee_is_volatile;
+        g_decl.pointee_volatile_mask = base_volatile_mask;
         direct_funcptr = 0;
         parenthesized_array = 0;
         parenthesized_total = 0;
         parenthesized_stride = 0;
 
         while (accept('*')) {
-            g_decl.pointee_is_volatile = g_decl.is_volatile;
-            g_decl.is_volatile = skip_type_qualifiers_volatile();
+            advance_pointer_qualifiers();
             type = type_add_ptr(type);
         }
 
@@ -1797,6 +1799,7 @@ void gen_local_decl_after_type(int base)
             copy_funcptr_prototype_to_sym(s, direct_funcptr);
             s->is_volatile = g_decl.is_volatile;
             s->pointee_is_volatile = g_decl.pointee_is_volatile;
+            s->pointee_volatile_mask = g_decl.pointee_volatile_mask;
             s->is_register = g_decl.is_register;
             freshly_allocated = 1;
             if (arrlen > 0 || g_last_array_dim_count > 0) {

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -1438,6 +1438,7 @@ void parse_old_style_param_declarations(void)
     int base_is_register;
     int base_is_volatile;
     int base_pointee_is_volatile;
+    unsigned int base_volatile_mask;
     int type;
     int direct_funcptr;
     char name[64];
@@ -1448,15 +1449,16 @@ void parse_old_style_param_declarations(void)
         base_is_register = g_decl.is_register;
         base_is_volatile = g_decl.is_volatile;
         base_pointee_is_volatile = g_decl.pointee_is_volatile;
+        base_volatile_mask = g_decl.pointee_volatile_mask;
 
         for (;;) {
             type = base;
             direct_funcptr = 0;
             g_decl.is_volatile = base_is_volatile;
             g_decl.pointee_is_volatile = base_pointee_is_volatile;
+            g_decl.pointee_volatile_mask = base_volatile_mask;
             while (accept('*')) {
-                g_decl.pointee_is_volatile = g_decl.is_volatile;
-                g_decl.is_volatile = skip_type_qualifiers_volatile();
+                advance_pointer_qualifiers();
                 type = type_add_ptr(type);
             }
 
@@ -1488,6 +1490,7 @@ void parse_old_style_param_declarations(void)
                 s->is_register = base_is_register;
                 s->is_volatile = g_decl.is_volatile;
                 s->pointee_is_volatile = g_decl.pointee_is_volatile;
+                s->pointee_volatile_mask = g_decl.pointee_volatile_mask;
                 copy_funcptr_prototype_to_sym(s, direct_funcptr);
                 if (g_ptr_array_dim_count > 0) {
                     s->elem_size = g_ptr_array_elem_size;
@@ -1569,8 +1572,7 @@ void parse_param_list(void)
         unnamed_id = 0;
 
         while (accept('*')) {
-            g_decl.pointee_is_volatile = g_decl.is_volatile;
-            g_decl.is_volatile = skip_type_qualifiers_volatile();
+            advance_pointer_qualifiers();
             type = type_add_ptr(type);
         }
         skip_type_qualifiers();
@@ -1619,6 +1621,7 @@ void parse_param_list(void)
                 ps->is_register = g_decl.is_register;
                 ps->is_volatile = g_decl.is_volatile;
                 ps->pointee_is_volatile = g_decl.pointee_is_volatile;
+                ps->pointee_volatile_mask = g_decl.pointee_volatile_mask;
                 /* A pointer declared on top of an array typedef preserves
                  * the typedef's row shape: `typedef T A[N]; A *p` is a
                  * pointer to an N-element row, not merely T **. */
@@ -2188,6 +2191,7 @@ typedef struct SpecParseState {
     int licm_seq;
     int decl_is_volatile;
     int decl_pointee_is_volatile;
+    unsigned int decl_volatile_mask;
 } SpecParseState;
 
 static SpecParseState spec_parse_save(void)
@@ -2205,6 +2209,7 @@ static SpecParseState spec_parse_save(void)
     s.licm_seq = g_func_pass.licm_seq;
     s.decl_is_volatile = g_decl.is_volatile;
     s.decl_pointee_is_volatile = g_decl.pointee_is_volatile;
+    s.decl_volatile_mask = g_decl.pointee_volatile_mask;
     return s;
 }
 
@@ -2222,6 +2227,7 @@ static void spec_parse_restore(const SpecParseState *s)
     g_func_pass.licm_seq = s->licm_seq;
     g_decl.is_volatile = s->decl_is_volatile;
     g_decl.pointee_is_volatile = s->decl_pointee_is_volatile;
+    g_decl.pointee_volatile_mask = s->decl_volatile_mask;
 }
 
 /* Speculatively parses the rest of the enclosing block (from the current
@@ -2419,6 +2425,7 @@ void scan_local_decl_after_type(int base)
     int type, bytes, arrlen;
     int base_is_volatile;
     int base_pointee_is_volatile;
+    unsigned int base_volatile_mask;
     int total_elems;
     int direct_funcptr;
     int parenthesized_array;
@@ -2430,19 +2437,20 @@ void scan_local_decl_after_type(int base)
 
     base_is_volatile = g_decl.is_volatile;
     base_pointee_is_volatile = g_decl.pointee_is_volatile;
+    base_volatile_mask = g_decl.pointee_volatile_mask;
 
     for (;;) {
         type = base;
         g_decl.is_volatile = base_is_volatile;
         g_decl.pointee_is_volatile = base_pointee_is_volatile;
+        g_decl.pointee_volatile_mask = base_volatile_mask;
         direct_funcptr = 0;
         parenthesized_array = 0;
         parenthesized_total = 0;
         parenthesized_stride = 0;
 
         while (accept('*')) {
-            g_decl.pointee_is_volatile = g_decl.is_volatile;
-            g_decl.is_volatile = skip_type_qualifiers_volatile();
+            advance_pointer_qualifiers();
             type = type_add_ptr(type);
         }
 
@@ -2622,6 +2630,7 @@ void scan_local_decl_after_type(int base)
             copy_funcptr_prototype_to_sym(s, direct_funcptr);
             s->is_volatile = g_decl.is_volatile;
             s->pointee_is_volatile = g_decl.pointee_is_volatile;
+            s->pointee_volatile_mask = g_decl.pointee_volatile_mask;
             freshly_allocated = 1;
             if (arrlen > 0 || g_last_array_dim_count > 0) {
                 s->is_array = 1;
@@ -2696,6 +2705,7 @@ void scan_static_local_decl_after_type(int base)
     int type, bytes, arrlen;
     int base_is_volatile;
     int base_pointee_is_volatile;
+    unsigned int base_volatile_mask;
     char name[64];
     char source_name[64];
     char backing_name[64];
@@ -2704,15 +2714,16 @@ void scan_static_local_decl_after_type(int base)
 
     base_is_volatile = g_decl.is_volatile;
     base_pointee_is_volatile = g_decl.pointee_is_volatile;
+    base_volatile_mask = g_decl.pointee_volatile_mask;
 
     for (;;) {
         type = base;
         g_decl.is_volatile = base_is_volatile;
         g_decl.pointee_is_volatile = base_pointee_is_volatile;
+        g_decl.pointee_volatile_mask = base_volatile_mask;
 
         while (accept('*')) {
-            g_decl.pointee_is_volatile = g_decl.is_volatile;
-            g_decl.is_volatile = skip_type_qualifiers_volatile();
+            advance_pointer_qualifiers();
             type = type_add_ptr(type);
         }
 
@@ -2799,6 +2810,7 @@ void scan_static_local_decl_after_type(int base)
         g->is_static = 1;
         g->is_volatile = g_decl.is_volatile;
         g->pointee_is_volatile = g_decl.pointee_is_volatile;
+        g->pointee_volatile_mask = g_decl.pointee_volatile_mask;
         g->size = bytes;
         if (arrlen != 0 || g_last_array_dim_count > 0) {
             g->is_array = 1;
@@ -2812,6 +2824,7 @@ void scan_static_local_decl_after_type(int base)
             l = add_local_known(name, type, SC_GLOBAL, 0, bytes);
             l->is_volatile = g_decl.is_volatile;
             l->pointee_is_volatile = g_decl.pointee_is_volatile;
+            l->pointee_volatile_mask = g_decl.pointee_volatile_mask;
             strncpy(l->link_name, backing_name, sizeof(l->link_name) - 1);
             l->link_name[sizeof(l->link_name) - 1] = 0;
             if (arrlen != 0 || g_last_array_dim_count > 0) {
@@ -2974,6 +2987,7 @@ void parse_typedef_decl(void)
     int base_type;
     int base_is_volatile;
     int base_pointee_is_volatile;
+    unsigned int base_volatile_mask;
     int done;
 
     expect(TOK_TYPEDEF);
@@ -2986,6 +3000,7 @@ void parse_typedef_decl(void)
     base_type = parse_base_type();
     base_is_volatile = g_decl.is_volatile;
     base_pointee_is_volatile = g_decl.pointee_is_volatile;
+    base_volatile_mask = g_decl.pointee_volatile_mask;
     done = 0;
 
     while (!done && g_lex.tok.kind != TOK_EOF) {
@@ -2998,6 +3013,7 @@ void parse_typedef_decl(void)
         int is_func;
         int is_volatile;
         int pointee_is_volatile;
+        unsigned int volatile_mask;
         char name[64];
 
         type = base_type;
@@ -3008,9 +3024,13 @@ void parse_typedef_decl(void)
         is_func = 0;
         is_volatile = base_is_volatile;
         pointee_is_volatile = base_pointee_is_volatile;
+        volatile_mask = base_volatile_mask;
         name[0] = 0;
 
         while (accept('*')) {
+            volatile_mask = ((volatile_mask |
+                (unsigned int)(pointee_is_volatile != 0)) << 1) |
+                (unsigned int)(is_volatile != 0);
             pointee_is_volatile = is_volatile;
             is_volatile = skip_type_qualifiers_volatile();
             type = type_add_ptr(type);
@@ -3020,6 +3040,7 @@ void parse_typedef_decl(void)
             /* Parenthesized function-pointer typedef. */
             is_volatile = g_decl.is_volatile;
             pointee_is_volatile = g_decl.pointee_is_volatile;
+            volatile_mask = g_decl.pointee_volatile_mask;
         } else {
             if (g_lex.tok.kind != TOK_ID) {
                 error_here("identifier expected in typedef");
@@ -3068,6 +3089,7 @@ void parse_typedef_decl(void)
                     is_volatile, pointee_is_volatile);
             ti = find_typedef(name);
             if (ti >= 0) {
+                typedefs[ti].pointee_volatile_mask = volatile_mask;
                 typedefs[ti].dim_count = typedef_dim_count;
                 for (di = 0; di < MAX_ARRAY_DIMS; ++di)
                     typedefs[ti].dims[di] = di < typedef_dim_count
@@ -3087,10 +3109,12 @@ void parse_function_or_global(int base_type)
     int done;
     int base_is_volatile;
     int base_pointee_is_volatile;
+    unsigned int base_volatile_mask;
 
     done = 0;
     base_is_volatile = g_decl.is_volatile;
     base_pointee_is_volatile = g_decl.pointee_is_volatile;
+    base_volatile_mask = g_decl.pointee_volatile_mask;
 
     while (!done && g_lex.tok.kind != TOK_EOF) {
         int type;
@@ -3112,10 +3136,12 @@ void parse_function_or_global(int base_type)
         int pointer_over_array_typedef;
         int object_is_volatile;
         int pointee_is_volatile;
+        unsigned int volatile_mask;
 
         type = base_type;
         object_is_volatile = base_is_volatile;
         pointee_is_volatile = base_pointee_is_volatile;
+        volatile_mask = base_volatile_mask;
         base_is_func_typedef = g_typedef_is_func;
         is_funcret_funcptr_decl = 0;
         direct_funcptr_decl = 0;
@@ -3134,6 +3160,9 @@ void parse_function_or_global(int base_type)
          *     int *a, b, c[10];
          * where only a is a pointer. */
         while (accept('*')) {
+            volatile_mask = ((volatile_mask |
+                (unsigned int)(pointee_is_volatile != 0)) << 1) |
+                (unsigned int)(object_is_volatile != 0);
             pointee_is_volatile = object_is_volatile;
             object_is_volatile = skip_type_qualifiers_volatile();
             type = type_add_ptr(type);
@@ -3154,6 +3183,7 @@ void parse_function_or_global(int base_type)
             direct_funcptr_decl = 1;
             object_is_volatile = g_decl.is_volatile;
             pointee_is_volatile = g_decl.pointee_is_volatile;
+            volatile_mask = g_decl.pointee_volatile_mask;
         } else {
             if (g_lex.tok.kind != TOK_ID) {
                 error_here("identifier expected");
@@ -3545,6 +3575,7 @@ void parse_function_or_global(int base_type)
                 s = add_global(name, type, SC_EXTERN);
                 s->is_volatile = object_is_volatile;
                 s->pointee_is_volatile = pointee_is_volatile;
+                s->pointee_volatile_mask = volatile_mask;
                 copy_funcptr_prototype_to_sym(s, direct_funcptr_decl);
                 /* Keep the same array-shape metadata as a definition.  The
                  * expression parser needs it immediately for declarations
@@ -3631,6 +3662,7 @@ void parse_function_or_global(int base_type)
             s->needs_extrn = 0;
             s->is_volatile = object_is_volatile;
             s->pointee_is_volatile = pointee_is_volatile;
+            s->pointee_volatile_mask = volatile_mask;
             if (g_decl.is_static)
                 s->is_static = 1;
 

--- a/src/dcc/dcc_mir.c
+++ b/src/dcc/dcc_mir.c
@@ -1886,6 +1886,10 @@ static void mir_set_field_memory(struct MirInsn *insn,
 {
     insn->memory_size = field->size > 0 ? field->size : type_size(field->type);
     insn->memory_flags = field->is_volatile ? 1 : 0;
+        insn->pointee_volatile_mask = insn->opcode == MIR_MEMBER_ADDRESS
+                ? (field->pointee_volatile_mask << 1) |
+                    (unsigned int)(field->is_volatile != 0)
+                : field->pointee_volatile_mask;
     if (field->is_array)
         insn->memory_flags |= 2;
     if (type_is_struct_object(field->type))
@@ -3944,6 +3948,9 @@ void mir_note_declared_symbol(struct Sym *symbol)
     mir.declared_is_volatile[i] = symbol->is_volatile;
     mir.declared_pointee_is_volatile[i] =
         symbol->pointee_is_volatile;
+    mir.declared_pointee_volatile_masks[i] =
+        symbol->pointee_volatile_mask |
+        (unsigned int)(symbol->pointee_is_volatile != 0);
     mir.declared_dynamic_strides[i] = symbol->runtime_stride_name[0] != 0;
     mir_copy_name(mir.declared_runtime_stride_names[i],
                   symbol->runtime_stride_name);
@@ -5313,14 +5320,14 @@ static int mir_dominated_load_memory_barrier(const struct MirInsn *insn)
     }
 }
 
-static int mir_indirect_load_pointee_is_volatile_value(int value, int depth)
+static unsigned int mir_pointer_volatile_mask(int value, int depth)
 {
     const struct MirInsn *definition;
     const struct Sym *symbol;
     int declared;
 
     if (depth > 64)
-        return 1;
+        return ~0U;
     if (value < 0)
         return 0;
     definition = mir_definition(value);
@@ -5329,31 +5336,44 @@ static int mir_indirect_load_pointee_is_volatile_value(int value, int depth)
     if (definition->opcode == MIR_PARAM || definition->opcode == MIR_LOAD) {
         for (declared = 0; declared < mir.declared_count; ++declared)
             if (!strcmp(mir.declared_names[declared], definition->name))
-                return mir.declared_pointee_is_volatile[declared];
+                return mir.declared_pointee_volatile_masks[declared];
         symbol = find_global(definition->name);
-        return symbol != NULL && symbol->pointee_is_volatile;
+        return symbol != NULL ? symbol->pointee_volatile_mask |
+            (unsigned int)(symbol->pointee_is_volatile != 0) : 0;
     }
     if (definition->opcode == MIR_ADDRESS) {
         for (declared = 0; declared < mir.declared_count; ++declared)
             if (!strcmp(mir.declared_names[declared], definition->name))
-                return mir.declared_is_volatile[declared];
+                                return (mir.declared_pointee_volatile_masks[declared] << 1) |
+                                             (unsigned int)(mir.declared_is_volatile[declared] != 0);
         symbol = find_global(definition->name);
-        return (definition->memory_flags & 1) != 0 ||
-               (symbol != NULL && symbol->is_volatile);
+                return (unsigned int)((definition->memory_flags & 1) != 0) |
+                             (symbol != NULL ?
+                                ((symbol->pointee_volatile_mask |
+                                    (unsigned int)(symbol->pointee_is_volatile != 0)) << 1) |
+                                (unsigned int)(symbol->is_volatile != 0) : 0);
     }
+        if (definition->opcode == MIR_LOAD_INDIRECT)
+                return definition->pointee_volatile_mask |
+                             (mir_pointer_volatile_mask(definition->src1, depth + 1) >> 1);
+        if (definition->opcode == MIR_MEMBER_ADDRESS)
+                return definition->pointee_volatile_mask |
+                             (unsigned int)((definition->memory_flags & MIR_MEMORY_FLAG_VOLATILE) != 0) |
+                             (mir_pointer_volatile_mask(definition->src1, depth + 1) & 1U);
     if (definition->opcode == MIR_INDEX_ADDRESS ||
-        definition->opcode == MIR_MEMBER_ADDRESS ||
         definition->opcode == MIR_UNARY)
-        return (definition->opcode == MIR_MEMBER_ADDRESS &&
-                (definition->memory_flags & MIR_MEMORY_FLAG_VOLATILE) != 0) ||
-               mir_indirect_load_pointee_is_volatile_value(
-                   definition->src1, depth + 1);
+            return mir_pointer_volatile_mask(definition->src1, depth + 1);
     if (definition->opcode == MIR_BINARY || definition->opcode == MIR_PHI)
-        return mir_indirect_load_pointee_is_volatile_value(
-                   definition->src1, depth + 1) ||
-               mir_indirect_load_pointee_is_volatile_value(
+        return mir_pointer_volatile_mask(
+                   definition->src1, depth + 1) |
+               mir_pointer_volatile_mask(
                    definition->src2, depth + 1);
     return 0;
+}
+
+static int mir_indirect_load_pointee_is_volatile_value(int value, int depth)
+{
+    return (mir_pointer_volatile_mask(value, depth) & 1U) != 0;
 }
 
 static int mir_indirect_load_pointee_is_volatile(
@@ -7528,6 +7548,16 @@ scoped_type_repair_done:
         struct MirInsn *insn = &mir.insns[i];
         struct MirInsn *address;
         int pointee_type;
+        if (insn->opcode == MIR_INDEX_ADDRESS && insn->src1 >= 0) {
+            struct MirInsn *base = mir_mutable_definition(insn->src1);
+            if (base != NULL && base->opcode == MIR_LOAD_INDIRECT &&
+                (base->memory_flags & 256) != 0 &&
+                type_ptr_depth(base->type) > 0) {
+                insn->type = base->type;
+                insn->memory_size = type_size(type_decay_ptr(base->type));
+                insn->immediate = type_index_elem_size(base->type);
+            }
+        }
         if ((insn->opcode != MIR_LOAD_INDIRECT &&
              insn->opcode != MIR_STORE_INDIRECT) ||
             insn->bit_width > 0 || insn->src1 < 0)
@@ -7544,8 +7574,12 @@ scoped_type_repair_done:
             insn->dst = -1;
             continue;
         }
-        if ((insn->memory_flags & 256) != 0)
+        if ((insn->memory_flags & 256) != 0) {
+            if (type_ptr_depth(insn->type) == 0 &&
+                type_ptr_depth(address->type) == 2)
+                insn->type = type_decay_ptr(address->type);
             continue;
+        }
         pointee_type = type_decay_ptr(address->type);
         if (type_size(pointee_type) <= 0)
             continue;

--- a/src/dcc/dcc_mir.c
+++ b/src/dcc/dcc_mir.c
@@ -5344,8 +5344,10 @@ static int mir_indirect_load_pointee_is_volatile_value(int value, int depth)
     if (definition->opcode == MIR_INDEX_ADDRESS ||
         definition->opcode == MIR_MEMBER_ADDRESS ||
         definition->opcode == MIR_UNARY)
-        return mir_indirect_load_pointee_is_volatile_value(
-            definition->src1, depth + 1);
+        return (definition->opcode == MIR_MEMBER_ADDRESS &&
+                (definition->memory_flags & MIR_MEMORY_FLAG_VOLATILE) != 0) ||
+               mir_indirect_load_pointee_is_volatile_value(
+                   definition->src1, depth + 1);
     if (definition->opcode == MIR_BINARY || definition->opcode == MIR_PHI)
         return mir_indirect_load_pointee_is_volatile_value(
                    definition->src1, depth + 1) ||

--- a/src/dcc/dcc_mir_internal.h
+++ b/src/dcc/dcc_mir_internal.h
@@ -129,6 +129,7 @@ struct MirInsn {
     int object;
     int memory_size;
     int memory_flags;
+    unsigned int pointee_volatile_mask;
     int bit_width;
     int bit_shift;
     unsigned int bit_mask;
@@ -288,6 +289,7 @@ struct MirFunction {
     int declared_is_array[MAX_LOCALS];
     int declared_is_volatile[MAX_LOCALS];
     int declared_pointee_is_volatile[MAX_LOCALS];
+    unsigned int declared_pointee_volatile_masks[MAX_LOCALS];
     int declared_dynamic_strides[MAX_LOCALS];
     char declared_runtime_stride_names[MAX_LOCALS][64];
     int declared_is_const[MAX_LOCALS];

--- a/src/dcc/dcc_types.c
+++ b/src/dcc/dcc_types.c
@@ -423,6 +423,7 @@ void parse_struct_definition(int struct_id)
     int decl_type;
     int field_base_is_volatile;
     int field_base_pointee_is_volatile;
+    unsigned int field_base_volatile_mask;
 
     sd = &struct_defs[struct_id - 1];
 
@@ -448,6 +449,7 @@ void parse_struct_definition(int struct_id)
         decl_type = parse_base_type();
         field_base_is_volatile = g_decl.is_volatile;
         field_base_pointee_is_volatile = g_decl.pointee_is_volatile;
+        field_base_volatile_mask = g_decl.pointee_volatile_mask;
 
         for (;;) {
             int is_funcptr_field;
@@ -457,9 +459,9 @@ void parse_struct_definition(int struct_id)
             ftype = decl_type;
             g_decl.is_volatile = field_base_is_volatile;
             g_decl.pointee_is_volatile = field_base_pointee_is_volatile;
+            g_decl.pointee_volatile_mask = field_base_volatile_mask;
             while (accept('*')) {
-                g_decl.pointee_is_volatile = g_decl.is_volatile;
-                g_decl.is_volatile = skip_type_qualifiers_volatile();
+                advance_pointer_qualifiers();
                 ftype = type_add_ptr(ftype);
             }
 
@@ -570,6 +572,9 @@ void parse_struct_definition(int struct_id)
             dcc_copy_str(field_defs[nfield_defs].name, sizeof(field_defs[nfield_defs].name), fname);
             field_defs[nfield_defs].type = ftype;
             field_defs[nfield_defs].is_volatile = g_decl.is_volatile;
+            field_defs[nfield_defs].pointee_volatile_mask =
+                g_decl.pointee_volatile_mask |
+                (unsigned int)(g_decl.pointee_is_volatile != 0);
             field_defs[nfield_defs].parent_struct_id = struct_id;
             /* union: all fields at offset 0; struct: cumulative */
             field_defs[nfield_defs].offset = sd->is_union ? 0 : sd->size;
@@ -656,6 +661,7 @@ void add_typedef_name_ex(const char *name, int type, int array_len, int is_func,
     typedefs[i].type = type;
     typedefs[i].is_volatile = is_volatile;
     typedefs[i].pointee_is_volatile = pointee_is_volatile;
+    typedefs[i].pointee_volatile_mask = (unsigned int)(pointee_is_volatile != 0);
     typedefs[i].array_len = array_len;
     typedefs[i].is_func = is_func;
     typedefs[i].has_proto = g_funcptr_has_proto;
@@ -709,6 +715,7 @@ int parse_base_type(void)
     g_decl.is_const = 0;
     g_decl.is_volatile = 0;
     g_decl.pointee_is_volatile = 0;
+    g_decl.pointee_volatile_mask = 0;
     g_decl.is_inline = 0;
     g_decl.is_noreturn = 0;
     g_decl.is_fastcall = 0;
@@ -778,10 +785,12 @@ int parse_base_type(void)
             int sid;
             int struct_is_volatile;
             int struct_pointee_is_volatile;
+            unsigned int struct_volatile_mask;
             char sname[64];
             int is_union_kw;
             struct_is_volatile = g_decl.is_volatile;
             struct_pointee_is_volatile = g_decl.pointee_is_volatile;
+            struct_volatile_mask = g_decl.pointee_volatile_mask;
             is_union_kw = (g_lex.tok.kind == TOK_UNION);
             next_token();
             if (g_lex.tok.kind == TOK_ID) {
@@ -801,6 +810,7 @@ int parse_base_type(void)
                 parse_struct_definition(sid);
                 g_decl.is_volatile = struct_is_volatile;
                 g_decl.pointee_is_volatile = struct_pointee_is_volatile;
+                g_decl.pointee_volatile_mask = struct_volatile_mask;
             }
             t = make_struct_type(sid);
             saw_any = 1;
@@ -897,6 +907,7 @@ int parse_base_type(void)
             g_typedef_base_type = t;
             g_decl.is_volatile |= typedefs[td].is_volatile;
             g_decl.pointee_is_volatile = typedefs[td].pointee_is_volatile;
+            g_decl.pointee_volatile_mask = typedefs[td].pointee_volatile_mask;
             g_typedef_array_len = typedefs[td].array_len;
             g_typedef_array_dim_count = typedefs[td].dim_count;
             memcpy(g_typedef_array_dims, typedefs[td].dims,
@@ -937,13 +948,22 @@ int parse_base_type(void)
     return t;
 }
 
+void advance_pointer_qualifiers(void)
+{
+    g_decl.pointee_volatile_mask =
+        ((g_decl.pointee_volatile_mask |
+          (unsigned int)(g_decl.pointee_is_volatile != 0)) << 1) |
+        (unsigned int)(g_decl.is_volatile != 0);
+    g_decl.pointee_is_volatile = g_decl.is_volatile;
+    g_decl.is_volatile = skip_type_qualifiers_volatile();
+}
+
 int parse_type(void)
 {
     int t;
     t = parse_base_type();
     while (accept('*')) {
-        g_decl.pointee_is_volatile = g_decl.is_volatile;
-        g_decl.is_volatile = skip_type_qualifiers_volatile();
+        advance_pointer_qualifiers();
         t = type_add_ptr(t);
     }
     return t;

--- a/tests/host/README.md
+++ b/tests/host/README.md
@@ -47,7 +47,20 @@ Target loop execution and volatile access-count/flag assertions are covered by:
 ```sh
 pwsh ./scripts/run-mir-clobber-tests.ps1 -Cases semantics
 pwsh ./scripts/run-mir-clobber-tests.ps1 -Cases domloop
+pwsh ./scripts/run-mir-clobber-tests.ps1 -Cases aliasmem
 ```
 
-Both fixtures run in release, full debug, and line-debug modes, with and
+These fixtures run in release, full debug, and line-debug modes, with and
 without peephole optimization and stack checks.
+
+`aliasmem` checks writes through identical and distinct pointers, conditional
+alias writes, mutating calls, and `memcpy`. Its MIR assertions require volatile
+array-member and nested-member accesses to retain their count, byte width,
+and volatile flags, including stores. Nonvolatile controls must still reuse
+repeated loads and combine adjacent little-endian bytes. Runtime output alone
+cannot detect a removed volatile read when the backing memory stays unchanged.
+
+The member-address fix does not establish complete qualifier propagation
+through arbitrary pointer indirection. Double-indirection cases in the fixture
+are execution smoke tests, not assertions that every access has complete
+qualifier metadata.

--- a/tests/host/README.md
+++ b/tests/host/README.md
@@ -60,7 +60,19 @@ and volatile flags, including stores. Nonvolatile controls must still reuse
 repeated loads and combine adjacent little-endian bytes. Runtime output alone
 cannot detect a removed volatile read when the backing memory stays unchanged.
 
-The member-address fix does not establish complete qualifier propagation
-through arbitrary pointer indirection. Double-indirection cases in the fixture
-are execution smoke tests, not assertions that every access has complete
-qualifier metadata.
+Pointer qualifier regressions cover direct and typedef-based parameters,
+old-style parameters, globals, block locals, static locals, and pointer fields.
+They distinguish volatile byte reads from volatile intermediate pointer reads,
+including a pointer to a volatile pointer to volatile bytes. Nonvolatile
+controls detect qualifier leakage. A block-local double-pointer case also
+checks deferred pointer-word type repair and byte-index scaling.
+
+Declaration, symbol, typedef, and field metadata retain a
+`pointee_volatile_mask`: bit zero describes the immediate pointee, bit one the
+next pointee, and so on. Adding a pointer shifts existing levels and records
+the previous object's qualifier. MIR loads shift the address mask back one
+level; member addresses combine the field's own qualifier with its pointee
+mask. This preserves the distinction between a volatile pointer and volatile
+data without replacing the existing type encoding or debug metadata format.
+These tests do not claim complete qualifier handling for every cast or
+function-return expression.

--- a/tests/mir-clobber/aliasmem.c
+++ b/tests/mir-clobber/aliasmem.c
@@ -13,6 +13,17 @@ struct NestedBytes {
     struct VolatileBytes member;
 };
 
+typedef volatile unsigned char *VolatilePointer;
+typedef VolatilePointer *VolatilePointerPointer;
+
+struct PointerFields {
+    volatile unsigned char *value, plain;
+    volatile unsigned char **deep;
+    unsigned char * volatile changing;
+};
+
+static volatile unsigned char **deep_global;
+
 static int failures;
 
 static void check(const char *name, int actual, int expected)
@@ -71,6 +82,81 @@ int vindirect(volatile unsigned char **pointer, int index)
            (*pointer)[index + 1];
 }
 
+int vtypedef(VolatilePointerPointer pointer, int index)
+{
+    return (*pointer)[index + 1] + (*pointer)[index + 1] +
+           (*pointer)[index + 1];
+}
+
+int vold(pointer, index)
+volatile unsigned char **pointer;
+int index;
+{
+    return (*pointer)[index + 1] + (*pointer)[index + 1] +
+           (*pointer)[index + 1];
+}
+
+int vglobal(int index)
+{
+    return (*deep_global)[index + 1] + (*deep_global)[index + 1] +
+           (*deep_global)[index + 1];
+}
+
+int vlocal(volatile unsigned char **pointer, int index)
+{
+    {
+        volatile unsigned char **copy = pointer;
+        return (*copy)[index + 1] + (*copy)[index + 1] +
+               (*copy)[index + 1];
+    }
+}
+
+int vpfield(struct PointerFields *object, int index)
+{
+    return object->value[index + 1] + object->value[index + 1] +
+           object->value[index + 1];
+}
+
+int vdfield(struct PointerFields *object, int index)
+{
+    return (*object->deep)[index + 1] + (*object->deep)[index + 1] +
+           (*object->deep)[index + 1];
+}
+
+int vchange(struct PointerFields *object, int index)
+{
+    return object->changing[index + 1] + object->changing[index + 1] +
+           object->changing[index + 1];
+}
+
+int nindirect(unsigned char **pointer, int index)
+{
+    return (*pointer)[index + 1] + (*pointer)[index + 1] +
+           (*pointer)[index + 1];
+}
+
+int vboth(volatile unsigned char * volatile *pointer, int index)
+{
+    return (*pointer)[index + 1] + (*pointer)[index + 1] +
+           (*pointer)[index + 1];
+}
+
+int nlocal(unsigned char **pointer, int index)
+{
+    {
+        unsigned char **copy = pointer;
+        return (*copy)[index + 1];
+    }
+}
+
+int vstatic(volatile unsigned char **pointer, int index)
+{
+    static volatile unsigned char **saved;
+    saved = pointer;
+    return (*saved)[index + 1] + (*saved)[index + 1] +
+           (*saved)[index + 1];
+}
+
 int aliaswrite(unsigned char *value, unsigned char *alias, int index)
 {
     int before = value[index + 1];
@@ -110,10 +196,13 @@ int main(void)
 {
     volatile unsigned char observed[3];
     volatile unsigned char *pointer = observed;
+    volatile unsigned char * volatile changing_pointer = observed;
     unsigned char bytes[3];
     struct VolatileBytes object;
     struct PlainBytes ordinary;
     struct NestedBytes nested;
+    struct PointerFields fields;
+    unsigned char *ordinary_pointer = bytes;
 
     observed[1] = 3;
     bytes[1] = 5;
@@ -122,6 +211,11 @@ int main(void)
     ordinary.bytes[0] = 0x12;
     ordinary.bytes[1] = 0x34;
     nested.member.bytes[1] = 3;
+    fields.value = observed;
+    fields.deep = &pointer;
+    fields.changing = bytes;
+    fields.plain = 2;
+    deep_global = &pointer;
     check("volatile member", vmember(&object, 0), 0x34 * 3);
     check("volatile word", vmword(&object), 0x3412);
     check("ordinary member", nmember(&ordinary, 0), 0x34 * 3);
@@ -131,6 +225,17 @@ int main(void)
     check("volatile stores", object.bytes[1], 7);
     check("local volatile pointer", vptrptr(&pointer, 0), 9);
     check("indirect volatile pointer", vindirect(&pointer, 0), 9);
+    check("typedef volatile pointer", vtypedef(&pointer, 0), 9);
+    check("old-style volatile pointer", vold(&pointer, 0), 9);
+    check("global volatile pointer", vglobal(0), 9);
+    check("local volatile pointer copy", vlocal(&pointer, 0), 9);
+    check("pointer field", vpfield(&fields, 0), 9);
+    check("deep pointer field", vdfield(&fields, 0), 9);
+    check("volatile pointer ordinary data", vchange(&fields, 0), 15);
+    check("ordinary indirect pointer", nindirect(&ordinary_pointer, 0), 15);
+    check("ordinary local pointer", nlocal(&ordinary_pointer, 0), 5);
+    check("both pointer levels volatile", vboth(&changing_pointer, 0), 9);
+    check("static pointer", vstatic(&pointer, 0), 9);
     check("alias store", aliaswrite(bytes, bytes + 1, 0), 19);
     bytes[1] = 5;
     bytes[2] = 0;

--- a/tests/mir-clobber/aliasmem.c
+++ b/tests/mir-clobber/aliasmem.c
@@ -1,0 +1,148 @@
+#include <stdio.h>
+#include <string.h>
+
+struct VolatileBytes {
+    volatile unsigned char bytes[4];
+};
+
+struct PlainBytes {
+    unsigned char bytes[4];
+};
+
+struct NestedBytes {
+    struct VolatileBytes member;
+};
+
+static int failures;
+
+static void check(const char *name, int actual, int expected)
+{
+    if (actual != expected) {
+        printf("FAIL %s: %d expected %d\n", name, actual, expected);
+        ++failures;
+    }
+}
+
+int nmember(struct PlainBytes *object, int index)
+{
+    return object->bytes[index + 1] + object->bytes[index + 1] +
+           object->bytes[index + 1];
+}
+
+unsigned int nmword(struct PlainBytes *object)
+{
+    return (unsigned int)object->bytes[0] |
+           ((unsigned int)object->bytes[1] << 8);
+}
+
+int vnested(struct NestedBytes *object, int index)
+{
+    return object->member.bytes[index + 1] + object->member.bytes[index + 1] +
+           object->member.bytes[index + 1];
+}
+
+void vmstore(struct VolatileBytes *object, int index)
+{
+    object->bytes[index + 1] = 5;
+    object->bytes[index + 1] = 7;
+}
+
+int vmember(struct VolatileBytes *object, int index)
+{
+    return object->bytes[index + 1] + object->bytes[index + 1] +
+           object->bytes[index + 1];
+}
+
+unsigned int vmword(struct VolatileBytes *object)
+{
+    return (unsigned int)object->bytes[0] |
+           ((unsigned int)object->bytes[1] << 8);
+}
+
+int vptrptr(volatile unsigned char **pointer, int index)
+{
+    volatile unsigned char *value = *pointer;
+    return value[index + 1] + value[index + 1] + value[index + 1];
+}
+
+int vindirect(volatile unsigned char **pointer, int index)
+{
+    return (*pointer)[index + 1] + (*pointer)[index + 1] +
+           (*pointer)[index + 1];
+}
+
+int aliaswrite(unsigned char *value, unsigned char *alias, int index)
+{
+    int before = value[index + 1];
+    *alias = 7;
+    return before + value[index + 1] + value[index + 1];
+}
+
+void mutate(unsigned char *alias)
+{
+    *alias = 9;
+}
+
+int aliascall(unsigned char *value, unsigned char *alias, int index)
+{
+    int before = value[index + 1];
+    mutate(alias);
+    return before + value[index + 1] + value[index + 1];
+}
+
+int abranch(unsigned char *value, unsigned char *alias, int index, int flag)
+{
+    int before = value[index + 1];
+    if (flag)
+        *alias = 11;
+    return before + value[index + 1] + value[index + 1];
+}
+
+int acopy(unsigned char *value, unsigned char *alias, int index)
+{
+    int before = value[index + 1];
+    unsigned char replacement = 13;
+    memcpy(alias, &replacement, 1);
+    return before + value[index + 1] + value[index + 1];
+}
+
+int main(void)
+{
+    volatile unsigned char observed[3];
+    volatile unsigned char *pointer = observed;
+    unsigned char bytes[3];
+    struct VolatileBytes object;
+    struct PlainBytes ordinary;
+    struct NestedBytes nested;
+
+    observed[1] = 3;
+    bytes[1] = 5;
+    object.bytes[0] = 0x12;
+    object.bytes[1] = 0x34;
+    ordinary.bytes[0] = 0x12;
+    ordinary.bytes[1] = 0x34;
+    nested.member.bytes[1] = 3;
+    check("volatile member", vmember(&object, 0), 0x34 * 3);
+    check("volatile word", vmword(&object), 0x3412);
+    check("ordinary member", nmember(&ordinary, 0), 0x34 * 3);
+    check("ordinary word", nmword(&ordinary), 0x3412);
+    check("nested volatile", vnested(&nested, 0), 9);
+    vmstore(&object, 0);
+    check("volatile stores", object.bytes[1], 7);
+    check("local volatile pointer", vptrptr(&pointer, 0), 9);
+    check("indirect volatile pointer", vindirect(&pointer, 0), 9);
+    check("alias store", aliaswrite(bytes, bytes + 1, 0), 19);
+    bytes[1] = 5;
+    bytes[2] = 0;
+    check("distinct store", aliaswrite(bytes, bytes + 2, 0), 15);
+    bytes[1] = 5;
+    check("alias call", aliascall(bytes, bytes + 1, 0), 23);
+    bytes[1] = 5;
+    check("alias branch taken", abranch(bytes, bytes + 1, 0, 1), 27);
+    bytes[1] = 5;
+    check("alias branch skipped", abranch(bytes, bytes + 1, 0, 0), 15);
+    bytes[1] = 5;
+    check("alias copy", acopy(bytes, bytes + 1, 0), 31);
+    printf("MIR alias failures=%d\n", failures);
+    return failures != 0;
+}


### PR DESCRIPTION
## Summary
- Preserve volatile array-member and nested-member accesses so repeated reads are not merged and separate byte reads are not widened into a word read.
- Retain pointer-level volatile qualifier masks through parameters, old-style parameters, local/static/global declarations, typedefs, fields, and MIR dereferences. Distinguish volatile pointer objects from volatile data.
- Fix provisional scalar typing of deferred block-local pointer-word loads and restore the correct element width and indexing stride.
- Add aliasmem regressions for qualifier transport, aliasing stores/calls/copies, access counts and widths, and nonvolatile optimization controls. The existing clobber CI gate runs this fixture in twelve release/debug configurations.
- Document the qualifier representation and test coverage.

## Commits
- 3c88ae84: preserve volatile array-member memory effects
- c9ae3c00: retain pointer-level volatile qualifiers through MIR

## Validation
- Both strict full+extended release suites passed: 481 applications passed, 24 skipped per stack configuration; zero checked performance regressions.
- Before/after censuses accepted all 3,035 existing functions in both configurations with unchanged generated output.
- Complete MIR clobber, lifetime, and required-emission suites passed.
- aliasmem structural assertions and execution passed across release/full-debug/line-debug, peep/nopeep, and stack/no-stack configurations.
- Host verifier and representative qualifier compilation passed under ASan/UBSan.
- All 70 script tests and 10 debugger-host tests passed.
- git diff --check passed; performance baselines unchanged.

## Scope
This PR contains the completed memory-effects fixes only, following #183 and #184. It is not an exhaustive aliasing/type audit and does not claim complete qualifier handling for every cast or function-return expression. Those cases remain separate follow-up work. Cross-platform GitHub Actions results are pending.