### PR TITLE
Preserve cast and pointer-return qualifiers with systematic regression tests

### DIFF
--- a/scripts/run-mir-clobber-tests.ps1
+++ b/scripts/run-mir-clobber-tests.ps1
@@ -255,6 +255,22 @@ function Assert-ForcedRegionalSafe(
 $fixtureRoot = Join-Path $repoRoot "tests/mir-clobber"
 $caseDefinitions = @(
     [pscustomobject]@{
+        Name = "qualgen"
+        Sources = @(Join-Path $tempRoot "qualgen.c")
+        Defines = @()
+        Expected = @("MIR generated qualifier checks=576 failures=0")
+        Exit = 0
+        DebugModes = @("true", "lines")
+    },
+    [pscustomobject]@{
+        Name = "qualexpr"
+        Sources = @(Join-Path $fixtureRoot "qualexpr.c")
+        Defines = @()
+        Expected = @("MIR qualifier expressions failures=0")
+        Exit = 0
+        DebugModes = @("true", "lines")
+    },
+    [pscustomobject]@{
         Name = "aliasmem"
         Sources = @(Join-Path $fixtureRoot "aliasmem.c")
         Defines = @()
@@ -427,7 +443,82 @@ try {
     Set-ProcessEnvironment "DCC_MIR_MACHINE_REPORT" "1"
     Set-ProcessEnvironment "DCC_MIR_SELECT_REPORT" "1"
 
+    if ($Cases.Count -eq 0 -or "qualgen" -in $Cases) {
+        $seeds = @(0, 1, 127, 255, 256, 32767, 32768, 65535)
+        $variants = @("plain", "cast", "typedef", "return", "conditional", "roundtrip")
+        $source = [System.Text.StringBuilder]::new()
+        [void]$source.AppendLine('#include <stdio.h>')
+        $expected = [System.Collections.Generic.List[int]]::new()
+        $functionNames = [System.Collections.Generic.List[string]]::new()
+        foreach ($width in @(8, 16)) {
+            $element = if ($width -eq 8) { "unsigned char" } else { "unsigned int" }
+            [void]$source.AppendLine("typedef volatile $element *Q$width;")
+            [void]$source.AppendLine("volatile $element *r$width($element *pointer) { return pointer; }")
+            foreach ($variant in $variants) {
+                $name = "q$($functionNames.Count)"
+                $functionNames.Add($name)
+                $expression = switch ($variant) {
+                    "plain" { "plain" }
+                    "cast" { "((volatile $element *)plain)" }
+                    "typedef" { "((Q$width)plain)" }
+                    "return" { "r$width(plain)" }
+                    "conditional" { "(flag ? plain : observed)" }
+                    "roundtrip" { "(($element *)(volatile $element *)plain)" }
+                }
+                [void]$source.AppendLine("unsigned int $name(unsigned int seed, int index, int flag) {")
+                [void]$source.AppendLine("$element data[4], other[4]; int slot;")
+                [void]$source.AppendLine("$element *plain = data; volatile $element *observed = other;")
+                [void]$source.AppendLine("for (slot = 0; slot < 4; ++slot) { data[slot] = ($element)(seed + (unsigned int)slot * 257U); other[slot] = ($element)(seed + (unsigned int)slot * 257U + 19U); }")
+                [void]$source.AppendLine("return (unsigned int)((unsigned int)$expression[index] + seed) ^ (unsigned int)((unsigned int)$expression[index + 1] * 257U); }")
+            }
+        }
+        foreach ($seed in $seeds) {
+            foreach ($index in 0..2) {
+                foreach ($flag in 0..1) {
+                    foreach ($width in @(8, 16)) {
+                        $mask = if ($width -eq 8) { 255 } else { 65535 }
+                        foreach ($variant in $variants) {
+                            $bias = if ($variant -eq "conditional" -and $flag -eq 0) { 19 } else { 0 }
+                            $left = ($seed + $index * 257 + $bias) -band $mask
+                            $right = ($seed + ($index + 1) * 257 + $bias) -band $mask
+                            $expected.Add((($left + $seed) -band 65535) -bxor (($right * 257) -band 65535))
+                        }
+                    }
+                }
+            }
+        }
+        [void]$source.AppendLine("static unsigned int seeds[8] = { $($seeds -join ',') };")
+        [void]$source.AppendLine("static unsigned int expected[576] = { $($expected -join ',') };")
+        [void]$source.AppendLine('static int checks, failures;')
+        [void]$source.AppendLine('static void check(unsigned int actual) { if (actual != expected[checks]) { printf("FAIL generated %d got=%u expected=%u\n", checks, actual, expected[checks]); ++failures; } ++checks; }')
+        [void]$source.AppendLine('int main(void) { int sample, index, flag; for (sample = 0; sample < 8; ++sample) for (index = 0; index < 3; ++index) for (flag = 0; flag < 2; ++flag) {')
+        foreach ($name in $functionNames) {
+            [void]$source.AppendLine("check($name(seeds[sample], index, flag));")
+        }
+        [void]$source.AppendLine('} printf("MIR generated qualifier checks=%d failures=%d\n", checks, failures); return failures != 0; }')
+        [System.IO.File]::WriteAllText((Join-Path $tempRoot "qualgen.c"),
+            $source.ToString(), [System.Text.Encoding]::ASCII)
+    }
+
     foreach ($proofCase in @(
+        @{
+            Name = "qualexpr"; Source = "qualexpr.c"
+            Expectations = @(
+                @{ Function = "castadd"; Loads = 3; Volatile = 3; Width = 1 },
+                @{ Function = "casttype"; Loads = 3; Volatile = 3; Width = 1 },
+                @{ Function = "castdrop"; Loads = 1; Volatile = 0; Width = 1 },
+                @{ Function = "nested"; Loads = 1; Volatile = 1; Width = 1 },
+                @{ Function = "voidcast"; Loads = 1; Volatile = 1; Width = 1 },
+                @{ Function = "deepcast"; Loads = 2; Volatile = 1; ByteVolatile = 1 },
+                @{ Function = "retread"; Loads = 1; Volatile = 1; Width = 1 },
+                @{ Function = "retdeep"; Loads = 2; Volatile = 1; ByteVolatile = 1 },
+                @{ Function = "inclone"; Loads = 1; Volatile = 1; Width = 1 },
+                @{ Function = "recast"; Loads = 1; Volatile = 1; Width = 1 },
+                @{ Function = "plainret"; Loads = 1; Volatile = 0; Width = 1 },
+                @{ Function = "inread"; Loads = 1; Volatile = 1; Width = 1 },
+                @{ Function = "choose"; Loads = 1; Volatile = 1; Width = 1 }
+            )
+        },
         @{
             Name = "semantics"; Source = "semfix.c"
             Expectations = @(

--- a/src/dcc/dcc_ast.h
+++ b/src/dcc/dcc_ast.h
@@ -106,6 +106,7 @@ enum AstKind {
 struct AstNode {
     int kind;               /* enum AstKind                                */
     int type;               /* dcc type code of an expression's result     */
+    unsigned int pointee_volatile_mask;
     int op;                 /* operator token kind (unary/binary/assign)   */
     long ival;              /* integer/char literal, case value, label id  */
     unsigned long uval;     /* float bits or other unsigned payload        */

--- a/src/dcc/dcc_ast_build.c
+++ b/src/dcc/dcc_ast_build.c
@@ -779,13 +779,19 @@ static struct AstNode *p_unary(struct AstArena *ar)
         struct AstNode *operand;
         int cty;
         int csz;
+        unsigned int volatile_mask;
+        struct AstNode *cast;
         next_token();                    /* consume '(' */
         parse_type_name_decl(&cty, &csz); /* parse ( type-name */
+        volatile_mask = g_decl.pointee_volatile_mask |
+            (unsigned int)(g_decl.pointee_is_volatile != 0);
         expect(')');
         if (g_lex.tok.kind == '{')
             return p_postfix_tail(ar, ast_build_compound_literal(ar, cty));
         operand = p_unary(ar);
-        return ast_cast(ar, cty, operand);
+        cast = ast_cast(ar, cty, operand);
+        cast->pointee_volatile_mask = volatile_mask;
+        return cast;
     }
 
     return p_postfix(ar);

--- a/src/dcc/dcc_func.c
+++ b/src/dcc/dcc_func.c
@@ -3209,6 +3209,8 @@ void parse_function_or_global(int base_type)
          * fn_t *fp have already cleared base_is_func_typedef above. */
         if (base_is_func_typedef && g_funcptr_decl_array_len == 0) {
             s = add_global(name, type, SC_FUNC);
+            s->pointee_is_volatile = pointee_is_volatile;
+            s->pointee_volatile_mask = volatile_mask;
             s->is_inline |= g_decl.is_inline;
             s->is_noreturn |= g_decl.is_noreturn;
             parse_function_return_type = type;
@@ -3226,6 +3228,8 @@ void parse_function_or_global(int base_type)
         /* Function declarator or definition. */
         if (is_funcret_funcptr_decl || (g_funcptr_decl_array_len == 0 && accept('('))) {
             s = add_global(name, type, SC_FUNC);
+            s->pointee_is_volatile = pointee_is_volatile;
+            s->pointee_volatile_mask = volatile_mask;
             /* Unlike is_inline (an optimization hint dcc tolerates picking up
              * from any one declaration), a __fastcall mismatch between
              * declarations is a real ABI disagreement between call sites

--- a/src/dcc/dcc_mir.c
+++ b/src/dcc/dcc_mir.c
@@ -1317,6 +1317,7 @@ static struct AstNode *mir_clone_inline_expr(struct AstArena *arena,
 
     dst = ast_new(arena, src->kind);
     dst->type = src->type;
+    dst->pointee_volatile_mask = src->pointee_volatile_mask;
     dst->op = src->op;
     dst->ival = src->ival;
     dst->uval = src->uval;
@@ -1605,6 +1606,18 @@ static int mir_try_lower_inline_call_expr(const struct AstNode *call,
         return 0;
     }
     *out_value = mir_lower_expr(expr);
+    if (fn_sym != NULL && type_ptr_depth(fn_sym->type) > 0 &&
+        (fn_sym->pointee_volatile_mask != 0 || fn_sym->pointee_is_volatile)) {
+        int result = mir_new_value();
+        struct MirInsn *conversion = mir_emit(MIR_UNARY);
+        conversion->dst = result;
+        conversion->src1 = *out_value;
+        conversion->type = fn_sym->type;
+        conversion->has_pointer_qualifiers = 1;
+        conversion->pointee_volatile_mask = fn_sym->pointee_volatile_mask |
+            (unsigned int)(fn_sym->pointee_is_volatile != 0);
+        *out_value = result;
+    }
     mir_end_inline_call_scope(&scope);
     return 1;
 }
@@ -2783,6 +2796,10 @@ static int mir_lower_expr(const struct AstNode *node)
         insn->src1 = left;
         insn->type = node->type;
         insn->immediate = node->op;
+        if (node->kind == AST_CAST && type_ptr_depth(node->type) > 0) {
+            insn->has_pointer_qualifiers = 1;
+            insn->pointee_volatile_mask = node->pointee_volatile_mask;
+        }
         return value;
     case AST_POSTFIX:
         if (node->op == TOK_INC || node->op == TOK_DEC) {
@@ -5333,6 +5350,13 @@ static unsigned int mir_pointer_volatile_mask(int value, int depth)
     definition = mir_definition(value);
     if (definition == NULL)
         return 0;
+    if (definition->has_pointer_qualifiers)
+        return definition->pointee_volatile_mask;
+    if (definition->opcode == MIR_CALL) {
+        symbol = find_global(definition->name);
+        return symbol != NULL ? symbol->pointee_volatile_mask |
+            (unsigned int)(symbol->pointee_is_volatile != 0) : 0;
+    }
     if (definition->opcode == MIR_PARAM || definition->opcode == MIR_LOAD) {
         for (declared = 0; declared < mir.declared_count; ++declared)
             if (!strcmp(mir.declared_names[declared], definition->name))
@@ -6792,6 +6816,9 @@ static int mir_unary_is_representation_identity(
         return 0;
     source_size = type_size(source->type);
     target_size = type_size(insn->type);
+    if (insn->has_pointer_qualifiers &&
+        insn->pointee_volatile_mask != mir_pointer_volatile_mask(insn->src1, 0))
+        return 0;
     if (source->type == insn->type)
         return source_size == 1 || source_size == 2 || source_size == 4;
     if (source_size != target_size ||

--- a/src/dcc/dcc_mir_internal.h
+++ b/src/dcc/dcc_mir_internal.h
@@ -130,6 +130,7 @@ struct MirInsn {
     int memory_size;
     int memory_flags;
     unsigned int pointee_volatile_mask;
+    int has_pointer_qualifiers;
     int bit_width;
     int bit_shift;
     unsigned int bit_mask;

--- a/src/dcc/dcc_types.c
+++ b/src/dcc/dcc_types.c
@@ -1001,7 +1001,7 @@ int parse_type_name_decl(int *typep, int *sizep)
         sz = 1;
 
     while (accept('*')) {
-        skip_type_qualifiers();
+        advance_pointer_qualifiers();
         t = type_add_ptr(t);
         sz = 2;
     }
@@ -1011,7 +1011,7 @@ int parse_type_name_decl(int *typep, int *sizep)
         skip_type_qualifiers();
         saw_paren_ptr = 0;
         while (accept('*')) {
-            skip_type_qualifiers();
+            advance_pointer_qualifiers();
             saw_paren_ptr = 1;
         }
         if (g_lex.tok.kind == TOK_ID)

--- a/tests/host/README.md
+++ b/tests/host/README.md
@@ -48,6 +48,8 @@ Target loop execution and volatile access-count/flag assertions are covered by:
 pwsh ./scripts/run-mir-clobber-tests.ps1 -Cases semantics
 pwsh ./scripts/run-mir-clobber-tests.ps1 -Cases domloop
 pwsh ./scripts/run-mir-clobber-tests.ps1 -Cases aliasmem
+pwsh ./scripts/run-mir-clobber-tests.ps1 -Cases qualexpr
+pwsh ./scripts/run-mir-clobber-tests.ps1 -Cases qualgen
 ```
 
 These fixtures run in release, full debug, and line-debug modes, with and
@@ -74,5 +76,41 @@ the previous object's qualifier. MIR loads shift the address mask back one
 level; member addresses combine the field's own qualifier with its pointee
 mask. This preserves the distinction between a volatile pointer and volatile
 data without replacing the existing type encoding or debug metadata format.
-These tests do not claim complete qualifier handling for every cast or
-function-return expression.
+
+## Qualifier Expression Matrix
+
+`qualexpr.c` checks explicit and typedef casts, adding/removing/restoring
+volatile qualifiers, void-pointer casts, deep pointer casts, conditional
+qualifier merging, direct and inline pointer returns, deep pointer returns,
+and nonvolatile prototype-return controls. MIR assertions check access counts,
+widths, and which pointer level is volatile separately from runtime output.
+Qualifier-removal tests use objects originally declared nonvolatile; they do
+not read a volatile-defined object through an unqualified lvalue.
+
+Pointer casts carry their target qualifier mask in the AST and MIR. An
+explicit zero mask overrides the source qualifiers. Identity conversion
+elimination must preserve this distinction. Function symbols retain return
+qualifiers, and inline expansion preserves both cast metadata and the declared
+pointer-result contract.
+
+## Generated Differential Matrix
+
+`qualgen` generates a deterministic C program in the runner's temporary build
+directory and compares target results with a host-computed reference table.
+It covers 576 combinations: two element widths (8/16 bits), six expression
+forms (plain, explicit cast, typedef cast, direct return, conditional, and
+qualifier round trip), eight seeds (0, 1, 127, 255, 256, 32767, 32768, 65535),
+three indices, and both conditional outcomes.
+
+The reference calculation uses host integers and explicitly masks element
+values to 8 or 16 bits and arithmetic results to 16 bits. It does not assume
+that the host C compiler has dcc's integer widths. All pointer indexing stays
+within four-element arrays, with no numeric-address comparison or dependence
+on host pointer size. The unsigned arithmetic is defined, including wrapping;
+there is no signed overflow or unsequenced mutation. Each generated check has
+a stable index reported on failure. The full clobber CI gate runs both matrices
+in all twelve release/debug configurations, for 6,912 generated target checks.
+
+This is a bounded differential matrix, not exhaustive C testing or randomized
+fuzzing. In particular, it does not establish complete return-qualifier
+transport for arbitrary indirect function calls or every abstract declarator.

--- a/tests/mir-clobber/qualexpr.c
+++ b/tests/mir-clobber/qualexpr.c
@@ -1,0 +1,127 @@
+#include <stdio.h>
+
+typedef volatile unsigned char *VByte;
+typedef VByte *VDeep;
+static unsigned char bytes[4];
+static VByte byte_pointer = bytes;
+
+VDeep getdeep(void)
+{
+    return &byte_pointer;
+}
+
+int retdeep(void)
+{
+    return (*getdeep())[1];
+}
+
+static inline VByte incast(unsigned char *pointer)
+{
+    return (VByte)pointer;
+}
+
+int inclone(unsigned char *pointer)
+{
+    return incast(pointer)[1];
+}
+
+int recast(unsigned char *pointer)
+{
+    return ((VByte)(unsigned char *)(VByte)pointer)[1];
+}
+
+int plainret(void);
+unsigned char *getplain(void);
+
+int plainret(void)
+{
+    return getplain()[1];
+}
+
+unsigned char *getplain(void)
+{
+    return bytes;
+}
+
+volatile unsigned char *getbyte(void)
+{
+    return bytes;
+}
+
+static inline volatile unsigned char *inbyte(unsigned char *pointer)
+{
+    return pointer;
+}
+
+int inread(unsigned char *pointer)
+{
+    return inbyte(pointer)[1];
+}
+
+int castdrop(volatile unsigned char *pointer, int index)
+{
+    return ((unsigned char *)pointer)[index + 1] +
+           ((unsigned char *)pointer)[index + 1] +
+           ((unsigned char *)pointer)[index + 1];
+}
+
+int nested(unsigned char *pointer)
+{
+    return ((volatile unsigned char *)(unsigned char *)pointer)[1];
+}
+
+int voidcast(void *pointer)
+{
+    return ((VByte)pointer)[1];
+}
+
+int deepcast(unsigned char **pointer)
+{
+    return (*(VDeep)pointer)[1];
+}
+
+int castadd(unsigned char *pointer, int index)
+{
+    return ((volatile unsigned char *)pointer)[index + 1] +
+           ((volatile unsigned char *)pointer)[index + 1] +
+           ((volatile unsigned char *)pointer)[index + 1];
+}
+
+int casttype(unsigned char *pointer, int index)
+{
+    return ((VByte)pointer)[index + 1] + ((VByte)pointer)[index + 1] +
+           ((VByte)pointer)[index + 1];
+}
+
+int retread(int index)
+{
+    return getbyte()[index + 1];
+}
+
+int choose(unsigned char *plain, volatile unsigned char *observed, int flag)
+{
+    return (flag ? plain : observed)[1];
+}
+
+int main(void)
+{
+    int failures = 0;
+    unsigned char *pointer = bytes;
+    bytes[1] = 7;
+    failures += castadd(bytes, 0) != 21;
+    failures += casttype(bytes, 0) != 21;
+    failures += retread(0) != 7;
+    failures += choose(bytes, bytes, 0) != 7;
+    failures += choose(bytes, bytes, 1) != 7;
+    failures += castdrop(bytes, 0) != 21;
+    failures += nested(bytes) != 7;
+    failures += voidcast(bytes) != 7;
+    failures += deepcast(&pointer) != 7;
+    failures += inread(bytes) != 7;
+    failures += retdeep() != 7;
+    failures += inclone(bytes) != 7;
+    failures += recast(bytes) != 7;
+    failures += plainret() != 7;
+    printf("MIR qualifier expressions failures=%d\n", failures);
+    return failures != 0;
+}


### PR DESCRIPTION
## Summary
- Preserve explicit and typedef pointer-cast volatile qualifier masks in AST and MIR, including explicit qualifier removal.
- Retain direct function-return qualifiers and preserve declared pointer-result qualifiers and cast metadata through inline expansion.
- Prevent identity-cast elimination from dropping qualifier changes.
- Add a fixed qualifier-expression matrix with independent MIR access-count, width, and volatility assertions.
- Add 576 deterministic generated differential cases with explicit 8/16-bit element and modulo-65536 arithmetic expectations, executed in twelve release/debug configurations (6,912 checks).
- Document the reference model, test commands, and coverage limits. Both matrices are included in the existing clobber CI gate.

## Validation
- Both strict full+extended release suites passed: 481 applications passed and 24 skipped per stack configuration, with zero checked performance regressions.
- All 3,035 existing corpus functions accepted in both stack configurations with unchanged generated output.
- Complete MIR clobber, lifetime, and required-emission suites passed.
- Fixed and generated matrices passed in release/full-debug/line-debug, peep/nopeep, and stack/no-stack configurations.
- Host verifier and qualifier-expression compilation passed under ASan/UBSan.
- All 70 script tests and 10 debugger-host tests passed.
- git diff --check passed. Performance baselines remain unchanged.

## Scope
Follow-up to #185. This is bounded qualifier testing, not exhaustive C coverage or a whole-compiler correctness proof. Arbitrary indirect function-return qualifiers and every abstract-declarator form remain separate follow-up work. Qualifier-removal tests use originally nonvolatile backing objects, and generated pointer accesses stay within array bounds. Cross-platform GitHub Actions results are pending.