### PR TITLE
Version and validate the legacy-excluded coverage denominator

### DIFF
--- a/docs/compiler-coverage.md
+++ b/docs/compiler-coverage.md
@@ -45,6 +45,25 @@ classification. Diagnostics, defensive checks, and unused helpers within
 included modules remain in the denominator. Legacy codegen is not a target
 for coverage-driven test additions.
 
+`scripts/ast-mir-coverage.tsv` is the versioned module classification: 28
+active-owner modules, four mixed modules pending function-level classification,
+and two optional diagnostic modules. Each row includes its rationale. The
+coverage runner validates it before building: missing files, duplicate entries,
+invalid categories, and newly added unclassified AST/MIR modules fail rather
+than silently changing the denominator. No classification is based on whether
+the current tests happened to execute a function.
+
+Validate the classification independently with:
+
+```sh
+sh scripts/coverage-sources.sh
+sh scripts/test-coverage-sources.sh
+```
+
+Function-level separation of production, diagnostic, and unreachable code is
+still pending inside mixed modules. Do not relabel those files as legacy or
+include them wholesale merely to claim a complete production denominator.
+
 Measured on macOS with Apple Clang 21, on 2026-09-07, using compiler revision
 `9ad4775e` plus the coverage-routing and host-test changes documented here:
 

--- a/scripts/ast-mir-coverage.tsv
+++ b/scripts/ast-mir-coverage.tsv
@@ -1,0 +1,35 @@
+category	source	reason
+active-owner	src/dcc/dcc_ast.c	AST arena and node construction
+active-owner	src/dcc/dcc_ast_build.c	Function expression and statement parsing
+mixed-pending	src/dcc/dcc_ast_gen.c	Classifiers require function-level separation from compatibility helpers
+mixed-pending	src/dcc/dcc_ast_gen_cond.c	Active condition proofs and retained compatibility paths
+mixed-pending	src/dcc/dcc_ast_gen_expr.c	Active initializer metadata mixed with retained expression emission
+mixed-pending	src/dcc/dcc_ast_gen_support.c	Active semantic proofs and retained compatibility paths
+active-owner	src/dcc/dcc_ast_metadata.c	Non-emitting declaration scope and debug metadata
+active-owner	src/dcc/dcc_ast_stmt_meta.c	Statement capture and metadata planning
+active-owner	src/dcc/dcc_mir.c	Lowering metadata repair CFG promotion and allocation
+active-owner	src/dcc/dcc_mir_emit_common.c	Shared production MIR emission
+active-owner	src/dcc/dcc_mir_homed_cfg.c	Production fixed and regional home emission
+active-owner	src/dcc/dcc_mir_machine_aggregate_checks.c	Production aggregate schedules
+active-owner	src/dcc/dcc_mir_machine_attention.c	Production attention schedules
+active-owner	src/dcc/dcc_mir_machine_byte_scans.c	Production byte and row schedules
+active-owner	src/dcc/dcc_mir_machine_call_runners.c	Production call schedules
+active-owner	src/dcc/dcc_mir_machine_constant_folding.c	Production constant and result schedules
+active-owner	src/dcc/dcc_mir_machine_containers.c	Production container schedules
+active-owner	src/dcc/dcc_mir_machine_emit.c	Production schedule coordination
+active-owner	src/dcc/dcc_mir_machine_endgame.c	Production late schedule families
+active-owner	src/dcc/dcc_mir_machine_float_recursion.c	Production float and recursion schedules
+active-owner	src/dcc/dcc_mir_machine_float_reports.c	Production floating point schedules
+active-owner	src/dcc/dcc_mir_machine_interpreter_runners.c	Production interpreter schedules
+active-owner	src/dcc/dcc_mir_machine_numeric.c	Production numeric schedules
+active-owner	src/dcc/dcc_mir_machine_runtime_runners.c	Production runtime call schedules
+active-owner	src/dcc/dcc_mir_machine_scanners.c	Production scanner schedules
+active-owner	src/dcc/dcc_mir_machine_structural_checks.c	Production structural schedules
+active-owner	src/dcc/dcc_mir_machine_validation_runners.c	Production validation runner schedules
+active-owner	src/dcc/dcc_mir_machine_wide_records.c	Production wide value schedules
+optional-diagnostic	src/dcc/dcc_mir_schedule.c	Shadow scheduler not used for production selection
+active-owner	src/dcc/dcc_mir_select.c	Production candidate selection and cost policy
+active-owner	src/dcc/dcc_mir_spilled_cfg.c	Production spilled CFG emission
+active-owner	src/dcc/dcc_mir_stream.c	Transactional production streams
+optional-diagnostic	src/dcc/dcc_mir_target.c	Shadow target model not used for production selection
+active-owner	src/dcc/dcc_mir_verify.c	Production dominance verification

--- a/scripts/compiler-coverage.sh
+++ b/scripts/compiler-coverage.sh
@@ -41,6 +41,8 @@ if [ -z "$llvm_cov" ] || [ -z "$llvm_profdata" ]; then
     exit 1
 fi
 
+coverage_sources=$(sh "$repo_root/scripts/coverage-sources.sh")
+
 cmake -S "$repo_root/src/dcc" -B "$build_dir/cmake" \
     -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_C_COMPILER="$clang_cmd" \
@@ -74,17 +76,12 @@ fi
     -object "$build_dir/cmake/mir-verify-test" \
     -instr-profile="$build_dir/dcc.profdata" \
     "$repo_root"/src/dcc/*.c >"$report_dir/summary.txt"
-set -- \
-    "$repo_root/src/dcc/dcc_ast.c" \
-    "$repo_root/src/dcc/dcc_ast_build.c" \
-    "$repo_root/src/dcc/dcc_ast_metadata.c" \
-    "$repo_root/src/dcc/dcc_ast_stmt_meta.c"
-for source in "$repo_root"/src/dcc/dcc_mir*.c; do
-    case "$source" in
-        */dcc_mir_schedule.c|*/dcc_mir_target.c) continue ;;
-    esac
+set --
+while IFS= read -r source; do
     set -- "$@" "$source"
-done
+done <<EOF
+$coverage_sources
+EOF
 printf '%s\n' "$@" >"$report_dir/ast-mir-sources.txt"
 "$llvm_cov" report "$binary_dir/dcc" \
     -object "$build_dir/cmake/mir-verify-test" \

--- a/scripts/coverage-sources.sh
+++ b/scripts/coverage-sources.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+manifest=${1:-"$repo_root/scripts/ast-mir-coverage.tsv"}
+
+awk -F '\t' '
+NR == 1 {
+    if ($0 != "category\tsource\treason") exit 1
+    next
+}
+{
+    if (NF != 3 || $3 == "" ||
+        $1 !~ /^(active-owner|mixed-pending|optional-diagnostic|legacy)$/ ||
+        $2 !~ /^src\/dcc\/dcc_(ast|mir)[a-z_]*\.c$/ || seen[$2]++) {
+        print "Invalid coverage classification at row " NR > "/dev/stderr"
+        failed = 1
+    }
+    if ($1 == "active-owner") included++
+}
+END { if (failed || !included) exit 1 }
+' "$manifest"
+
+tab=$(printf '\t')
+while IFS="$tab" read -r category source reason; do
+    if [ "$category" = category ]; then continue; fi
+    if [ ! -f "$repo_root/$source" ]; then
+        echo "Coverage manifest source does not exist: $source" >&2
+        exit 1
+    fi
+done < "$manifest"
+
+for source in "$repo_root"/src/dcc/dcc_ast*.c "$repo_root"/src/dcc/dcc_mir*.c; do
+    relative=${source#"$repo_root/"}
+    if ! awk -F '\t' -v source="$relative" '
+        $2 == source { found = 1 }
+        END { exit !found }
+    ' "$manifest"; then
+        echo "Unclassified AST/MIR module: $relative" >&2
+        exit 1
+    fi
+done
+
+awk -F '\t' -v root="$repo_root" '
+    $1 == "active-owner" { print root "/" $2 }
+' "$manifest"

--- a/scripts/test-coverage-sources.sh
+++ b/scripts/test-coverage-sources.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+manifest="$repo_root/scripts/ast-mir-coverage.tsv"
+workspace=$(mktemp -d)
+trap 'rm -rf "$workspace"' EXIT HUP INT TERM
+
+expect_failure()
+{
+    if sh "$repo_root/scripts/coverage-sources.sh" "$workspace/invalid.tsv" \
+        >"$workspace/output" 2>"$workspace/error"; then
+        echo "FAIL: invalid manifest accepted: $1" >&2
+        exit 1
+    fi
+    if [ -s "$workspace/output" ]; then
+        echo "FAIL: invalid manifest published partial source list: $1" >&2
+        exit 1
+    fi
+}
+
+sh "$repo_root/scripts/coverage-sources.sh" >"$workspace/sources"
+if grep -E 'dcc_ast_gen|dcc_mir_(schedule|target)\.c' "$workspace/sources"; then
+    echo "FAIL: excluded modules entered active coverage" >&2
+    exit 1
+fi
+awk 'NR == 2 { print } { print }' "$manifest" >"$workspace/invalid.tsv"
+expect_failure duplicate
+awk 'NR != 2' "$manifest" >"$workspace/invalid.tsv"
+expect_failure unclassified
+awk 'NR == 2 { sub(/active-owner/, "unknown") } { print }' \
+    "$manifest" >"$workspace/invalid.tsv"
+expect_failure category
+awk 'NR == 2 { sub(/dcc_ast.c/, "dcc_ast_missing.c") } { print }' \
+    "$manifest" >"$workspace/invalid.tsv"
+expect_failure missing
+printf '%s\n' "Coverage source manifest tests passed"


### PR DESCRIPTION
## Summary
- Version all 34 AST/MIR module classifications: 28 active-owner modules, four mixed modules pending function classification, and two optional diagnostic modules.
- Fail before coverage collection on unknown categories, missing/duplicate entries, missing files, or new unclassified modules.
- Add manifest rejection tests and document limits. Legacy codegen remains excluded.

## Validation
- Manifest output exactly matches the previous 28-file coverage denominator.
- Negative manifest tests and shell syntax checks passed.
- Full instrumented coverage workflow passed with unchanged scope.
- git diff --check passed.

## Dependency
Stacked on #187; this PR shows only the explicit denominator follow-up. Merge #187 first, then retarget this PR to main. This is a reviewed module denominator, not a completed function-level classification of mixed modules.