### PR TITLE
Complete mixed AST function coverage classification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,13 @@ jobs:
         shell: pwsh
         run: ./scripts/run-mir-clobber-tests.ps1
 
+      - name: Validate AST coverage classifications
+        if: runner.os == 'Linux'
+        run: |
+          sh scripts/test-coverage-sources.sh
+          python3 -m unittest discover -s scripts/tests -p 'test_ast_function_coverage.py'
+          python3 scripts/ast-function-coverage.py
+
       - name: Run debugger host and debug metadata tests
         if: runner.os == 'Linux'
         run: |

--- a/docs/compiler-coverage.md
+++ b/docs/compiler-coverage.md
@@ -23,9 +23,12 @@ signatures. Each run removes old raw profiles before collecting fresh ones.
 
 ## Legacy-excluded AST/MIR report
 
-Use `ast-mir-summary.txt` as the scoped report, with
+Use `ast-mir-function-summary.txt` for the function-scoped headline described
+below. The original `ast-mir-summary.txt` remains a module-scoped baseline, with
 `ast-mir-sources.txt` recording its exact source-file denominator and
-`ast-mir-coverage.json` containing machine-readable regions and branches.
+`ast-mir-coverage.json` holding the raw LLVM export. LLVM can include functions
+outside the requested files in that export; use the verified function summary
+JSON, not the raw export's function list, for scoped aggregates.
 `summary.txt` and `html/index.html` are unfiltered collection artifacts, not
 coverage targets.
 
@@ -38,15 +41,15 @@ The scoped report includes:
 
 It excludes the legacy direct-codegen modules, all mixed `dcc_ast_gen*.c`
 modules, and the optional `dcc_mir_schedule.c` / `dcc_mir_target.c` shadow
-models. Excluding mixed modules also omits some active AST classifiers; their
-coverage must be classified function-by-function before including it. This is
+models. The separate function-scoped report adds classified active AST helpers.
+This historical baseline is
 an active-owner **module** report, not a complete production-only function
 classification. Diagnostics, defensive checks, and unused helpers within
 included modules remain in the denominator. Legacy codegen is not a target
 for coverage-driven test additions.
 
 `scripts/ast-mir-coverage.tsv` is the versioned module classification: 28
-active-owner modules, four mixed modules pending function-level classification,
+active-owner modules, four function-classified mixed modules,
 and two optional diagnostic modules. Each row includes its rationale. The
 coverage runner validates it before building: missing files, duplicate entries,
 invalid categories, and newly added unclassified AST/MIR modules fail rather
@@ -60,9 +63,8 @@ sh scripts/coverage-sources.sh
 sh scripts/test-coverage-sources.sh
 ```
 
-Function-level separation of production, diagnostic, and unreachable code is
-still pending inside mixed modules. Do not relabel those files as legacy or
-include them wholesale merely to claim a complete production denominator.
+The module baseline intentionally stays unchanged as function classification
+adds mixed-module helpers to the separate report below.
 
 Measured on macOS with Apple Clang 21, on 2026-09-07, using compiler revision
 `9ad4775e` plus the coverage-routing and host-test changes documented here:
@@ -100,6 +102,75 @@ the percentage of bugs removed. Uncovered branches should be inspected for
 meaningful supported cases, not executed merely to improve the total.
 Prioritize active qualifier/call contracts and selector rejection proofs;
 retain the existing separate tests of volatile access counts and widths.
+
+## Function-scoped denominator
+
+`scripts/ast-function-coverage.json` explicitly classifies every definition in
+the four mixed modules. Clang's JSON AST supplies definitions and references;
+prototypes and header definitions are not counted. New or removed definitions,
+duplicate entries, and changes to guarded production-to-legacy references fail
+validation. CI runs this check independently of expensive coverage collection.
+
+| Mixed module | Production | Legacy-only |
+| --- | ---: | ---: |
+| `dcc_ast_gen.c` | 87 | 7 |
+| `dcc_ast_gen_cond.c` | 29 | 27 |
+| `dcc_ast_gen_expr.c` | 14 | 73 |
+| `dcc_ast_gen_support.c` | 41 | 8 |
+| Total | 171 | 115 |
+
+Production roots were traced from `dcc_ast_metadata.c`, `dcc_ast_stmt_meta.c`,
+`dcc_mir.c`, `dcc_ast_build.c`, `dcc_func.c`, `dcc_decl.c`, and `dcc_stmt.c`:
+statement/support gates, condition and type/address proofs, loop metadata,
+initializer capture, VLA-bound expressions, and inline metadata. Their
+transitive mixed-module helpers are included even when unexecuted. Remaining
+definitions belong to retained emission and emitter-only proofs. Classification
+is not inferred from function names or measured execution counts.
+
+Seven mixed-module references cross from included functions to excluded
+emitters. The manifest records each guard: initializer capture returns when
+MIR is active; discarded expressions use MIR instead of dead-expression
+emission; inline metadata passes `emit_values=0`. The analogous external
+`emit_init_auto_struct_type` reference to `ast_gen_expr` also follows a MIR
+capture path that bypasses emission. These are reviewed control-flow arguments,
+not a whole-program reachability proof. The validator detects changed reference
+sets, not edits to the guards themselves. Positive execution of an excluded
+function is a hard coverage-workflow error and requires reclassification.
+
+Included functions remain whole: their diagnostics, defensive checks, and
+guarded legacy branches are not removed to raise percentages. The 28
+active-owner modules likewise retain all their compiled functions. Thus the
+denominator excludes legacy-only functions in mixed modules but is deliberately
+conservative, not a claim that every included line is production-reachable.
+
+Artifacts:
+
+- `ast-mir-functions.txt`: exact LLVM function-name allowlist.
+- `ast-mir-function-detail.txt`: native LLVM per-function line/region/branch metrics.
+- `ast-mir-function-coverage.json`: verified per-function metrics and summed totals.
+- `ast-mir-function-summary.txt`: readable headline totals.
+
+LLVM file reports and JSON exports do not apply function-name filters. This
+workflow uses `llvm-cov report -show-functions` with an `[llvmcov]` allowlist,
+then checks that every reported name matches the expected set exactly before
+summing native metrics. It does not reconstruct executable lines from source
+text or coverage regions. Line totals are function-summed and should only be
+compared with subsequent reports using the same convention and classification.
+
+Measured on 2026-09-07 with Apple Clang 21 and the same compiler/workload as the
+module baseline (classification changes do not change compiler behavior):
+
+| Metric | Covered | Total | Coverage |
+| --- | ---: | ---: | ---: |
+| Functions | 4,055 | 4,381 | 92.56% |
+| Lines | 167,417 | 190,418 | 87.92% |
+| Branch outcomes | 85,635 | 145,185 | 58.98% |
+| Regions | 162,334 | 182,782 | 88.81% |
+
+```sh
+python3 scripts/ast-function-coverage.py
+python3 -m unittest discover -s scripts/tests -p 'test_ast_function_coverage.py'
+```
 
 ## Historical unfiltered report
 

--- a/scripts/ast-function-coverage.json
+++ b/scripts/ast-function-coverage.json
@@ -1,0 +1,145 @@
+{
+  "reasons": {
+    "production": "Reachable from MIR lowering, statement gating, initializer capture, or inline metadata; include the entire function including diagnostics and guarded legacy branches.",
+    "legacy": "Retained AST emission or a proof referenced only by retained emitters; no generated-only production entry path. See docs/compiler-coverage.md for roots and guards."
+  },
+  "guarded_edges": [
+    ["ast_emit_init_expr", "ast_gen_expr", "mir_is_active captures and returns before emission"],
+    ["ast_emit_init_expr", "gen_pointer_expr_ast", "mir_is_active captures and returns before emission"],
+    ["ast_emit_discarded_expr", "ast_gen_dead_expr", "only the !mir_is_active branch emits"],
+    ["ast_emit_struct_init_expr_assign", "gen_struct_addr_expr_ast", "MIR initializer capture returns before emission"],
+    ["ast_emit_struct_init_expr_assign", "gen_struct_return_call_assign_ast", "MIR initializer capture returns before emission"],
+    ["prepare_inline_arg_temps", "emit_inline_arg_temp_store", "ast_process_inline_call_metadata passes emit_values=0"],
+    ["prepare_inline_local_temp", "emit_inline_arg_temp_store", "ast_process_inline_call_metadata passes emit_values=0"]
+  ],
+  "sources": {
+    "src/dcc/dcc_ast_gen.c": {
+      "production": [
+        "ident_supported", "is_cmp_op", "is_shift_op", "is_float_arith_op",
+        "is_supported_binary_op", "ast_is_plain_int_type", "ast_ident_is_const",
+        "ast_value_is_plain_int", "ast_node_is_const", "ast_index_composite_elem_type",
+        "ast_index_plain_int_read", "ast_index_scalar_array_elem_type",
+        "ast_index_long_read", "ast_index_float_read", "ast_index_array_row_ptr_type",
+        "ast_index_struct_object_type", "ast_index_struct_object_subscript_supported",
+        "ast_index_subscript_binary_literal", "ast_index_subscript_supported",
+        "ast_index_2d_addressable_addr", "ast_index_symbol_nd_collect",
+        "ast_index_symbol_nd_elem_type", "ast_index_symbol_nd_addressable_addr",
+        "ast_index_deref_pointer_array_collect", "ast_deref_pointer_array_decay",
+        "ast_is_pointer_array_ident", "ast_deref_pointer_array_chain_collect",
+        "ast_index_member_array_nd_collect", "ast_index_2d_array_elem_type",
+        "ast_index_addressable_addr", "ast_index_pointer_expr_elem_type",
+        "ast_index_reversed_pointer_expr_elem_type", "ast_index_pointer_array_elem_type",
+        "ast_index_member_pointer_elem_type", "ast_index_scalar_pointer_elem_type",
+        "ast_pointer_expr_type", "ast_deref_lvalue_plain_int_type", "ast_deref_lvalue_type",
+        "ast_member_base_type", "ast_member_array_field_elem_type",
+        "ast_member_plain_array_field_elem_type", "ast_member_pointer_array_field_elem_type",
+        "ast_member_plain_int_read", "ast_member_bitfield_read", "ast_member_bitfield_lvalue_type",
+        "ast_member_long_read", "ast_member_float_read", "ast_member_pointer_read",
+        "ast_member_lvalue_type", "ast_unique_field_by_name", "ast_deref_plain_int_read",
+        "ast_va_arg_deref_type", "ast_long_va_arg_self_assign_supported",
+        "ast_deref_pointer_word_read", "ast_deref_long_read", "ast_deref_float_read",
+        "ast_preincdec_plain_int", "ast_preincdec_pointer_word", "ast_preincdec_pointer_type",
+        "ast_postfix_plain_int", "ast_address_of_supported", "ast_address_of_value_type",
+        "ast_numeric_value_supported", "ast_cond_numeric_supported",
+        "ast_cond_result_is_float", "ast_cond_result_is_long", "ast_void_expr_supported",
+        "ast_cond_void_supported", "ast_index_cmp_cond_supported", "ast_logical_operand_ok",
+        "ast_null_pointer_const", "ast_pointer_cmp_operand_ok", "ast_pointer_cmp_supported",
+        "ast_pointer_diff_supported", "ast_long_cmp_supported", "ast_long_arith_supported",
+        "ast_mixed_long_rhs_arith_supported", "ast_const_plain_int_binary_supported",
+        "ast_struct_return_call_assign_supported", "ast_struct_deref_copy_assign_supported",
+        "ast_struct_member_copy_assign_supported", "ast_struct_addr_expr_supported",
+        "ast_struct_copy_assign_supported", "ast_struct_assign_tree_type",
+        "ast_struct_chain_copy_assign_supported", "ast_is_const_zero_condition",
+        "ast_is_const_nonzero_condition"
+      ],
+      "legacy": [
+        "ast_field_array_index_stride", "ast_mul_const_value_ok", "gen_va_arg_deref_ast",
+        "gen_long_va_arg_self_assign_ast", "ast_zero_arg_inline_body",
+        "ast_is_byte_addr_lvalue", "ast_is_byte_addr_copy_assign"
+      ]
+    },
+    "src/dcc/dcc_ast_gen_cond.c": {
+      "production": [
+        "ast_return_stmt_supported", "ast_cmp_operand_ok", "ast_is_simple_cmp_cond",
+        "ast_const_cmp_extract", "ast_is_const_cmp_cond", "ast_is_const_plain_int_cmp_cond",
+        "ast_strip_byte_cast_mask_cond", "ast_low_byte_sum_operand_cond", "ast_byte_operand",
+        "ast_is_byte_cmp_cond", "ast_is_direct_byte_bitand_cond", "ast_is_direct_wide_bitand_cond",
+        "ast_is_direct_long_const_eq_cond", "ast_global_char_index_cond", "ast_is_float_cmp_cond",
+        "ast_cond_not_indexed_scalar", "ast_cond_indexed_array_row_operand",
+        "ast_cond_not_indexed_array_row", "ast_cond_generic", "ast_is_local_self_add_stmt",
+        "ast_deadincdec_sym_direct", "ast_deadincdec_member_ok", "ast_incdec_addr_type_ok",
+        "ast_index_lvalue_elem_type", "ast_deadincdec_addr_lvalue_type", "ast_dead_expr_supported",
+        "ast_for_init_expr_supported", "ast_expr_stmt_supported", "ast_stmt_supported"
+      ],
+      "legacy": [
+        "ast_operand_is_ptr_ident", "ast_is_general_const_cmp_cond", "ast_range_extract_lower",
+        "ast_range_extract_upper", "ast_is_range_check_cond", "ast_gen_global_char_index_branch",
+        "ast_emit_local_self_add_stmt", "gen_deadincdec_addr_lvalue_ast", "ast_gen_cmp_branch",
+        "ast_gen_const_cmp_branch", "ast_gen_byte_cmp_branch", "ast_gen_direct_byte_bitand_branch",
+        "ast_gen_direct_wide_bitand_branch", "ast_gen_range_check_branch", "ast_cond_is_abs_idiom",
+        "ast_gen_abs_idiom_value", "ast_is_byte_eq_cond", "ast_gen_byte_eq_branch",
+        "ast_is_global_char_index_eq_cond", "ast_gen_global_char_index_eq_branch",
+        "ast_gen_direct_long_const_eq_branch", "ast_gen_float_cmp_branch", "ast_gen_long_cmp_branch",
+        "ast_is_pure_bool_valued", "ast_gen_cond_branch", "ast_switch_find_case", "ast_switch_table_ok"
+      ]
+    },
+    "src/dcc/dcc_ast_gen_expr.c": {
+      "production": [
+        "ast_emit_init_expr", "ast_emit_discarded_expr", "ast_emit_struct_init_expr_assign",
+        "inline_arg_reusable", "inline_param_index_for_call", "inline_temp_name_for_call",
+        "inline_substitution_body", "inline_arg_is_body_independent", "inline_arg_needs_temp",
+        "prepare_inline_arg_temps", "clone_inline_expr", "prepare_inline_local_temp",
+        "ast_process_inline_call_metadata", "ast_member_field_value_type"
+      ],
+      "legacy": [
+        "ast_gen_dead_expr", "ast_masked_byte_operand", "ast_long_byte_extract",
+        "emit_long_byte_from_reg", "emit_long_one_byte_from_a", "emit_long_byte_shift_to_reg",
+        "emit_low_byte_expr_to_a", "emit_long_oreq_byte_lane", "gen_int_lit", "gen_cast_ast",
+        "gen_str_lit", "gen_ident", "gen_unary_ast", "gen_compound_literal_ast",
+        "gen_compound_literal_value_ast", "gen_pointer_cmp_operand_ast", "gen_sizeof_expr_ast",
+        "gen_pointer_cmp_ast", "gen_pointer_diff_ast", "emit_signed_long_const_cmp_ast",
+        "gen_long_cmp_ast", "ast_strip_u16_widen_cast", "ast_is_plain_u16_source",
+        "ast_const_int_operand_value", "ast_same_plain_u16_source", "gen_long_arith_ast",
+        "gen_binop32_promote_16lhs_ast", "gen_binary_try_fast_preeval", "gen_binary_ast",
+        "gen_shift_ast", "gen_index_subscript_expr_ast", "ast_bool_bitand_const_rhs",
+        "emit_store_bool_masked_hl_to_addr_on_stack", "ast_is_float_madd_rhs",
+        "emit_float_compound_rhs", "emit_store_long_edcb_via_hl", "gen_assign_ast",
+        "ast_ident_plus_const_rhs", "emit_store_ident_plus_const_to_addr_hl",
+        "gen_assign_lvalue_expr_ast", "gen_assign_ident_ast", "gen_assign_ident_plain_ast",
+        "gen_assign_ident_compound_ast", "emit_array_symbase_index", "emit_runtime_pointer_array_stride",
+        "emit_pointer_symbase_index", "gen_index_addr_ast", "gen_index_ast", "gen_call_star_indirect_ast",
+        "emit_inline_arg_temp_store", "try_gen_inline_call_ast", "gen_fastcall_arg", "gen_call_ast",
+        "gen_struct_return_call_assign_ast", "gen_struct_addr_expr_ast", "gen_struct_copy_assign_ast",
+        "gen_struct_chain_copy_assign_ast", "gen_struct_deref_copy_assign_ast",
+        "gen_struct_member_copy_assign_ast", "gen_byte_lvalue_addr_ast", "gen_byte_addr_copy_assign_ast",
+        "gen_member_addr_ast", "ast_member_global_word_field", "emit_load_global_field_word_direct",
+        "emit_store_global_field_word_direct", "gen_member_ast", "ast_const_ptr_array_base",
+        "gen_pointer_expr_ast", "gen_deref_addr_ast", "gen_logical_ast", "gen_cond_ast",
+        "gen_postfix_ast", "ast_gen_expr"
+      ]
+    },
+    "src/dcc/dcc_ast_gen_support.c": {
+      "production": [
+        "ast_support_cache_begin", "ast_expr_yields_bool01", "ast_int_elem_assign_rhs_ok",
+        "ast_gen_supported", "ast_scalar_binary_supported_uncached", "ast_assign_supported_uncached",
+        "ast_other_supported_uncached", "ast_gen_supported_uncached", "ast_call_arg_word_supported",
+        "ast_call_struct_arg_supported", "ast_update_lvalue_long_type", "ast_value_is_long_word",
+        "ast_long_word_type", "ast_call_arg_supported", "ast_va_builtin_supported",
+        "ast_call_named_args_supported", "ast_call_star_indirect_base", "ast_indirect_call_proto_sym",
+        "ast_call_star_indirect_supported", "ast_call_indirect_supported", "ast_value_is_float_word",
+        "ast_value_is_pointer_word", "ast_pointer_assign_rhs_supported", "ast_unary_int_const_fold",
+        "ast_int_const_cast_fold", "ast_unary_long_const_fold", "ast_fold_binary_target",
+        "ast_const_scalar_fold", "ast_const_apply_int_cast", "ast_const_condition_fold",
+        "ast_global_byte_array_const_store", "ast_global_byte_array_fast_store", "ast_for_mod_fill_supported",
+        "ast_expr_references_ident", "ast_expr_has_side_effects", "ast_find_unconditional_divmod_op",
+        "ast_replace_subtree", "ast_divmod_fuse_compound", "ast_for_hoist_lvalue_addr_supported",
+        "ast_for_rhs_hoist_scan_supported", "ast_for_hoist_global_member_value_supported"
+      ],
+      "legacy": [
+        "gen_call_struct_arg_ast", "gen_struct_return_call_arg_ast", "ast_unary_float_const_fold",
+        "ast_const_fold_strict", "ast_index_exprs_structurally_equal", "ast_index_expr_is_plus_one",
+        "ast_byte_pair_word_read_match", "ast_byte_pair_word_write_match"
+      ]
+    }
+  }
+}

--- a/scripts/ast-function-coverage.py
+++ b/scripts/ast-function-coverage.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Validate static mixed-AST classifications and report scoped LLVM coverage."""
+
+import argparse
+import csv
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIXED = tuple(sorted((ROOT / "src/dcc").glob("dcc_ast_gen*.c")))
+CATEGORIES = {"production", "diagnostic", "legacy"}
+
+
+def walk(node):
+    yield node
+    for child in node.get("inner", []):
+        yield from walk(child)
+
+
+def definitions(tree, source):
+    result = {}
+    for node in tree.get("inner", []):
+        location = node.get("loc", {})
+        if node.get("kind") != "FunctionDecl" or "includedFrom" in location:
+            continue
+        if "file" in location and Path(location["file"]).resolve() != source.resolve():
+            continue
+        bodies = [child for child in node.get("inner", [])
+                  if child.get("kind") == "CompoundStmt"]
+        if not bodies:
+            continue
+        calls = {child["referencedDecl"]["name"] for child in walk(bodies[0])
+                 if child.get("referencedDecl", {}).get("kind") == "FunctionDecl"}
+        result[node["name"]] = {
+            "line": location.get("line"),
+            "calls": sorted(calls),
+        }
+    return result
+
+
+def inventory(compiler, sources=MIXED):
+    result = {}
+    for source in sources:
+        process = subprocess.run(
+            [compiler, "-std=c11", "-fsyntax-only", "-Xclang", "-ast-dump=json", str(source)],
+            check=True, capture_output=True, text=True,
+        )
+        result[source.relative_to(ROOT).as_posix()] = definitions(json.loads(process.stdout), source)
+    return result
+
+
+def read_manifest(filename):
+    result = {}
+    manifest = json.loads(filename.read_text(encoding="utf-8"))
+    for source, groups in manifest["sources"].items():
+        for category, names in groups.items():
+            if category not in CATEGORIES or not manifest["reasons"].get(category):
+                raise ValueError("invalid category or missing rationale: " + category)
+            for name in names:
+                key = (source, name)
+                if key in result:
+                    raise ValueError("duplicate classification: " + str(key))
+                result[key] = category
+    return result, manifest["guarded_edges"]
+
+
+def validate(found, classified):
+    expected = {(source, name) for source, functions in found.items() for name in functions}
+    missing = expected - classified.keys()
+    stale = classified.keys() - expected
+    if missing or stale:
+        raise ValueError(f"unclassified definitions: {sorted(missing)}; stale entries: {sorted(stale)}")
+
+
+def validate_edges(found, classified, guards):
+    by_name = {name: category for (_, name), category in classified.items()}
+    expected = {(caller, callee) for caller, callee, reason in guards if reason}
+    actual = set()
+    for source, functions in found.items():
+        for caller, body in functions.items():
+            if classified[(source, caller)] == "legacy":
+                continue
+            for callee in body["calls"]:
+                if by_name.get(callee) == "legacy":
+                    actual.add((caller, callee))
+    if actual != expected:
+        raise ValueError(f"changed legacy boundaries: new={sorted(actual - expected)}, "
+                         f"stale={sorted(expected - actual)}")
+
+
+def select_functions(report, classified, active_sources):
+    selected = set()
+    seen = set()
+    for data in report["data"]:
+        for function in data["functions"]:
+            source = Path(function["filenames"][0]).resolve()
+            if not source.is_relative_to(ROOT):
+                continue
+            relative = source.relative_to(ROOT).as_posix()
+            name = function["name"].split(":")[-1]
+            key = (relative, name)
+            if relative not in active_sources and key not in classified:
+                continue
+            seen.add(key)
+            if classified.get(key) == "legacy":
+                if function["count"]:
+                    raise ValueError("executed legacy exclusion: " + str(key))
+            else:
+                selected.add(function["name"])
+    missing = {key for key, category in classified.items() if category != "legacy"} - seen
+    if missing or not selected:
+        raise ValueError(f"coverage missing classified functions: {sorted(missing)}")
+    return sorted(selected)
+
+
+def summarize_native(text, selected):
+    functions = {}
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) != 10 or parts[0] == "TOTAL" or not parts[3].endswith("%"):
+            continue
+        name = parts[0]
+        if name not in selected or name in functions:
+            raise ValueError("unexpected or duplicate native function: " + name)
+        functions[name] = {}
+        for metric, offset in (("regions", 1), ("lines", 4), ("branches", 7)):
+            total, missed = int(parts[offset]), int(parts[offset + 1])
+            if not 0 <= missed <= total:
+                raise ValueError("invalid native counts: " + name)
+            functions[name][metric] = {"count": total, "covered": total - missed}
+    if functions.keys() != set(selected):
+        raise ValueError("native report did not honor exact function selection")
+    totals = {metric: {key: sum(function[metric][key] for function in functions.values())
+                       for key in ("count", "covered")}
+              for metric in ("regions", "lines", "branches")}
+    return {"functions": functions, "totals": totals}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--clang", default="clang")
+    parser.add_argument("--inventory", type=Path)
+    parser.add_argument("--manifest", type=Path, default=ROOT / "scripts/ast-function-coverage.json")
+    parser.add_argument("--coverage", type=Path)
+    parser.add_argument("--allowlist", type=Path)
+    parser.add_argument("--native-report", type=Path)
+    parser.add_argument("--summary", type=Path)
+    args = parser.parse_args()
+    found = inventory(args.clang)
+    if args.inventory:
+        args.inventory.write_text(json.dumps(found, indent=2) + "\n", encoding="utf-8")
+    else:
+        classified, guards = read_manifest(args.manifest)
+        validate(found, classified)
+        validate_edges(found, classified, guards)
+        if args.coverage:
+            with (ROOT / "scripts/ast-mir-coverage.tsv").open(encoding="utf-8") as stream:
+                active_sources = {row["source"] for row in csv.DictReader(stream, delimiter="\t")
+                                  if row["category"] == "active-owner"}
+            selected = select_functions(json.loads(args.coverage.read_text()), classified, active_sources)
+            if not args.allowlist:
+                parser.error("--coverage requires --allowlist")
+            args.allowlist.write_text("[llvmcov]\n" + "".join(
+                "allowlist_fun:" + name + "\n" for name in selected), encoding="utf-8")
+            if args.native_report:
+                if not args.summary:
+                    parser.error("--native-report requires --summary")
+                summary = summarize_native(args.native_report.read_text(), set(selected))
+                report = json.loads(args.coverage.read_text())
+                executed = {function["name"] for data in report["data"] for function in data["functions"]
+                            if function["name"] in selected and function["count"] > 0}
+                summary["totals"]["functions"] = {"count": len(selected), "covered": len(executed)}
+                args.summary.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+                for metric, counts in summary["totals"].items():
+                    total, covered = counts["count"], counts["covered"]
+                    print(f"{metric}: {covered}/{total} ({100 * covered / total if total else 100:.2f}%)")
+            print(f"Selected {len(selected)} AST/MIR functions")
+        print(f"Validated {len(classified)} mixed-AST function classifications")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ast-mir-coverage.tsv
+++ b/scripts/ast-mir-coverage.tsv
@@ -1,10 +1,10 @@
 category	source	reason
 active-owner	src/dcc/dcc_ast.c	AST arena and node construction
 active-owner	src/dcc/dcc_ast_build.c	Function expression and statement parsing
-mixed-pending	src/dcc/dcc_ast_gen.c	Classifiers require function-level separation from compatibility helpers
-mixed-pending	src/dcc/dcc_ast_gen_cond.c	Active condition proofs and retained compatibility paths
-mixed-pending	src/dcc/dcc_ast_gen_expr.c	Active initializer metadata mixed with retained expression emission
-mixed-pending	src/dcc/dcc_ast_gen_support.c	Active semantic proofs and retained compatibility paths
+mixed-classified	src/dcc/dcc_ast_gen.c	Per-function roles in ast-function-coverage.json
+mixed-classified	src/dcc/dcc_ast_gen_cond.c	Per-function roles in ast-function-coverage.json
+mixed-classified	src/dcc/dcc_ast_gen_expr.c	Per-function roles in ast-function-coverage.json
+mixed-classified	src/dcc/dcc_ast_gen_support.c	Per-function roles in ast-function-coverage.json
 active-owner	src/dcc/dcc_ast_metadata.c	Non-emitting declaration scope and debug metadata
 active-owner	src/dcc/dcc_ast_stmt_meta.c	Statement capture and metadata planning
 active-owner	src/dcc/dcc_mir.c	Lowering metadata repair CFG promotion and allocation

--- a/scripts/compiler-coverage.sh
+++ b/scripts/compiler-coverage.sh
@@ -42,6 +42,7 @@ if [ -z "$llvm_cov" ] || [ -z "$llvm_profdata" ]; then
 fi
 
 coverage_sources=$(sh "$repo_root/scripts/coverage-sources.sh")
+python3 "$repo_root/scripts/ast-function-coverage.py" --clang "$clang_cmd"
 
 cmake -S "$repo_root/src/dcc" -B "$build_dir/cmake" \
     -DCMAKE_BUILD_TYPE=Debug \
@@ -91,6 +92,19 @@ printf '%s\n' "$@" >"$report_dir/ast-mir-sources.txt"
     -object "$build_dir/cmake/mir-verify-test" \
     -instr-profile="$build_dir/dcc.profdata" \
     "$@" >"$report_dir/ast-mir-coverage.json"
+python3 "$repo_root/scripts/ast-function-coverage.py" --clang "$clang_cmd" \
+    --coverage "$report_dir/ast-mir-coverage.json" \
+    --allowlist "$report_dir/ast-mir-functions.txt"
+"$llvm_cov" report "$binary_dir/dcc" \
+    -object "$build_dir/cmake/mir-verify-test" \
+    -instr-profile="$build_dir/dcc.profdata" \
+    -name-allowlist="$report_dir/ast-mir-functions.txt" -show-functions \
+    "$@" "$repo_root"/src/dcc/dcc_ast_gen*.c >"$report_dir/ast-mir-function-detail.txt"
+python3 "$repo_root/scripts/ast-function-coverage.py" --clang "$clang_cmd" \
+    --coverage "$report_dir/ast-mir-coverage.json" \
+    --allowlist "$report_dir/ast-mir-functions.txt" \
+    --native-report "$report_dir/ast-mir-function-detail.txt" \
+    --summary "$report_dir/ast-mir-function-coverage.json" >"$report_dir/ast-mir-function-summary.txt"
 "$llvm_cov" show "$binary_dir/dcc" \
     -object "$build_dir/cmake/mir-verify-test" \
     -instr-profile="$build_dir/dcc.profdata" \
@@ -103,4 +117,5 @@ echo "Unfiltered collection summary (not a target): $report_dir/summary.txt"
 echo "Legacy-excluded AST/MIR summary: $report_dir/ast-mir-summary.txt"
 echo "AST/MIR source manifest:   $report_dir/ast-mir-sources.txt"
 echo "AST/MIR coverage data:     $report_dir/ast-mir-coverage.json"
+echo "Function-scoped AST/MIR summary: $report_dir/ast-mir-function-summary.txt"
 echo "Compiler coverage HTML:    $report_dir/html/index.html"

--- a/scripts/coverage-sources.sh
+++ b/scripts/coverage-sources.sh
@@ -11,7 +11,7 @@ NR == 1 {
 }
 {
     if (NF != 3 || $3 == "" ||
-        $1 !~ /^(active-owner|mixed-pending|optional-diagnostic|legacy)$/ ||
+        $1 !~ /^(active-owner|mixed-classified|optional-diagnostic|legacy)$/ ||
         $2 !~ /^src\/dcc\/dcc_(ast|mir)[a-z_]*\.c$/ || seen[$2]++) {
         print "Invalid coverage classification at row " NR > "/dev/stderr"
         failed = 1

--- a/scripts/tests/test_ast_function_coverage.py
+++ b/scripts/tests/test_ast_function_coverage.py
@@ -1,0 +1,74 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SPEC = importlib.util.spec_from_file_location(
+    "ast_function_coverage", Path(__file__).resolve().parents[1] / "ast-function-coverage.py")
+coverage = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(coverage)
+
+
+class FunctionCoverageTests(unittest.TestCase):
+    def test_definitions_exclude_prototypes_and_headers(self):
+        tree = {"inner": [
+            {"kind": "FunctionDecl", "name": "prototype"},
+            {"kind": "FunctionDecl", "name": "header", "loc": {"includedFrom": {}},
+             "inner": [{"kind": "CompoundStmt"}]},
+            {"kind": "FunctionDecl", "name": "active", "loc": {"line": 10},
+             "inner": [{"kind": "CompoundStmt", "inner": [
+                 {"kind": "DeclRefExpr", "referencedDecl": {
+                     "kind": "FunctionDecl", "name": "callee"}}]}]},
+        ]}
+        self.assertEqual(coverage.definitions(tree, Path("test.c")), {
+            "active": {"line": 10, "calls": ["callee"]}})
+
+    def test_unclassified_definition_fails(self):
+        with self.assertRaisesRegex(ValueError, "unclassified"):
+            coverage.validate({"source": {"new_function": {}}}, {})
+
+    def test_removed_definition_fails(self):
+        with self.assertRaisesRegex(ValueError, "stale"):
+            coverage.validate({}, {("source", "old_function"): {}})
+
+    def test_complete_inventory_passes(self):
+        coverage.validate({"source": {"function": {}}}, {("source", "function"): {}})
+
+    def test_new_legacy_reference_fails(self):
+        found = {"source": {"active": {"calls": ["old"]}, "old": {"calls": []}}}
+        classified = {("source", "active"): "production", ("source", "old"): "legacy"}
+        with self.assertRaisesRegex(ValueError, "changed legacy boundaries"):
+            coverage.validate_edges(found, classified, [])
+        coverage.validate_edges(found, classified, [["active", "old", "MIR guard"]])
+
+    def test_zero_count_active_function_is_included(self):
+        report = {"data": [{"functions": [{"name": "source.c:active", "count": 0,
+                   "filenames": [str(coverage.ROOT / "source.c")]}]}]}
+        self.assertEqual(coverage.select_functions(report, {("source.c", "active"): "production"}, set()),
+                         ["source.c:active"])
+
+    def test_executed_legacy_exclusion_fails(self):
+        report = {"data": [{"functions": [{"name": "old", "count": 1,
+                   "filenames": [str(coverage.ROOT / "source.c")]}]}]}
+        with self.assertRaisesRegex(ValueError, "executed legacy"):
+            coverage.select_functions(report, {("source.c", "old"): "legacy"}, set())
+
+    def test_missing_coverage_function_fails(self):
+        with self.assertRaisesRegex(ValueError, "missing classified"):
+            coverage.select_functions({"data": [{"functions": []}]},
+                                      {("source.c", "active"): "production"}, set())
+
+    def test_native_metrics_and_exact_name_check(self):
+        text = "active 10 2 80.00% 8 1 87.50% 4 2 50.00%\nTOTAL 10 2 80.00% 8 1 87.50% 4 2 50.00%\n"
+        result = coverage.summarize_native(text, {"active"})
+        self.assertEqual(result["totals"]["lines"], {"count": 8, "covered": 7})
+        with self.assertRaisesRegex(ValueError, "exact function selection"):
+            coverage.summarize_native(text, {"active", "missing"})
+        with self.assertRaisesRegex(ValueError, "unexpected or duplicate"):
+            coverage.summarize_native(text, {"other"})
+        with self.assertRaisesRegex(ValueError, "unexpected or duplicate"):
+            coverage.summarize_native(text + text, {"active"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Explicitly classify all 286 mixed AST definitions: 171 production-reachable helpers and 115 retained-emitter-only functions.
- Validate Clang definitions and seven reviewed guarded references without classifying by observed execution.
- Extend the 28-module denominator with the active mixed helpers using an exact LLVM function allowlist and native per-function metrics. Fail on missing names or executed legacy exclusions.
- Add nine unit tests, Linux CI validation, and documented roots, guards, limitations, and measured totals.

## Validation
- Full instrumented coverage workflow passed.
- 4,381 included functions: 87.92% function-summed lines and 58.98% branch outcomes. No production compiler changes.
- Module validation, nine unit tests, Clang inventory, Pylance syntax checks, and git diff --check passed.

## Dependency
Stacked on #188 (which depends on #187). The existing module baseline is preserved. Included functions retain all diagnostic and guarded legacy branches; this is not a claim of 100% reachable-line coverage.